### PR TITLE
feat: implement SGX attestation verification

### DIFF
--- a/packages/sdk/src/attestation.ts
+++ b/packages/sdk/src/attestation.ts
@@ -1,3 +1,5 @@
+import { toHex } from "viem";
+
 /** Configuration for SGX attestation verification. */
 export interface AttestationConfig {
   /** Minimum acceptable security version (SVN) for the enclave. */
@@ -18,22 +20,146 @@ export interface AttestationResult {
 }
 
 /**
+ * Intel SGX DCAP Quote v3 layout offsets.
+ *
+ * Reference: Intel SGX-TDX-DCAP-QuoteVerificationLibrary QuoteConstants.h
+ * and piplabs/story SGXValidationHook.sol
+ *
+ * ```
+ * Offset 0-47:    Quote Header (48 bytes)
+ * Offset 48-431:  Enclave Report Body (384 bytes)
+ *   Body+64:      MRENCLAVE  (32 bytes) → quote offset 112
+ *   Body+128:     MRSIGNER   (32 bytes) → quote offset 176
+ *   Body+256:     ISV PRODID (2 bytes)  → quote offset 304
+ *   Body+258:     ISV SVN    (2 bytes)  → quote offset 306
+ *   Body+320:     Report Data (64 bytes) → quote offset 368
+ * Offset 432+:    Auth Data (variable)
+ * ```
+ */
+const SGX_QUOTE_HEADER_SIZE = 48;
+const SGX_REPORT_BODY_SIZE = 384;
+const SGX_MIN_QUOTE_SIZE = SGX_QUOTE_HEADER_SIZE + SGX_REPORT_BODY_SIZE; // 432
+
+// Offsets from start of quote (header + offset within report body)
+const MRENCLAVE_OFFSET = SGX_QUOTE_HEADER_SIZE + 64; // 112
+const MRENCLAVE_SIZE = 32;
+const MRSIGNER_OFFSET = SGX_QUOTE_HEADER_SIZE + 128; // 176
+const MRSIGNER_SIZE = 32;
+const ISV_SVN_OFFSET = SGX_QUOTE_HEADER_SIZE + 258; // 306
+const ISV_SVN_SIZE = 2;
+
+/**
+ * Parse fields from an SGX DCAP Quote v3 binary.
+ *
+ * @param report - Raw SGX quote bytes (from DKG Registered event `enclaveReport`)
+ * @returns Parsed fields: mrEnclave, mrSigner, securityVersion
+ * @throws {Error} If the report is too short to be a valid SGX quote
+ *
+ * @example
+ * ```ts
+ * const fields = parseSgxQuote(enclaveReportBytes);
+ * console.log(fields.mrEnclave); // "0x51c08cf3..."
+ * ```
+ */
+export function parseSgxQuote(report: Uint8Array): {
+  mrEnclave: `0x${string}`;
+  mrSigner: `0x${string}`;
+  securityVersion: number;
+} {
+  if (report.length < SGX_MIN_QUOTE_SIZE) {
+    throw new Error(
+      `Invalid SGX quote: ${report.length} bytes, minimum ${SGX_MIN_QUOTE_SIZE} required`,
+    );
+  }
+
+  const mrEnclave = toHex(report.slice(MRENCLAVE_OFFSET, MRENCLAVE_OFFSET + MRENCLAVE_SIZE));
+  const mrSigner = toHex(report.slice(MRSIGNER_OFFSET, MRSIGNER_OFFSET + MRSIGNER_SIZE));
+
+  // ISV SVN is 2 bytes, little-endian
+  const securityVersion = report[ISV_SVN_OFFSET] | (report[ISV_SVN_OFFSET + 1] << 8);
+
+  return {
+    mrEnclave: mrEnclave as `0x${string}`,
+    mrSigner: mrSigner as `0x${string}`,
+    securityVersion,
+  };
+}
+
+/**
  * Verify an SGX attestation report against the given config.
  *
- * @experimental This function is not yet implemented. It will parse the SGX DCAP
- * quote format (header 48 bytes + report body 384 bytes + auth data) and verify
- * MRENCLAVE, MRSIGNER, and ISV SVN against the provided config.
+ * Parses the SGX DCAP Quote v3 binary and checks MRENCLAVE, MRSIGNER,
+ * and ISV SVN against the provided configuration.
  *
- * See SGXValidationHook.sol in piplabs/story for the on-chain verification reference.
+ * Note: This performs client-side field verification only. The cryptographic
+ * signature chain (Intel QE → PCK → root CA) is verified on-chain by
+ * SGXValidationHook via Automata DCAP contracts. This function provides
+ * an additional defense-in-depth check for SDK consumers.
  *
- * @throws {Error} Always throws until SGX attestation verification is implemented.
+ * @param report - Raw SGX quote bytes (from DKG Registered event `enclaveReport`)
+ * @param config - Verification criteria (all optional; omitted fields are not checked)
+ * @returns Verification result with parsed fields and pass/fail status
+ *
+ * @example
+ * ```ts
+ * const result = await verifyAttestation(enclaveReportBytes, {
+ *   expectedMrEnclave: "0x51c08cf3...",
+ *   minSecurityVersion: 1,
+ * });
+ * if (!result.valid) console.error(result.error);
+ * ```
  */
 export async function verifyAttestation(
-  _report: Uint8Array,
-  _config?: AttestationConfig,
+  report: Uint8Array,
+  config?: AttestationConfig,
 ): Promise<AttestationResult> {
-  throw new Error(
-    "SGX attestation verification is not yet implemented. " +
-    "Track progress: https://github.com/piplabs/cdr-sdk/issues — attestation implementation.",
-  );
+  if (report.length === 0) {
+    return { valid: false, error: "Empty attestation report" };
+  }
+
+  let parsed;
+  try {
+    parsed = parseSgxQuote(report);
+  } catch (e) {
+    return { valid: false, error: (e as Error).message };
+  }
+
+  const result: AttestationResult = {
+    valid: true,
+    mrEnclave: parsed.mrEnclave,
+    mrSigner: parsed.mrSigner,
+    securityVersion: parsed.securityVersion,
+  };
+
+  if (config?.expectedMrEnclave !== undefined) {
+    if (parsed.mrEnclave.toLowerCase() !== config.expectedMrEnclave.toLowerCase()) {
+      return {
+        ...result,
+        valid: false,
+        error: `MRENCLAVE mismatch: expected ${config.expectedMrEnclave}, got ${parsed.mrEnclave}`,
+      };
+    }
+  }
+
+  if (config?.expectedMrSigner !== undefined) {
+    if (parsed.mrSigner.toLowerCase() !== config.expectedMrSigner.toLowerCase()) {
+      return {
+        ...result,
+        valid: false,
+        error: `MRSIGNER mismatch: expected ${config.expectedMrSigner}, got ${parsed.mrSigner}`,
+      };
+    }
+  }
+
+  if (config?.minSecurityVersion !== undefined) {
+    if (parsed.securityVersion < config.minSecurityVersion) {
+      return {
+        ...result,
+        valid: false,
+        error: `ISV SVN ${parsed.securityVersion} < minimum ${config.minSecurityVersion}`,
+      };
+    }
+  }
+
+  return result;
 }

--- a/packages/sdk/src/attestation.ts
+++ b/packages/sdk/src/attestation.ts
@@ -39,6 +39,7 @@ export interface AttestationResult {
 const SGX_QUOTE_HEADER_SIZE = 48;
 const SGX_REPORT_BODY_SIZE = 384;
 const SGX_MIN_QUOTE_SIZE = SGX_QUOTE_HEADER_SIZE + SGX_REPORT_BODY_SIZE; // 432
+const SGX_DCAP_V3_VERSION = 3; // Expected quote version (bytes 0-1, little-endian)
 
 // Offsets from start of quote (header + offset within report body)
 const MRENCLAVE_OFFSET = SGX_QUOTE_HEADER_SIZE + 64; // 112
@@ -69,6 +70,16 @@ export function parseSgxQuote(report: Uint8Array): {
   if (report.length < SGX_MIN_QUOTE_SIZE) {
     throw new Error(
       `Invalid SGX quote: ${report.length} bytes, minimum ${SGX_MIN_QUOTE_SIZE} required`,
+    );
+  }
+
+  // Validate quote version (bytes 0-1, little-endian). DCAP v3 = 0x0003.
+  // Quote v4 / TDX quotes have different report-body offsets and would
+  // produce incorrect MRENCLAVE/MRSIGNER if parsed with v3 offsets.
+  const quoteVersion = report[0] | (report[1] << 8);
+  if (quoteVersion !== SGX_DCAP_V3_VERSION) {
+    throw new Error(
+      `Unsupported SGX quote version: ${quoteVersion} (expected ${SGX_DCAP_V3_VERSION} for DCAP v3)`,
     );
   }
 

--- a/packages/sdk/src/observer.ts
+++ b/packages/sdk/src/observer.ts
@@ -324,6 +324,63 @@ export class Observer {
   }
 
   /**
+   * Get validator attestation reports (raw SGX quotes) from DKG Registered events.
+   * Returns a map of validator address → enclaveReport bytes (most recent per validator).
+   *
+   * Use with `verifyAttestation()` to verify each validator's TEE enclave
+   * before trusting their partial decryptions.
+   *
+   * @example
+   * ```ts
+   * import { verifyAttestation } from "@piplabs/cdr-sdk";
+   * const attestations = await observer.getValidatorAttestations();
+   * for (const [addr, report] of attestations) {
+   *   const result = await verifyAttestation(report, { expectedMrEnclave: "0x..." });
+   *   console.log(addr, result.valid);
+   * }
+   * ```
+   */
+  async getValidatorAttestations(params?: {
+    fromBlock?: bigint;
+    round?: number;
+  }): Promise<Map<string, Uint8Array>> {
+    const toBlock = await this.publicClient.getBlockNumber();
+    const fromBlock = params?.fromBlock ??
+      (toBlock > Observer.DEFAULT_LOOKBACK_BLOCKS
+        ? toBlock - Observer.DEFAULT_LOOKBACK_BLOCKS
+        : 0n);
+
+    const rawLogs = await this.fetchDkgEventLogs(
+      this.publicClient,
+      "Registered",
+      fromBlock,
+      toBlock,
+    );
+
+    const parsed = parseEventLogs({
+      abi: dkgAbi,
+      logs: rawLogs,
+      eventName: "Registered",
+    });
+
+    const attestations = new Map<string, Uint8Array>();
+    for (const log of parsed) {
+      if (params?.round !== undefined && log.args.round !== params.round) {
+        continue;
+      }
+      const addr = log.args.validatorAddr.toLowerCase() as `0x${string}`;
+      attestations.set(addr, toBytes(log.args.enclaveReport));
+    }
+
+    // Fallback: if lookback window found nothing, scan from block 0
+    if (attestations.size === 0 && fromBlock > 0n) {
+      return this.getValidatorAttestations({ fromBlock: 0n, round: params?.round });
+    }
+
+    return attestations;
+  }
+
+  /**
    * Get the maximum allowed encrypted data size for vault writes.
    * @example
    * ```ts

--- a/packages/sdk/src/observer.ts
+++ b/packages/sdk/src/observer.ts
@@ -372,8 +372,11 @@ export class Observer {
       attestations.set(addr, toBytes(log.args.enclaveReport));
     }
 
-    // Fallback: if lookback window found nothing, scan from block 0
-    if (attestations.size === 0 && fromBlock > 0n) {
+    // Fallback: if lookback window found nothing and the caller did NOT
+    // explicitly provide fromBlock, scan from block 0. When the caller
+    // passes an explicit fromBlock we respect their intent and do not
+    // silently expand the search scope.
+    if (attestations.size === 0 && !params?.fromBlock && fromBlock > 0n) {
       return this.getValidatorAttestations({ fromBlock: 0n, round: params?.round });
     }
 


### PR DESCRIPTION
## Summary

Implements client-side SGX attestation verification for CDR SDK, replacing the placeholder that threw `Error("not yet implemented")`.

Closes #30

## Changes

### `attestation.ts`
- **`parseSgxQuote(report)`**: Parse SGX DCAP Quote v3 binary to extract MRENCLAVE, MRSIGNER, ISV SVN
- **`verifyAttestation(report, config)`**: Verify extracted fields against user-provided `AttestationConfig`
- Field offsets verified against `SGXValidationHook.sol` in piplabs/story

SGX DCAP Quote v3 layout:
```
Offset 0-47:    Quote Header (48 bytes)
Offset 48-431:  Enclave Report Body (384 bytes)
  Body+64:      MRENCLAVE  (32 bytes) → quote offset 112
  Body+128:     MRSIGNER   (32 bytes) → quote offset 176
  Body+258:     ISV SVN    (2 bytes)  → quote offset 306
Offset 432+:    Auth Data (variable)
```

### `observer.ts`
- **`getValidatorAttestations(params?)`**: New method to fetch `enclaveReport` bytes from DKG `Registered` events, keyed by validator address
- Includes 7-day lookback with fallback to block 0

## Usage

```typescript
import { verifyAttestation } from "@piplabs/cdr-sdk";

// Get attestation reports from chain
const attestations = await cdr.observer.getValidatorAttestations();

// Verify each validator
for (const [addr, report] of attestations) {
  const result = await verifyAttestation(report, {
    expectedMrEnclave: "0x51c08cf3...",
    minSecurityVersion: 1,
  });
  if (!result.valid) console.warn(`${addr}: ${result.error}`);
}
```

## Note

This is client-side field verification only. The cryptographic signature chain (Intel QE → PCK → root CA) is verified on-chain by `SGXValidationHook` via Automata DCAP contracts. This provides defense-in-depth for SDK consumers.

## Test Plan

- [x] Unit test: `parseSgxQuote` with known quote bytes — SEC-08a (mock 432-byte quote, verify exact MRENCLAVE/MRSIGNER/SVN extraction)
- [x] Unit test: `verifyAttestation` with matching/mismatching config — SEC-08b~f (positive), SEC-08g~m (negative: empty, too-short, MRENCLAVE/MRSIGNER/SVN mismatch, short-circuit)
- [x] E2E: `getValidatorAttestations` returns non-empty map on devnet — SEC-08n (3 validators, 4734-byte real SGX quotes), SEC-08o (all share MRENCLAVE `0x032821cf1c...`), SEC-08p (wrong config rejected)

**CI run:** [piplabs/story-cdr-e2e#84](https://github.com/piplabs/story-cdr-e2e/actions/runs/24173152495) — 24/24 passed (16 SEC-08 sub-tests + 8 other security tests)