### PR TITLE
feat: verify partial decryption signature

### DIFF
--- a/packages/crypto/__tests__/signature.test.ts
+++ b/packages/crypto/__tests__/signature.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect } from "vitest";
+import { secp256k1 } from "@noble/curves/secp256k1";
+import { keccak_256 as keccak256 } from "@noble/hashes/sha3";
+import { RLP } from "@ethereumjs/rlp";
+import { verifyPartialSignature } from "../src/signature.js";
+
+/** Reproduce the kernel's signPartialDecryptResponse in JS. */
+function kernelSign(params: {
+  round: number;
+  ciphertext: Uint8Array;
+  encryptedPartial: Uint8Array;
+  ephemeralPubKey: Uint8Array;
+  pubShare: Uint8Array;
+  privateKey: Uint8Array;
+}): Uint8Array {
+  const encoded = RLP.encode([
+    params.round,
+    params.ciphertext,
+    params.encryptedPartial,
+    params.ephemeralPubKey,
+    params.pubShare,
+  ]);
+  const hash = keccak256(encoded);
+
+  const sig = secp256k1.sign(hash, params.privateKey);
+  const sigBytes = new Uint8Array(65);
+  sigBytes.set(sig.toCompactRawBytes(), 0);
+  // recovery id: kernel adds 27 if < 27
+  sigBytes[64] = sig.recovery + 27;
+  return sigBytes;
+}
+
+describe("verifyPartialSignature", () => {
+  function makeTestData() {
+    const privateKey = secp256k1.utils.randomPrivateKey();
+    // commPubKey is 64 bytes: uncompressed pubkey without the 0x04 prefix
+    const fullPubKey = secp256k1.getPublicKey(privateKey, false);
+    const commPubKey = fullPubKey.slice(1); // drop 0x04 prefix → 64 bytes
+
+    const round = 1;
+    const ciphertext = new Uint8Array([0xaa, 0xbb, 0xcc]);
+    const encryptedPartial = new Uint8Array([0xde, 0xad, 0xbe, 0xef]);
+    const ephemeralPubKey = new Uint8Array([0xca, 0xfe, 0x00, 0x00]);
+    const pubShare = new Uint8Array([0xba, 0xbe, 0x00, 0x00]);
+
+    const signature = kernelSign({
+      round,
+      ciphertext,
+      encryptedPartial,
+      ephemeralPubKey,
+      pubShare,
+      privateKey,
+    });
+
+    return { round, ciphertext, encryptedPartial, ephemeralPubKey, pubShare, signature, commPubKey, privateKey };
+  }
+
+  it("returns true for a valid kernel-signed partial", () => {
+    const d = makeTestData();
+    const result = verifyPartialSignature({
+      round: d.round,
+      ciphertext: d.ciphertext,
+      encryptedPartial: d.encryptedPartial,
+      ephemeralPubKey: d.ephemeralPubKey,
+      pubShare: d.pubShare,
+      signature: d.signature,
+      commPubKey: d.commPubKey,
+    });
+    expect(result).toBe(true);
+  });
+
+  it("returns false when encryptedPartial is tampered", () => {
+    const d = makeTestData();
+    const tampered = new Uint8Array(d.encryptedPartial);
+    tampered[0] ^= 0xff;
+
+    const result = verifyPartialSignature({
+      round: d.round,
+      ciphertext: d.ciphertext,
+      encryptedPartial: tampered,
+      ephemeralPubKey: d.ephemeralPubKey,
+      pubShare: d.pubShare,
+      signature: d.signature,
+      commPubKey: d.commPubKey,
+    });
+    expect(result).toBe(false);
+  });
+
+  it("returns false when round is wrong", () => {
+    const d = makeTestData();
+    const result = verifyPartialSignature({
+      round: d.round + 1,
+      ciphertext: d.ciphertext,
+      encryptedPartial: d.encryptedPartial,
+      ephemeralPubKey: d.ephemeralPubKey,
+      pubShare: d.pubShare,
+      signature: d.signature,
+      commPubKey: d.commPubKey,
+    });
+    expect(result).toBe(false);
+  });
+
+  it("returns false when commPubKey does not match signer", () => {
+    const d = makeTestData();
+    const wrongKey = secp256k1.getPublicKey(secp256k1.utils.randomPrivateKey(), false).slice(1);
+
+    const result = verifyPartialSignature({
+      round: d.round,
+      ciphertext: d.ciphertext,
+      encryptedPartial: d.encryptedPartial,
+      ephemeralPubKey: d.ephemeralPubKey,
+      pubShare: d.pubShare,
+      signature: d.signature,
+      commPubKey: wrongKey,
+    });
+    expect(result).toBe(false);
+  });
+
+  it("returns false for malformed signature (wrong length)", () => {
+    const d = makeTestData();
+    const result = verifyPartialSignature({
+      round: d.round,
+      ciphertext: d.ciphertext,
+      encryptedPartial: d.encryptedPartial,
+      ephemeralPubKey: d.ephemeralPubKey,
+      pubShare: d.pubShare,
+      signature: new Uint8Array([0x00, 0x01]),
+      commPubKey: d.commPubKey,
+    });
+    expect(result).toBe(false);
+  });
+
+  it("handles round=0 correctly (RLP encodes as empty bytes)", () => {
+    const privateKey = secp256k1.utils.randomPrivateKey();
+    const commPubKey = secp256k1.getPublicKey(privateKey, false).slice(1);
+    const ciphertext = new Uint8Array([0x01]);
+    const encryptedPartial = new Uint8Array([0x02]);
+    const ephemeralPubKey = new Uint8Array([0x03]);
+    const pubShare = new Uint8Array([0x04]);
+
+    const signature = kernelSign({
+      round: 0,
+      ciphertext,
+      encryptedPartial,
+      ephemeralPubKey,
+      pubShare,
+      privateKey,
+    });
+
+    const result = verifyPartialSignature({
+      round: 0,
+      ciphertext,
+      encryptedPartial,
+      ephemeralPubKey,
+      pubShare,
+      signature,
+      commPubKey,
+    });
+    expect(result).toBe(true);
+  });
+});

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -11,9 +11,10 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
+    "@ethereumjs/rlp": "^10.1.1",
+    "@noble/ciphers": "^1.0",
     "@noble/curves": "^1.6",
-    "@noble/hashes": "^1.5",
-    "@noble/ciphers": "^1.0"
+    "@noble/hashes": "^1.5"
   },
   "devDependencies": {
     "typescript": "^5.5",

--- a/packages/crypto/src/index.ts
+++ b/packages/crypto/src/index.ts
@@ -4,3 +4,4 @@ export * from "./types.js";
 export * from "./errors.js";
 export { initWasm, resetWasm, getWasm, setWasmForTesting, CURVE_ED25519 } from "./wasm/loader.js";
 export type { CbMpcWasm } from "./wasm/loader.js";
+export { verifyPartialSignature } from "./signature.js";

--- a/packages/crypto/src/signature.ts
+++ b/packages/crypto/src/signature.ts
@@ -1,0 +1,66 @@
+import { RLP } from "@ethereumjs/rlp";
+import { secp256k1 } from "@noble/curves/secp256k1";
+import { keccak_256 as keccak256Noble } from "@noble/hashes/sha3";
+import { bytesToHex } from "@noble/hashes/utils";
+
+/**
+ * Verify a partial decryption signature produced by the story-kernel TEE.
+ *
+ * Reproduces the kernel's signing protocol:
+ * 1. RLP encode [Round, Ciphertext, EncryptedPartial, EphemeralPubKey, PubShare]
+ * 2. Keccak256 hash the encoded bytes
+ * 3. Recover the secp256k1 public key from the signature
+ * 4. Compare the recovered address with the expected address derived from commPubKey
+ *
+ * @returns true if the signature is valid and was produced by the holder of commPubKey
+ */
+export function verifyPartialSignature(params: {
+  round: number;
+  ciphertext: Uint8Array;
+  encryptedPartial: Uint8Array;
+  ephemeralPubKey: Uint8Array;
+  pubShare: Uint8Array;
+  /** 65-byte secp256k1 signature (r || s || v), where v is 27 or 28 */
+  signature: Uint8Array;
+  /** 64-byte uncompressed public key (without 0x04 prefix) from DKG Registered event */
+  commPubKey: Uint8Array;
+}): boolean {
+  const { round, ciphertext, encryptedPartial, ephemeralPubKey, pubShare, signature, commPubKey } = params;
+
+  if (signature.length !== 65) return false;
+  if (commPubKey.length !== 64) return false;
+
+  try {
+    // 1. RLP encode the signature material (matches Go struct field order).
+    // @ethereumjs/rlp encodes numbers as minimal big-endian bytes, matching Go's RLP uint encoding.
+    const encoded = RLP.encode([round, ciphertext, encryptedPartial, ephemeralPubKey, pubShare]);
+
+    // 2. Keccak256 hash
+    const respHash = keccak256Noble(encoded);
+
+    // 3. Normalize recovery ID and recover public key
+    let recoveryId = signature[64];
+    if (recoveryId >= 27) recoveryId -= 27;
+
+    const r = signature.slice(0, 32);
+    const s = signature.slice(32, 64);
+
+    const sig = new secp256k1.Signature(
+      BigInt("0x" + bytesToHex(r)),
+      BigInt("0x" + bytesToHex(s)),
+    ).addRecoveryBit(recoveryId);
+
+    const recoveredPubKey = sig.recoverPublicKey(respHash).toRawBytes(false);
+    // recoveredPubKey is 65 bytes (0x04 || x || y), drop prefix to get 64 bytes
+    const recoveredRaw = recoveredPubKey.slice(1);
+
+    // 4. Compare addresses: keccak256(pubkey)[12:32]
+    const recoveredAddr = keccak256Noble(recoveredRaw).slice(12);
+    const expectedAddr = keccak256Noble(commPubKey).slice(12);
+
+    return recoveredAddr.length === expectedAddr.length &&
+      recoveredAddr.every((byte, i) => byte === expectedAddr[i]);
+  } catch {
+    return false;
+  }
+}

--- a/packages/sdk/__tests__/consumer.test.ts
+++ b/packages/sdk/__tests__/consumer.test.ts
@@ -5,9 +5,11 @@ import { encodeAbiParameters, keccak256, toBytes, padHex } from "viem";
 vi.mock("@piplabs/cdr-crypto", () => ({
   decryptPartial: vi.fn(),
   tdh2Combine: vi.fn(),
+  verifyPartialSignature: vi.fn(),
 }));
 
 import { Consumer } from "../src/consumer.js";
+import { verifyPartialSignature } from "@piplabs/cdr-crypto";
 
 function makePartialDecryptionLog(opts: {
   validator: `0x${string}`;
@@ -78,6 +80,56 @@ function mockClients() {
   return { publicClient, walletClient };
 }
 
+function makeRegisteredLog(opts: {
+  validatorAddr: `0x${string}`;
+  enclaveCommKey: `0x${string}`;
+  round: number;
+}) {
+  const topic0 = keccak256(
+    toBytes(
+      "Registered(bytes,uint32,address,bytes32,bytes,bytes,bytes32,uint256,bytes32,bytes)",
+    ),
+  );
+  const topic1 = padHex(opts.validatorAddr, { size: 32 });
+
+  const data = encodeAbiParameters(
+    [
+      { name: "enclaveReport", type: "bytes" },
+      { name: "round", type: "uint32" },
+      { name: "enclaveType", type: "bytes32" },
+      { name: "enclaveCommKey", type: "bytes" },
+      { name: "dkgPubKey", type: "bytes" },
+      { name: "codeCommitment", type: "bytes32" },
+      { name: "startBlockHeight", type: "uint256" },
+      { name: "startBlockHash", type: "bytes32" },
+      { name: "validationContext", type: "bytes" },
+    ],
+    [
+      "0x",
+      opts.round,
+      "0x0000000000000000000000000000000000000000000000000000000000000000",
+      opts.enclaveCommKey,
+      "0x",
+      "0x0000000000000000000000000000000000000000000000000000000000000000",
+      0n,
+      "0x0000000000000000000000000000000000000000000000000000000000000000",
+      "0x",
+    ],
+  );
+
+  return {
+    address: "0xcccccc0000000000000000000000000000000004" as `0x${string}`,
+    topics: [topic0, topic1] as [`0x${string}`, `0x${string}`],
+    data,
+    blockHash: "0x0000000000000000000000000000000000000000000000000000000000000000" as `0x${string}`,
+    blockNumber: 50n,
+    transactionHash: "0x0000000000000000000000000000000000000000000000000000000000000002" as `0x${string}`,
+    transactionIndex: 0,
+    logIndex: 0,
+    removed: false,
+  };
+}
+
 describe("Consumer", () => {
   it("read sends tx with correct fee and requesterPubKey", async () => {
     const { publicClient, walletClient } = mockClients();
@@ -127,6 +179,8 @@ describe("Consumer", () => {
 
   it("collectPartials polls until minPartials reached", async () => {
     const { publicClient, walletClient } = mockClients();
+    vi.mocked(verifyPartialSignature).mockReturnValue(true);
+
     // Return incrementing block numbers so the condition `currentBlock >= lastScannedBlock`
     // stays true on each poll and getLogs is called every iteration.
     publicClient.getBlockNumber
@@ -134,9 +188,14 @@ describe("Consumer", () => {
       .mockResolvedValueOnce(101n)
       .mockResolvedValue(102n);
 
-    // First poll: no matching logs. Second poll: 3 properly encoded logs.
+    // First call: DKG Registered events. Second poll: no CDR logs. Third poll: 3 CDR logs.
     // Default fallback: empty array so any extra calls don't return undefined.
     publicClient.getLogs
+      .mockResolvedValueOnce([
+        makeRegisteredLog({ validatorAddr: "0x0000000000000000000000000000000000000001", enclaveCommKey: ("0x" + "aa".repeat(64)) as `0x${string}`, round: 1 }),
+        makeRegisteredLog({ validatorAddr: "0x0000000000000000000000000000000000000002", enclaveCommKey: ("0x" + "bb".repeat(64)) as `0x${string}`, round: 1 }),
+        makeRegisteredLog({ validatorAddr: "0x0000000000000000000000000000000000000003", enclaveCommKey: ("0x" + "cc".repeat(64)) as `0x${string}`, round: 1 }),
+      ])
       .mockResolvedValueOnce([])
       .mockResolvedValueOnce([
         makePartialDecryptionLog({ validator: "0x0000000000000000000000000000000000000001", round: 1, pid: 1, uuid: 1 }),
@@ -167,12 +226,17 @@ describe("Consumer", () => {
 
   it("collectPartials deduplicates events from the same validator+pid", async () => {
     const { publicClient, walletClient } = mockClients();
+    vi.mocked(verifyPartialSignature).mockReturnValue(true);
+
     // Incrementing block numbers so getLogs is called every iteration.
     publicClient.getBlockNumber.mockResolvedValueOnce(100n).mockResolvedValue(101n);
 
-    // Two logs with identical validator+pid — only one should be kept.
-    // Third log fills the final slot. After that, return empty arrays.
+    // First call: DKG Registered events. Then CDR logs with duplicates.
     publicClient.getLogs
+      .mockResolvedValueOnce([
+        makeRegisteredLog({ validatorAddr: "0x0000000000000000000000000000000000000001", enclaveCommKey: ("0x" + "aa".repeat(64)) as `0x${string}`, round: 1 }),
+        makeRegisteredLog({ validatorAddr: "0x0000000000000000000000000000000000000002", enclaveCommKey: ("0x" + "bb".repeat(64)) as `0x${string}`, round: 1 }),
+      ])
       .mockResolvedValueOnce([
         makePartialDecryptionLog({ validator: "0x0000000000000000000000000000000000000001", round: 1, pid: 1, uuid: 5 }),
         makePartialDecryptionLog({ validator: "0x0000000000000000000000000000000000000001", round: 1, pid: 1, uuid: 5 }),
@@ -199,15 +263,19 @@ describe("Consumer", () => {
 
   it("collectPartials ignores events for a different uuid", async () => {
     const { publicClient, walletClient } = mockClients();
+    vi.mocked(verifyPartialSignature).mockReturnValue(true);
+
     // Incrementing block numbers so getLogs is called every iteration.
     publicClient.getBlockNumber
       .mockResolvedValueOnce(100n)
       .mockResolvedValueOnce(101n)
       .mockResolvedValue(102n);
 
-    // uuid=99 events should be ignored when collecting for uuid=1;
-    // only the uuid=1 event counts. Fallback to empty arrays.
+    // First call: DKG Registered events. Then CDR logs with wrong/right uuid.
     publicClient.getLogs
+      .mockResolvedValueOnce([
+        makeRegisteredLog({ validatorAddr: "0x0000000000000000000000000000000000000001", enclaveCommKey: ("0x" + "aa".repeat(64)) as `0x${string}`, round: 1 }),
+      ])
       .mockResolvedValueOnce([
         makePartialDecryptionLog({ validator: "0x0000000000000000000000000000000000000001", round: 1, pid: 1, uuid: 99 }),
       ])
@@ -236,10 +304,13 @@ describe("Consumer", () => {
 
   it("collectPartials throws PartialCollectionTimeoutError when deadline expires", async () => {
     const { publicClient, walletClient } = mockClients();
+    vi.mocked(verifyPartialSignature).mockReturnValue(true);
+
     // Always return an incrementing block so getLogs is always called, but no logs.
     let block = 100n;
     publicClient.getBlockNumber.mockImplementation(() => Promise.resolve(block++));
-    publicClient.getLogs.mockResolvedValue([]);
+    // First call: DKG Registered (empty). Rest: empty CDR logs.
+    publicClient.getLogs.mockResolvedValueOnce([]).mockResolvedValue([]);
 
     const consumer = new Consumer({
       network: "testnet",
@@ -256,5 +327,157 @@ describe("Consumer", () => {
         pollIntervalMs: 10,
       }),
     ).rejects.toThrow("Timed out collecting partials after 100ms: got 0/3");
+  });
+
+  it("collectPartials verifies signatures and accepts valid partials", async () => {
+    const { publicClient, walletClient } = mockClients();
+    const mockVerify = vi.mocked(verifyPartialSignature);
+    mockVerify.mockReset();
+    mockVerify.mockReturnValue(true);
+
+    publicClient.getBlockNumber.mockResolvedValueOnce(100n).mockResolvedValue(101n);
+
+    publicClient.getLogs
+      .mockResolvedValueOnce([
+        makeRegisteredLog({
+          validatorAddr: "0x0000000000000000000000000000000000000001",
+          enclaveCommKey: ("0x" + "aa".repeat(64)) as `0x${string}`,
+          round: 1,
+        }),
+      ])
+      .mockResolvedValueOnce([
+        makePartialDecryptionLog({ validator: "0x0000000000000000000000000000000000000001", round: 1, pid: 1, uuid: 1 }),
+      ])
+      .mockResolvedValue([]);
+
+    const consumer = new Consumer({ network: "testnet", publicClient, walletClient });
+    const partials = await consumer.collectPartials({
+      uuid: 1,
+      minPartials: 1,
+      fromBlock: 90n,
+      timeoutMs: 5_000,
+      pollIntervalMs: 50,
+    });
+
+    expect(partials).toHaveLength(1);
+    expect(mockVerify).toHaveBeenCalledOnce();
+  });
+
+  it("collectPartials rejects invalid signatures and invokes callback", async () => {
+    const { publicClient, walletClient } = mockClients();
+    const mockVerify = vi.mocked(verifyPartialSignature);
+    mockVerify.mockReset();
+    mockVerify.mockReturnValueOnce(false).mockReturnValue(true);
+
+    publicClient.getBlockNumber.mockResolvedValueOnce(100n).mockResolvedValue(101n);
+
+    publicClient.getLogs
+      .mockResolvedValueOnce([
+        makeRegisteredLog({
+          validatorAddr: "0x0000000000000000000000000000000000000001",
+          enclaveCommKey: ("0x" + "aa".repeat(64)) as `0x${string}`,
+          round: 1,
+        }),
+        makeRegisteredLog({
+          validatorAddr: "0x0000000000000000000000000000000000000002",
+          enclaveCommKey: ("0x" + "bb".repeat(64)) as `0x${string}`,
+          round: 1,
+        }),
+      ])
+      .mockResolvedValueOnce([
+        makePartialDecryptionLog({ validator: "0x0000000000000000000000000000000000000001", round: 1, pid: 1, uuid: 1 }),
+        makePartialDecryptionLog({ validator: "0x0000000000000000000000000000000000000002", round: 1, pid: 2, uuid: 1 }),
+      ])
+      .mockResolvedValue([]);
+
+    const onInvalidPartial = vi.fn();
+    const consumer = new Consumer({ network: "testnet", publicClient, walletClient });
+    const partials = await consumer.collectPartials({
+      uuid: 1,
+      minPartials: 1,
+      fromBlock: 90n,
+      timeoutMs: 5_000,
+      pollIntervalMs: 50,
+      onInvalidPartial,
+    });
+
+    expect(partials).toHaveLength(1);
+    expect(partials[0].pid).toBe(2);
+    expect(onInvalidPartial).toHaveBeenCalledOnce();
+    expect(onInvalidPartial.mock.calls[0][0].pid).toBe(1);
+    expect(onInvalidPartial.mock.calls[0][1]).toBeInstanceOf(Error);
+  });
+
+  it("collectPartials skips partials from unknown validators", async () => {
+    const { publicClient, walletClient } = mockClients();
+    const mockVerify = vi.mocked(verifyPartialSignature);
+    mockVerify.mockReset();
+    mockVerify.mockReturnValue(true);
+
+    publicClient.getBlockNumber.mockResolvedValueOnce(100n).mockResolvedValue(101n);
+
+    publicClient.getLogs
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([
+        makePartialDecryptionLog({ validator: "0x0000000000000000000000000000000000000001", round: 1, pid: 1, uuid: 1 }),
+      ])
+      .mockResolvedValue([]);
+
+    const onInvalidPartial = vi.fn();
+    const consumer = new Consumer({ network: "testnet", publicClient, walletClient });
+
+    await expect(
+      consumer.collectPartials({
+        uuid: 1,
+        minPartials: 1,
+        fromBlock: 90n,
+        timeoutMs: 200,
+        pollIntervalMs: 50,
+        onInvalidPartial,
+      }),
+    ).rejects.toThrow("Timed out");
+
+    expect(onInvalidPartial).toHaveBeenCalledOnce();
+    expect(onInvalidPartial.mock.calls[0][1].message).toContain("unknown validator");
+  });
+
+  it("collectPartials silently skips invalid partials when no callback provided", async () => {
+    const { publicClient, walletClient } = mockClients();
+    const mockVerify = vi.mocked(verifyPartialSignature);
+    mockVerify.mockReset();
+    mockVerify.mockReturnValueOnce(false).mockReturnValue(true);
+
+    publicClient.getBlockNumber.mockResolvedValueOnce(100n).mockResolvedValue(101n);
+
+    publicClient.getLogs
+      .mockResolvedValueOnce([
+        makeRegisteredLog({
+          validatorAddr: "0x0000000000000000000000000000000000000001",
+          enclaveCommKey: ("0x" + "aa".repeat(64)) as `0x${string}`,
+          round: 1,
+        }),
+        makeRegisteredLog({
+          validatorAddr: "0x0000000000000000000000000000000000000002",
+          enclaveCommKey: ("0x" + "bb".repeat(64)) as `0x${string}`,
+          round: 1,
+        }),
+      ])
+      .mockResolvedValueOnce([
+        makePartialDecryptionLog({ validator: "0x0000000000000000000000000000000000000001", round: 1, pid: 1, uuid: 1 }),
+        makePartialDecryptionLog({ validator: "0x0000000000000000000000000000000000000002", round: 1, pid: 2, uuid: 1 }),
+      ])
+      .mockResolvedValue([]);
+
+    const consumer = new Consumer({ network: "testnet", publicClient, walletClient });
+    const partials = await consumer.collectPartials({
+      uuid: 1,
+      minPartials: 1,
+      fromBlock: 90n,
+      timeoutMs: 5_000,
+      pollIntervalMs: 50,
+    });
+
+    expect(partials).toHaveLength(1);
+    expect(partials[0].pid).toBe(2);
   });
 });

--- a/packages/sdk/__tests__/observer.test.ts
+++ b/packages/sdk/__tests__/observer.test.ts
@@ -52,6 +52,56 @@ function makeFinalizedLog(globalPubKey: `0x${string}`, validator: `0x${string}` 
   };
 }
 
+function makeRegisteredLog(opts: {
+  validatorAddr: `0x${string}`;
+  enclaveCommKey: `0x${string}`;
+  round: number;
+}) {
+  const topic0 = keccak256(
+    toBytes(
+      "Registered(bytes,uint32,address,bytes32,bytes,bytes,bytes32,uint256,bytes32,bytes)",
+    ),
+  );
+  const topic1 = padHex(opts.validatorAddr, { size: 32 });
+
+  const data = encodeAbiParameters(
+    [
+      { name: "enclaveReport", type: "bytes" },
+      { name: "round", type: "uint32" },
+      { name: "enclaveType", type: "bytes32" },
+      { name: "enclaveCommKey", type: "bytes" },
+      { name: "dkgPubKey", type: "bytes" },
+      { name: "codeCommitment", type: "bytes32" },
+      { name: "startBlockHeight", type: "uint256" },
+      { name: "startBlockHash", type: "bytes32" },
+      { name: "validationContext", type: "bytes" },
+    ],
+    [
+      "0x",
+      opts.round,
+      "0x0000000000000000000000000000000000000000000000000000000000000000",
+      opts.enclaveCommKey,
+      "0x",
+      "0x0000000000000000000000000000000000000000000000000000000000000000",
+      0n,
+      "0x0000000000000000000000000000000000000000000000000000000000000000",
+      "0x",
+    ],
+  );
+
+  return {
+    address: "0xcccccc0000000000000000000000000000000004" as `0x${string}`,
+    topics: [topic0, topic1] as [`0x${string}`, `0x${string}`],
+    data,
+    blockHash: "0x0000000000000000000000000000000000000000000000000000000000000000" as `0x${string}`,
+    blockNumber: 50n,
+    transactionHash: "0x0000000000000000000000000000000000000000000000000000000000000002" as `0x${string}`,
+    transactionIndex: 0,
+    logIndex: 0,
+    removed: false,
+  };
+}
+
 describe("Observer", () => {
   it("getVault reads vault from CDR contract", async () => {
     const client = mockPublicClient();
@@ -118,5 +168,57 @@ describe("Observer", () => {
     const pubKey = await observer.getGlobalPubKey();
 
     expect(toHex(pubKey)).toBe(newPubKey);
+  });
+
+  it("getRegisteredValidators returns map of validator address to commPubKey", async () => {
+    const client = mockPublicClient();
+    const commKey = ("0x" + "aa".repeat(64)) as `0x${string}`; // 64 bytes
+    client.getLogs.mockResolvedValueOnce([
+      makeRegisteredLog({
+        validatorAddr: "0x0000000000000000000000000000000000000001",
+        enclaveCommKey: commKey,
+        round: 1,
+      }),
+    ]);
+
+    const observer = new Observer({ network: "testnet", publicClient: client });
+    const validators = await observer.getRegisteredValidators();
+
+    expect(validators.size).toBe(1);
+    const key = validators.get("0x0000000000000000000000000000000000000001");
+    expect(key).toBeDefined();
+    expect(key!.length).toBe(64);
+  });
+
+  it("getRegisteredValidators filters by round when provided", async () => {
+    const client = mockPublicClient();
+    client.getLogs.mockResolvedValueOnce([
+      makeRegisteredLog({
+        validatorAddr: "0x0000000000000000000000000000000000000001",
+        enclaveCommKey: ("0x" + "aa".repeat(64)) as `0x${string}`,
+        round: 1,
+      }),
+      makeRegisteredLog({
+        validatorAddr: "0x0000000000000000000000000000000000000002",
+        enclaveCommKey: ("0x" + "bb".repeat(64)) as `0x${string}`,
+        round: 2,
+      }),
+    ]);
+
+    const observer = new Observer({ network: "testnet", publicClient: client });
+    const validators = await observer.getRegisteredValidators({ round: 2 });
+
+    expect(validators.size).toBe(1);
+    expect(validators.has("0x0000000000000000000000000000000000000002")).toBe(true);
+  });
+
+  it("getRegisteredValidators returns empty map when no Registered events", async () => {
+    const client = mockPublicClient();
+    client.getLogs.mockResolvedValueOnce([]);
+
+    const observer = new Observer({ network: "testnet", publicClient: client });
+    const validators = await observer.getRegisteredValidators();
+
+    expect(validators.size).toBe(0);
   });
 });

--- a/packages/sdk/src/consumer.ts
+++ b/packages/sdk/src/consumer.ts
@@ -1,6 +1,6 @@
 import { parseEventLogs, toBytes, type PublicClient, type WalletClient } from "viem";
-import { cdrAbi, contractAddresses, type Network } from "@piplabs/cdr-contracts";
-import { decryptPartial as eciesDecrypt, tdh2Combine, type TDH2Ciphertext, type DecryptedPartial } from "@piplabs/cdr-crypto";
+import { cdrAbi, dkgAbi, contractAddresses, type Network } from "@piplabs/cdr-contracts";
+import { decryptPartial as eciesDecrypt, tdh2Combine, verifyPartialSignature, type TDH2Ciphertext, type DecryptedPartial } from "@piplabs/cdr-crypto";
 import { PartialCollectionTimeoutError } from "./errors.js";
 import type { PartialDecryptionEvent } from "./types.js";
 import { uuidToLabel } from "./label.js";
@@ -48,9 +48,35 @@ export class Consumer {
     return { txHash };
   }
 
+  /** Fetch validator address → commPubKey map from DKG Registered events */
+  private async getCommPubKeyMap(): Promise<Map<string, Uint8Array>> {
+    const dkgAddress = contractAddresses[this.network].dkg;
+
+    const rawLogs = await this.publicClient.getLogs({
+      address: dkgAddress,
+      fromBlock: BigInt(0),
+      toBlock: "latest",
+    });
+
+    const parsed = parseEventLogs({
+      abi: dkgAbi,
+      logs: rawLogs,
+      eventName: "Registered",
+    });
+
+    const validators = new Map<string, Uint8Array>();
+    for (const log of parsed) {
+      const addr = log.args.validatorAddr.toLowerCase() as `0x${string}`;
+      validators.set(addr, toBytes(log.args.enclaveCommKey));
+    }
+
+    return validators;
+  }
+
   /**
    * Poll for EncryptedPartialDecryptionSubmitted events until minPartials are collected.
    * Filters by uuid to match events for this specific vault read request.
+   * Verifies each partial's TEE signature; invalid partials are skipped.
    */
   async collectPartials(params: {
     uuid: number;
@@ -58,10 +84,15 @@ export class Consumer {
     fromBlock: bigint;
     timeoutMs?: number;
     pollIntervalMs?: number;
+    /** Called when a partial fails signature verification. If not provided, invalid partials are silently skipped. */
+    onInvalidPartial?: (event: PartialDecryptionEvent, error: Error) => void;
   }): Promise<PartialDecryptionEvent[]> {
-    const { uuid, minPartials, fromBlock, timeoutMs = 60_000, pollIntervalMs = 3_000 } = params;
+    const { uuid, minPartials, fromBlock, timeoutMs = 60_000, pollIntervalMs = 3_000, onInvalidPartial } = params;
     const cdrAddress = contractAddresses[this.network].cdr;
     const deadline = Date.now() + timeoutMs;
+
+    // Build commPubKey map from DKG Registered events
+    const commPubKeyMap = await this.getCommPubKeyMap();
 
     let lastScannedBlock = fromBlock;
     const collected = new Map<string, PartialDecryptionEvent>();
@@ -86,7 +117,7 @@ export class Consumer {
           if (log.args.uuid === uuid) {
             const key = `${log.args.validator}-${log.args.pid}`;
             if (!collected.has(key)) {
-              collected.set(key, {
+              const event: PartialDecryptionEvent = {
                 validator: log.args.validator,
                 round: log.args.round,
                 pid: log.args.pid,
@@ -96,7 +127,33 @@ export class Consumer {
                 requesterPubKey: log.args.requesterPubKey,
                 uuid: log.args.uuid,
                 signature: log.args.signature,
-              } as PartialDecryptionEvent);
+              };
+
+              // Verify signature
+              const validatorAddr = log.args.validator.toLowerCase();
+              const commPubKey = commPubKeyMap.get(validatorAddr);
+
+              if (!commPubKey) {
+                onInvalidPartial?.(event, new Error(`unknown validator: ${log.args.validator}`));
+                continue;
+              }
+
+              const valid = verifyPartialSignature({
+                round: event.round,
+                ciphertext: toBytes(log.args.ciphertext),
+                encryptedPartial: toBytes(event.encryptedPartial),
+                ephemeralPubKey: toBytes(event.ephemeralPubKey),
+                pubShare: toBytes(event.pubShare),
+                signature: toBytes(event.signature),
+                commPubKey,
+              });
+
+              if (!valid) {
+                onInvalidPartial?.(event, new Error(`invalid signature from validator ${log.args.validator}`));
+                continue;
+              }
+
+              collected.set(key, event);
             }
           }
         }
@@ -157,6 +214,7 @@ export class Consumer {
     threshold: number;
     timeoutMs?: number;
     feeOverride?: bigint;
+    onInvalidPartial?: (event: PartialDecryptionEvent, error: Error) => void;
   }): Promise<{ dataKey: Uint8Array; txHash: `0x${string}` }> {
     const vault = await this.publicClient.readContract({
       address: contractAddresses[this.network].cdr,
@@ -182,6 +240,7 @@ export class Consumer {
       minPartials: params.threshold,
       fromBlock,
       timeoutMs: params.timeoutMs,
+      onInvalidPartial: params.onInvalidPartial,
     });
 
     const dataKey = await this.decryptDataKey({

--- a/packages/sdk/src/observer.ts
+++ b/packages/sdk/src/observer.ts
@@ -128,4 +128,43 @@ export class Observer {
     ]);
     return Math.ceil(participantCount * Number(operationalThreshold) / 1000);
   }
+
+  /**
+   * Get a map of validator address → enclaveCommKey from DKG Registered events.
+   * The commPubKey is the 64-byte uncompressed secp256k1 public key (without 0x04 prefix)
+   * used by the validator's TEE to sign partial decryption responses.
+   *
+   * @param round - If provided, only include validators registered for this round
+   * @returns Map where keys are lowercase checksummed addresses and values are commPubKey bytes
+   */
+  async getRegisteredValidators(params?: {
+    fromBlock?: bigint;
+    round?: number;
+  }): Promise<Map<string, Uint8Array>> {
+    const dkgAddress = contractAddresses[this.network].dkg;
+    const fromBlock = params?.fromBlock ?? BigInt(0);
+
+    const rawLogs = await this.publicClient.getLogs({
+      address: dkgAddress,
+      fromBlock,
+      toBlock: "latest",
+    });
+
+    const parsed = parseEventLogs({
+      abi: dkgAbi,
+      logs: rawLogs,
+      eventName: "Registered",
+    });
+
+    const validators = new Map<string, Uint8Array>();
+    for (const log of parsed) {
+      if (params?.round !== undefined && log.args.round !== params.round) {
+        continue;
+      }
+      const addr = log.args.validatorAddr.toLowerCase() as `0x${string}`;
+      validators.set(addr, toBytes(log.args.enclaveCommKey));
+    }
+
+    return validators;
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -61,6 +61,9 @@ importers:
 
   packages/crypto:
     dependencies:
+      '@ethereumjs/rlp':
+        specifier: ^10.1.1
+        version: 10.1.1
       '@noble/ciphers':
         specifier: ^1.0
         version: 1.3.0
@@ -395,6 +398,11 @@ packages:
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
+
+  '@ethereumjs/rlp@10.1.1':
+    resolution: {integrity: sha512-jbnWTEwcpoY+gE0r+wxfDG9zgiu54DcTcwnc9sX3DsqKR4l5K7x2V8mQL3Et6hURa4DuT9g7z6ukwpBLFchszg==}
+    engines: {node: '>=20'}
+    hasBin: true
 
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
@@ -1018,6 +1026,8 @@ snapshots:
 
   '@esbuild/win32-x64@0.27.3':
     optional: true
+
+  '@ethereumjs/rlp@10.1.1': {}
 
   '@jridgewell/sourcemap-codec@1.5.5': {}
 


### PR DESCRIPTION
## Summary

- Add `verifyPartialSignature()` to `@piplabs/cdr-crypto` that reproduces the kernel's signing protocol (RLP encode → Keccak256 → secp256k1 ecrecover) to verify TEE signatures on partial decryption responses
- Integrate verification into `Consumer.collectPartials` — invalid partials are rejected before reaching callers, with an optional `onInvalidPartial` callback for observability
- Add `Observer.getRegisteredValidators()` to resolve validator address → `enclaveCommKey` mappings from DKG `Registered` events
- Add `onInvalidPartial` passthrough to `Consumer.accessCDR`

## Motivation

The kernel signs partial decryption responses with secp256k1 over RLP-encoded material (`[Round, Ciphertext, EncryptedPartial, EphemeralPubKey, PubShare]`). The SDK previously collected these signatures but never verified them, leaving consumers unable to detect tampered partials before combining.

## Design decisions

- Verification happens inside `collectPartials` (secure by default)
- Invalid partials are silently skipped; optional `onInvalidPartial?: (event, error) => void` callback gives consumers control over logging
- CommPubKey lookup queries DKG `Registered` events (self-contained; future: replace with indexed endpoint)
- `verifyPartialSignature` lives in `@piplabs/cdr-crypto` alongside ECIES/TDH2

## Test plan

- [x] `verifyPartialSignature`: 6 unit tests — valid signature, tampered data, wrong round, wrong commPubKey, malformed signature, round=0 edge case
- [x] `Observer.getRegisteredValidators`: 3 tests — basic map, round filtering, empty case
- [x] `Consumer.collectPartials`: 4 new tests — valid acceptance, invalid rejection with callback, unknown validator, silent skip without callback
- [x] All existing tests updated and passing
- [x] Build and lint clean