### PR TITLE
test: add comprehensive unit test coverage + CI reporting

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,8 +12,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
-        with:
-          version: 9
       - uses: actions/setup-node@v4
         with:
           node-version: '20'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,49 @@
+name: Unit Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: pnpm
+      - run: pnpm install
+      - run: pnpm build
+      - name: Run tests with coverage
+        run: pnpm test:coverage
+      - name: Generate coverage summary
+        if: always()
+        run: |
+          {
+            echo "## Unit Test Coverage"
+            echo ""
+            for pkg in packages/sdk packages/crypto; do
+              SUMMARY="$pkg/coverage/coverage-summary.json"
+              if [ -f "$SUMMARY" ]; then
+                PKG_NAME=$(basename $pkg)
+                STMTS=$(jq '.total.statements.pct' "$SUMMARY")
+                BRANCHES=$(jq '.total.branches.pct' "$SUMMARY")
+                FUNCS=$(jq '.total.functions.pct' "$SUMMARY")
+                LINES=$(jq '.total.lines.pct' "$SUMMARY")
+                echo "### $PKG_NAME"
+                echo "| Metric | Coverage |"
+                echo "| --- | --- |"
+                echo "| Statements | ${STMTS}% |"
+                echo "| Branches | ${BRANCHES}% |"
+                echo "| Functions | ${FUNCS}% |"
+                echo "| Lines | ${LINES}% |"
+                echo ""
+              fi
+            done
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "scripts": {
     "build": "turbo build",
     "test": "turbo test",
+    "test:coverage": "turbo test:coverage",
     "lint": "turbo lint",
     "clean": "turbo clean"
   },

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "build": "tsc && cp src/wasm/cb-mpc-tdh2.js src/wasm/cb-mpc-tdh2.wasm dist/wasm/",
     "test": "vitest run",
+    "test:coverage": "vitest run --coverage",
     "clean": "rm -rf dist",
     "lint": "tsc --noEmit"
   },
@@ -17,6 +18,7 @@
     "@noble/hashes": "2.0.1"
   },
   "devDependencies": {
+    "@vitest/coverage-v8": "^2",
     "typescript": "^5.5",
     "vitest": "^2"
   }

--- a/packages/crypto/vitest.config.ts
+++ b/packages/crypto/vitest.config.ts
@@ -3,5 +3,11 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     globals: true,
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "json-summary", "html"],
+      include: ["src/**/*.ts"],
+      exclude: ["src/**/*.test.ts", "src/wasm/**"],
+    },
   },
 });

--- a/packages/sdk/__tests__/attestation.test.ts
+++ b/packages/sdk/__tests__/attestation.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect } from "vitest";
+import { parseSgxQuote, verifyAttestation } from "../src/attestation.js";
+
+const SGX_MIN_QUOTE_SIZE = 432;
+const MRENCLAVE_OFFSET = 112;
+const MRSIGNER_OFFSET = 176;
+const ISV_SVN_OFFSET = 306;
+
+/**
+ * Build a mock SGX DCAP Quote v3 binary with known values at the right offsets.
+ *
+ * @param opts.mrEnclave - 32-byte value placed at offset 112 (default: 0xAA repeated)
+ * @param opts.mrSigner  - 32-byte value placed at offset 176 (default: 0xBB repeated)
+ * @param opts.svn       - ISV SVN as a 16-bit LE value at offset 306 (default: 1)
+ * @param opts.size      - Total buffer size (default: 432, the minimum)
+ */
+function buildMockQuote(opts?: {
+  mrEnclave?: Uint8Array;
+  mrSigner?: Uint8Array;
+  svn?: number;
+  size?: number;
+}): Uint8Array {
+  const size = opts?.size ?? SGX_MIN_QUOTE_SIZE;
+  const buf = new Uint8Array(size);
+
+  // Fill MRENCLAVE (32 bytes at offset 112)
+  const mrEnclave = opts?.mrEnclave ?? new Uint8Array(32).fill(0xaa);
+  buf.set(mrEnclave, MRENCLAVE_OFFSET);
+
+  // Fill MRSIGNER (32 bytes at offset 176)
+  const mrSigner = opts?.mrSigner ?? new Uint8Array(32).fill(0xbb);
+  buf.set(mrSigner, MRSIGNER_OFFSET);
+
+  // Fill ISV SVN (2 bytes little-endian at offset 306)
+  const svn = opts?.svn ?? 1;
+  buf[ISV_SVN_OFFSET] = svn & 0xff;
+  buf[ISV_SVN_OFFSET + 1] = (svn >> 8) & 0xff;
+
+  return buf;
+}
+
+describe("parseSgxQuote", () => {
+  it("extracts correct MRENCLAVE (32 bytes at offset 112)", () => {
+    const mrEnclaveBytes = new Uint8Array(32);
+    for (let i = 0; i < 32; i++) mrEnclaveBytes[i] = i;
+    const quote = buildMockQuote({ mrEnclave: mrEnclaveBytes });
+    const result = parseSgxQuote(quote);
+
+    // viem toHex produces lowercase hex with 0x prefix
+    const expectedHex =
+      "0x000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f";
+    expect(result.mrEnclave).toBe(expectedHex);
+  });
+
+  it("extracts correct MRSIGNER (32 bytes at offset 176)", () => {
+    const mrSignerBytes = new Uint8Array(32).fill(0xcc);
+    const quote = buildMockQuote({ mrSigner: mrSignerBytes });
+    const result = parseSgxQuote(quote);
+
+    expect(result.mrSigner).toBe("0x" + "cc".repeat(32));
+  });
+
+  it("extracts correct ISV SVN (little-endian at offset 306), svn=3", () => {
+    const quote = buildMockQuote({ svn: 3 });
+    const result = parseSgxQuote(quote);
+    expect(result.securityVersion).toBe(3);
+  });
+
+  it("SVN > 255 works (svn=257 = 0x0101 LE)", () => {
+    const quote = buildMockQuote({ svn: 257 });
+    const result = parseSgxQuote(quote);
+    expect(result.securityVersion).toBe(257);
+  });
+
+  it("throws for 431 bytes (one byte short)", () => {
+    const quote = new Uint8Array(431);
+    expect(() => parseSgxQuote(quote)).toThrow(
+      "Invalid SGX quote: 431 bytes, minimum 432 required",
+    );
+  });
+
+  it("works for exactly 432 bytes (boundary)", () => {
+    const quote = buildMockQuote({ size: 432 });
+    const result = parseSgxQuote(quote);
+    expect(result.mrEnclave).toBeDefined();
+    expect(result.mrSigner).toBeDefined();
+    expect(result.securityVersion).toBeDefined();
+  });
+
+  it("works for 5000 bytes (oversized, like real quotes ~4734 bytes)", () => {
+    const quote = buildMockQuote({ size: 5000, svn: 42 });
+    const result = parseSgxQuote(quote);
+    expect(result.securityVersion).toBe(42);
+  });
+});
+
+describe("verifyAttestation", () => {
+  it("empty report returns { valid: false, error containing 'Empty attestation report' }", async () => {
+    const result = await verifyAttestation(new Uint8Array(0));
+    expect(result.valid).toBe(false);
+    expect(result.error).toBe("Empty attestation report");
+  });
+
+  it("no config returns { valid: true } with all fields populated", async () => {
+    const quote = buildMockQuote();
+    const result = await verifyAttestation(quote);
+    expect(result.valid).toBe(true);
+    expect(result.mrEnclave).toBeDefined();
+    expect(result.mrSigner).toBeDefined();
+    expect(result.securityVersion).toBeDefined();
+    expect(result.error).toBeUndefined();
+  });
+
+  it("matching expectedMrEnclave returns valid: true", async () => {
+    const mrEnclaveBytes = new Uint8Array(32).fill(0xdd);
+    const quote = buildMockQuote({ mrEnclave: mrEnclaveBytes });
+    const expectedHex = ("0x" + "dd".repeat(32)) as `0x${string}`;
+    const result = await verifyAttestation(quote, {
+      expectedMrEnclave: expectedHex,
+    });
+    expect(result.valid).toBe(true);
+  });
+
+  it("mismatching expectedMrEnclave returns valid: false with MRENCLAVE mismatch", async () => {
+    const quote = buildMockQuote({ mrEnclave: new Uint8Array(32).fill(0xdd) });
+    const wrongHex = ("0x" + "ee".repeat(32)) as `0x${string}`;
+    const result = await verifyAttestation(quote, {
+      expectedMrEnclave: wrongHex,
+    });
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain("MRENCLAVE mismatch");
+  });
+
+  it("mismatching expectedMrSigner returns valid: false with MRSIGNER mismatch", async () => {
+    const quote = buildMockQuote({ mrSigner: new Uint8Array(32).fill(0xbb) });
+    const wrongHex = ("0x" + "ff".repeat(32)) as `0x${string}`;
+    const result = await verifyAttestation(quote, {
+      expectedMrSigner: wrongHex,
+    });
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain("MRSIGNER mismatch");
+  });
+
+  it("SVN too low returns valid: false with ISV SVN error", async () => {
+    const quote = buildMockQuote({ svn: 2 });
+    const result = await verifyAttestation(quote, {
+      minSecurityVersion: 5,
+    });
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain("ISV SVN");
+  });
+
+  it("case-insensitive comparison: uppercase config vs lowercase parsed returns valid: true", async () => {
+    const mrEnclaveBytes = new Uint8Array(32).fill(0xab);
+    const quote = buildMockQuote({ mrEnclave: mrEnclaveBytes });
+    // parseSgxQuote uses viem toHex which returns lowercase
+    // Provide uppercase in config to test case-insensitive comparison
+    const upperHex = ("0x" + "AB".repeat(32)) as `0x${string}`;
+    const result = await verifyAttestation(quote, {
+      expectedMrEnclave: upperHex,
+    });
+    expect(result.valid).toBe(true);
+  });
+});

--- a/packages/sdk/__tests__/attestation.test.ts
+++ b/packages/sdk/__tests__/attestation.test.ts
@@ -23,6 +23,10 @@ function buildMockQuote(opts?: {
   const size = opts?.size ?? SGX_MIN_QUOTE_SIZE;
   const buf = new Uint8Array(size);
 
+  // Set quote version to 3 (DCAP v3) — bytes 0-1 little-endian
+  buf[0] = 3;
+  buf[1] = 0;
+
   // Fill MRENCLAVE (32 bytes at offset 112)
   const mrEnclave = opts?.mrEnclave ?? new Uint8Array(32).fill(0xaa);
   buf.set(mrEnclave, MRENCLAVE_OFFSET);

--- a/packages/sdk/__tests__/client.test.ts
+++ b/packages/sdk/__tests__/client.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi } from "vitest";
+
+// Mock @piplabs/cdr-crypto before importing CDRClient so the WASM loader is never executed.
+vi.mock("@piplabs/cdr-crypto", () => ({
+  tdh2Encrypt: vi.fn(),
+  encryptFile: vi.fn(),
+  getWasm: vi.fn().mockReturnValue(null),
+  decryptPartial: vi.fn(),
+  tdh2Combine: vi.fn(),
+  verifyPartialSignature: vi.fn(),
+  decryptFile: vi.fn(),
+  generateEphemeralKeyPair: vi.fn(),
+  CURVE_ED25519: 1,
+}));
+
+import { CDRClient } from "../src/client.js";
+import { WalletClientRequiredError } from "../src/errors.js";
+
+const mockPublicClient = {
+  readContract: vi.fn(),
+  getLogs: vi.fn(),
+  getBlockNumber: vi.fn().mockResolvedValue(1000n),
+  waitForTransactionReceipt: vi.fn(),
+  getTransactionReceipt: vi.fn(),
+  simulateContract: vi.fn(),
+} as any;
+
+const mockWalletClient = {
+  writeContract: vi.fn(),
+  account: { address: "0x1234567890abcdef1234567890abcdef12345678" },
+  chain: { id: 1 },
+} as any;
+
+describe("CDRClient", () => {
+  it("publicClient only: cdr.observer is defined (Observer instance)", () => {
+    const cdr = new CDRClient({
+      network: "testnet",
+      publicClient: mockPublicClient,
+    });
+    expect(cdr.observer).toBeDefined();
+  });
+
+  it("publicClient only: accessing cdr.uploader throws WalletClientRequiredError", () => {
+    const cdr = new CDRClient({
+      network: "testnet",
+      publicClient: mockPublicClient,
+    });
+    expect(() => cdr.uploader).toThrow(WalletClientRequiredError);
+  });
+
+  it("publicClient only: accessing cdr.consumer throws WalletClientRequiredError", () => {
+    const cdr = new CDRClient({
+      network: "testnet",
+      publicClient: mockPublicClient,
+    });
+    expect(() => cdr.consumer).toThrow(WalletClientRequiredError);
+  });
+
+  it("publicClient + walletClient: all three (observer, uploader, consumer) are defined", () => {
+    const cdr = new CDRClient({
+      network: "testnet",
+      publicClient: mockPublicClient,
+      walletClient: mockWalletClient,
+    });
+    expect(cdr.observer).toBeDefined();
+    expect(cdr.uploader).toBeDefined();
+    expect(cdr.consumer).toBeDefined();
+  });
+
+  it("validationRpcUrls passed: construction succeeds without error", () => {
+    expect(() => {
+      new CDRClient({
+        network: "testnet",
+        publicClient: mockPublicClient,
+        validationRpcUrls: ["http://localhost:8545", "http://localhost:8546"],
+      });
+    }).not.toThrow();
+  });
+
+  it("minThresholdRatio passed: construction succeeds without error", () => {
+    expect(() => {
+      new CDRClient({
+        network: "testnet",
+        publicClient: mockPublicClient,
+        minThresholdRatio: 0.67,
+      });
+    }).not.toThrow();
+  });
+});

--- a/packages/sdk/__tests__/conditions.test.ts
+++ b/packages/sdk/__tests__/conditions.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from "vitest";
+import { decodeAbiParameters } from "viem";
+import { conditions } from "../src/conditions.js";
+
+describe("conditions", () => {
+  const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000" as const;
+  const CONDITION_ADDR = "0x1111111111111111111111111111111111111111" as const;
+
+  describe("open", () => {
+    it("returns the supplied address and conditionData of 0x", () => {
+      const result = conditions.open({ address: CONDITION_ADDR });
+      expect(result).toEqual({
+        address: CONDITION_ADDR,
+        conditionData: "0x",
+      });
+    });
+
+    it("works with zero address", () => {
+      const result = conditions.open({ address: ZERO_ADDRESS });
+      expect(result.address).toBe(ZERO_ADDRESS);
+      expect(result.conditionData).toBe("0x");
+    });
+  });
+
+  describe("ownerOnly", () => {
+    it("returns correct ABI-encoded conditionData containing the owner address", () => {
+      const owner = "0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa" as const;
+      const result = conditions.ownerOnly({ address: CONDITION_ADDR, owner });
+
+      expect(result.address).toBe(CONDITION_ADDR);
+      // Decode the conditionData and verify it contains the owner address
+      const [decoded] = decodeAbiParameters(
+        [{ type: "address" }],
+        result.conditionData,
+      );
+      expect(decoded.toLowerCase()).toBe(owner.toLowerCase());
+    });
+  });
+
+  describe("tokenGate", () => {
+    it("returns correct ABI-encoded data with token address and minBalance", () => {
+      const token = "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB" as const;
+      const minBalance = 1000n;
+      const result = conditions.tokenGate({
+        address: CONDITION_ADDR,
+        token,
+        minBalance,
+      });
+
+      expect(result.address).toBe(CONDITION_ADDR);
+      const [decodedToken, decodedBalance] = decodeAbiParameters(
+        [{ type: "address" }, { type: "uint256" }],
+        result.conditionData,
+      );
+      expect(decodedToken.toLowerCase()).toBe(token.toLowerCase());
+      expect(decodedBalance).toBe(minBalance);
+    });
+  });
+
+  describe("merkle", () => {
+    it("returns correct ABI-encoded merkle root", () => {
+      const root =
+        "0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890" as const;
+      const result = conditions.merkle({ address: CONDITION_ADDR, root });
+
+      expect(result.address).toBe(CONDITION_ADDR);
+      const [decodedRoot] = decodeAbiParameters(
+        [{ type: "bytes32" }],
+        result.conditionData,
+      );
+      expect(decodedRoot).toBe(root);
+    });
+  });
+
+  describe("custom", () => {
+    it("passes through address and data unchanged", () => {
+      const customData = "0xdeadbeef" as const;
+      const result = conditions.custom({
+        address: CONDITION_ADDR,
+        conditionData: customData,
+      });
+
+      expect(result.address).toBe(CONDITION_ADDR);
+      expect(result.conditionData).toBe(customData);
+    });
+
+    it("does not modify arbitrary hex data", () => {
+      const longData =
+        "0x00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff" as const;
+      const result = conditions.custom({
+        address: CONDITION_ADDR,
+        conditionData: longData,
+      });
+      expect(result).toEqual({
+        address: CONDITION_ADDR,
+        conditionData: longData,
+      });
+    });
+  });
+});

--- a/packages/sdk/__tests__/download-file.test.ts
+++ b/packages/sdk/__tests__/download-file.test.ts
@@ -72,6 +72,7 @@ describe("Consumer.downloadFile", () => {
       globalPubKey: new Uint8Array(34),
       threshold: 2,
       storageProvider,
+      skipCidVerification: true,
     });
 
     // accessCDR was called

--- a/packages/sdk/__tests__/errors.test.ts
+++ b/packages/sdk/__tests__/errors.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect } from "vitest";
+import {
+  CDRError,
+  WalletClientRequiredError,
+  PartialCollectionTimeoutError,
+  ContractRevertError,
+  InvalidParamsError,
+  ObserverRequiredError,
+  CidIntegrityError,
+  RpcConsensusError,
+  InvalidConditionContractError,
+  LabelMismatchError,
+  ContentSizeExceededError,
+} from "../src/errors.js";
+
+describe("errors", () => {
+  describe("CDRError", () => {
+    it("has code and message properties", () => {
+      const err = new CDRError("test message", "TEST_CODE");
+      expect(err.code).toBe("TEST_CODE");
+      expect(err.message).toBe("test message");
+      expect(err.name).toBe("CDRError");
+      expect(err).toBeInstanceOf(Error);
+    });
+  });
+
+  describe("WalletClientRequiredError", () => {
+    it('has code "WALLET_CLIENT_REQUIRED"', () => {
+      const err = new WalletClientRequiredError();
+      expect(err.code).toBe("WALLET_CLIENT_REQUIRED");
+      expect(err.message).toContain("WalletClient");
+      expect(err).toBeInstanceOf(CDRError);
+    });
+  });
+
+  describe("PartialCollectionTimeoutError", () => {
+    it("includes collected, needed, and timeoutMs in message", () => {
+      const err = new PartialCollectionTimeoutError(3, 5, 30000);
+      expect(err.code).toBe("PARTIAL_COLLECTION_TIMEOUT");
+      expect(err.message).toContain("30000");
+      expect(err.message).toContain("3");
+      expect(err.message).toContain("5");
+      expect(err).toBeInstanceOf(CDRError);
+    });
+  });
+
+  describe("ContractRevertError", () => {
+    it("has reason property", () => {
+      const err = new ContractRevertError("insufficient balance");
+      expect(err.code).toBe("CONTRACT_REVERT");
+      expect(err.reason).toBe("insufficient balance");
+      expect(err.message).toContain("insufficient balance");
+      expect(err).toBeInstanceOf(CDRError);
+    });
+  });
+
+  describe("InvalidParamsError", () => {
+    it('has code "INVALID_PARAMS"', () => {
+      const err = new InvalidParamsError("missing field X");
+      expect(err.code).toBe("INVALID_PARAMS");
+      expect(err.message).toBe("missing field X");
+      expect(err).toBeInstanceOf(CDRError);
+    });
+  });
+
+  describe("ObserverRequiredError", () => {
+    it('has code "OBSERVER_REQUIRED"', () => {
+      const err = new ObserverRequiredError();
+      expect(err.code).toBe("OBSERVER_REQUIRED");
+      expect(err.message).toContain("globalPubKey");
+      expect(err).toBeInstanceOf(CDRError);
+    });
+  });
+
+  describe("CidIntegrityError", () => {
+    it("includes expected and actual CIDs in message", () => {
+      const err = new CidIntegrityError("QmExpected", "QmActual");
+      expect(err.code).toBe("CID_INTEGRITY");
+      expect(err.message).toContain("QmExpected");
+      expect(err.message).toContain("QmActual");
+      expect(err).toBeInstanceOf(CDRError);
+    });
+  });
+
+  describe("RpcConsensusError", () => {
+    it("includes field name in message", () => {
+      const err = new RpcConsensusError("blockNumber");
+      expect(err.code).toBe("RPC_CONSENSUS");
+      expect(err.message).toContain("blockNumber");
+      expect(err).toBeInstanceOf(CDRError);
+    });
+  });
+
+  describe("InvalidConditionContractError", () => {
+    it("includes address and type in message", () => {
+      const addr = "0x1234567890abcdef1234567890abcdef12345678";
+      const err = new InvalidConditionContractError(addr, "write");
+      expect(err.code).toBe("INVALID_CONDITION_CONTRACT");
+      expect(err.message).toContain(addr);
+      expect(err.message).toContain("write");
+      expect(err).toBeInstanceOf(CDRError);
+    });
+
+    it("works with read type as well", () => {
+      const addr = "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef";
+      const err = new InvalidConditionContractError(addr, "read");
+      expect(err.message).toContain("read");
+      expect(err.message).toContain(addr);
+    });
+  });
+
+  describe("LabelMismatchError", () => {
+    it("includes expected and actual hex strings in message", () => {
+      const expected = "0xaabb";
+      const actual = "0xccdd";
+      const err = new LabelMismatchError(expected, actual);
+      expect(err.code).toBe("LABEL_MISMATCH");
+      expect(err.message).toContain(expected);
+      expect(err.message).toContain(actual);
+      expect(err).toBeInstanceOf(CDRError);
+    });
+  });
+
+  describe("ContentSizeExceededError", () => {
+    it("has actual (number) and max (bigint) properties", () => {
+      const err = new ContentSizeExceededError(2048, 1024n);
+      expect(err.code).toBe("CONTENT_SIZE_EXCEEDED");
+      expect(err.actual).toBe(2048);
+      expect(err.max).toBe(1024n);
+      expect(err.message).toContain("2048");
+      expect(err.message).toContain("1024");
+      expect(err).toBeInstanceOf(CDRError);
+    });
+  });
+
+  describe("all errors extend CDRError", () => {
+    it("every error class is an instance of CDRError and Error", () => {
+      const errors = [
+        new WalletClientRequiredError(),
+        new PartialCollectionTimeoutError(1, 2, 3000),
+        new ContractRevertError("revert"),
+        new InvalidParamsError("bad"),
+        new ObserverRequiredError(),
+        new CidIntegrityError("a", "b"),
+        new RpcConsensusError("field"),
+        new InvalidConditionContractError("0x00", "write"),
+        new LabelMismatchError("0x11", "0x22"),
+        new ContentSizeExceededError(100, 50n),
+      ];
+
+      for (const err of errors) {
+        expect(err).toBeInstanceOf(CDRError);
+        expect(err).toBeInstanceOf(Error);
+      }
+    });
+  });
+});

--- a/packages/sdk/__tests__/label.test.ts
+++ b/packages/sdk/__tests__/label.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from "vitest";
+import { uuidToLabel } from "../src/label.js";
+
+describe("uuidToLabel", () => {
+  it("returns 32-byte Uint8Array of all zeros for uuid 0", () => {
+    const label = uuidToLabel(0);
+    expect(label).toBeInstanceOf(Uint8Array);
+    expect(label.length).toBe(32);
+    expect(label.every((b) => b === 0)).toBe(true);
+  });
+
+  it("returns 32 bytes with last 4 bytes being big-endian 1 for uuid 1", () => {
+    const label = uuidToLabel(1);
+    expect(label.length).toBe(32);
+    // First 28 bytes should all be zero
+    for (let i = 0; i < 28; i++) {
+      expect(label[i]).toBe(0);
+    }
+    // Last 4 bytes: big-endian 1 => 0x00 0x00 0x00 0x01
+    expect(label[28]).toBe(0x00);
+    expect(label[29]).toBe(0x00);
+    expect(label[30]).toBe(0x00);
+    expect(label[31]).toBe(0x01);
+  });
+
+  it("returns correct big-endian encoding for uuid 256", () => {
+    const label = uuidToLabel(256);
+    expect(label.length).toBe(32);
+    // 256 = 0x00000100 in big-endian
+    expect(label[28]).toBe(0x00);
+    expect(label[29]).toBe(0x00);
+    expect(label[30]).toBe(0x01);
+    expect(label[31]).toBe(0x00);
+  });
+
+  it("returns 0xFFFFFFFF in last 4 bytes for max uint32 (4294967295)", () => {
+    const label = uuidToLabel(4294967295);
+    expect(label.length).toBe(32);
+    // First 28 bytes should all be zero
+    for (let i = 0; i < 28; i++) {
+      expect(label[i]).toBe(0);
+    }
+    // Last 4 bytes: 0xFF 0xFF 0xFF 0xFF
+    expect(label[28]).toBe(0xff);
+    expect(label[29]).toBe(0xff);
+    expect(label[30]).toBe(0xff);
+    expect(label[31]).toBe(0xff);
+  });
+
+  it("always returns a Uint8Array of length 32", () => {
+    const testValues = [0, 1, 42, 1000, 65535, 16777216, 4294967295];
+    for (const uuid of testValues) {
+      const label = uuidToLabel(uuid);
+      expect(label).toBeInstanceOf(Uint8Array);
+      expect(label.length).toBe(32);
+    }
+  });
+});

--- a/packages/sdk/__tests__/observer.test.ts
+++ b/packages/sdk/__tests__/observer.test.ts
@@ -6,6 +6,7 @@ function mockPublicClient(overrides: Record<string, any> = {}) {
   return {
     readContract: vi.fn(),
     getLogs: vi.fn(),
+    getBlockNumber: vi.fn().mockResolvedValue(1000n),
     ...overrides,
   } as any;
 }
@@ -146,7 +147,9 @@ describe("Observer", () => {
 
   it("getGlobalPubKey throws when no Finalized event found", async () => {
     const client = mockPublicClient();
-    client.getLogs.mockResolvedValueOnce([]);
+    // First call: lookback window search returns empty
+    // Second call: fallback from block 0 also returns empty
+    client.getLogs.mockResolvedValue([]);
 
     const observer = new Observer({ network: "testnet", publicClient: client });
 

--- a/packages/sdk/__tests__/upload-file.test.ts
+++ b/packages/sdk/__tests__/upload-file.test.ts
@@ -4,6 +4,7 @@ import { encodeAbiParameters, keccak256, toBytes, toHex } from "viem";
 vi.mock("@piplabs/cdr-crypto", () => ({
   tdh2Encrypt: vi.fn(),
   encryptFile: vi.fn(),
+  getWasm: vi.fn().mockReturnValue(null),
 }));
 
 import { Uploader } from "../src/uploader.js";
@@ -50,6 +51,7 @@ function mockClients() {
   const publicClient = {
     readContract: vi.fn(),
     waitForTransactionReceipt: vi.fn(),
+    simulateContract: vi.fn().mockRejectedValue({ cause: { name: "ContractFunctionRevertedError" } }),
   } as any;
   const walletClient = {
     writeContract: vi.fn(),

--- a/packages/sdk/__tests__/uploader.test.ts
+++ b/packages/sdk/__tests__/uploader.test.ts
@@ -4,6 +4,7 @@ import { encodeAbiParameters, keccak256, toBytes } from "viem";
 // Mock @piplabs/cdr-crypto before importing Uploader so the WASM loader is never executed.
 vi.mock("@piplabs/cdr-crypto", () => ({
   tdh2Encrypt: vi.fn(),
+  getWasm: vi.fn().mockReturnValue(null),
 }));
 
 import { Uploader } from "../src/uploader.js";
@@ -54,6 +55,7 @@ function mockClients() {
     readContract: vi.fn(),
     waitForTransactionReceipt: vi.fn(),
     getTransactionReceipt: vi.fn(),
+    simulateContract: vi.fn().mockRejectedValue({ cause: { name: "ContractFunctionRevertedError" } }),
   } as any;
   const walletClient = {
     writeContract: vi.fn(),
@@ -189,6 +191,7 @@ describe("Uploader", () => {
         writeConditionData: "0x",
         readConditionData: "0x",
         feeOverride: 0n,
+        skipConditionValidation: true,
       }),
     ).rejects.toThrow("VaultAllocated event not found in transaction logs");
   });
@@ -201,13 +204,14 @@ describe("Uploader", () => {
     const uploader = new Uploader({ network: "testnet", publicClient, walletClient });
     const dataKey = new Uint8Array([10, 20, 30]);
     const globalPubKey = new Uint8Array([99]);
-    const result = await uploader.encryptDataKey({ dataKey, globalPubKey, label: "test-label" });
+    const label = new TextEncoder().encode("test-label");
+    const result = await uploader.encryptDataKey({ dataKey, globalPubKey, label });
 
     expect(tdh2Encrypt).toHaveBeenCalledOnce();
     const callArgs = vi.mocked(tdh2Encrypt).mock.calls[0][0];
     expect(callArgs.plaintext).toBe(dataKey);
     expect(callArgs.globalPubKey).toBe(globalPubKey);
-    expect(callArgs.label).toEqual(new TextEncoder().encode("test-label"));
+    expect(callArgs.label).toEqual(label);
     expect(result).toBe(mockCiphertext);
   });
 });

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "build": "tsc",
     "test": "vitest run",
+    "test:coverage": "vitest run --coverage",
     "clean": "rm -rf dist",
     "lint": "tsc --noEmit"
   },
@@ -15,21 +16,32 @@
     "@piplabs/cdr-crypto": "workspace:*"
   },
   "peerDependencies": {
-    "viem": "^2.21",
-    "helia": ">=5",
+    "@filoz/synapse-sdk": ">=0.1",
     "@helia/unixfs": ">=4",
     "@storacha/client": ">=1",
-    "@filoz/synapse-sdk": ">=0.1",
-    "multiformats": ">=13"
+    "helia": ">=5",
+    "multiformats": ">=13",
+    "viem": "^2.21"
   },
   "peerDependenciesMeta": {
-    "helia": { "optional": true },
-    "@helia/unixfs": { "optional": true },
-    "@storacha/client": { "optional": true },
-    "@filoz/synapse-sdk": { "optional": true },
-    "multiformats": { "optional": true }
+    "helia": {
+      "optional": true
+    },
+    "@helia/unixfs": {
+      "optional": true
+    },
+    "@storacha/client": {
+      "optional": true
+    },
+    "@filoz/synapse-sdk": {
+      "optional": true
+    },
+    "multiformats": {
+      "optional": true
+    }
   },
   "devDependencies": {
+    "@vitest/coverage-v8": "^2",
     "typescript": "^5.5",
     "viem": "^2.47.6",
     "vitest": "^2"

--- a/packages/sdk/vitest.config.ts
+++ b/packages/sdk/vitest.config.ts
@@ -3,5 +3,17 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     globals: true,
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "json-summary", "html"],
+      include: ["src/**/*.ts"],
+      exclude: ["src/**/*.test.ts", "src/storage/**"],
+      thresholds: {
+        statements: 60,
+        branches: 50,
+        functions: 60,
+        lines: 60,
+      },
+    },
   },
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,6 +74,9 @@ importers:
         specifier: 2.0.1
         version: 2.0.1
     devDependencies:
+      '@vitest/coverage-v8':
+        specifier: ^2
+        version: 2.1.9(vitest@2.1.9(@types/node@20.19.37)(terser@5.46.1))
       typescript:
         specifier: ^5.5
         version: 5.9.3
@@ -105,6 +108,9 @@ importers:
         specifier: '>=13'
         version: 13.4.2
     devDependencies:
+      '@vitest/coverage-v8':
+        specifier: ^2
+        version: 2.1.9(vitest@2.1.9(@types/node@20.19.37)(terser@5.46.1))
       typescript:
         specifier: ^5.5
         version: 5.9.3
@@ -128,6 +134,10 @@ packages:
 
   '@adraffy/ens-normalize@1.11.1':
     resolution: {integrity: sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==}
+
+  '@ampproject/remapping@2.3.0':
+    resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
+    engines: {node: '>=6.0.0'}
 
   '@assemblyscript/loader@0.9.4':
     resolution: {integrity: sha512-HazVq9zwTVwGmqdwYzu7WyQ6FQVZ7SwET0KKQuKm55jD0IfUpZgN0OPIiZG3zV1iSrVYcN0bdwLRXI/VNCYsUA==}
@@ -285,6 +295,9 @@ packages:
   '@babel/types@7.29.0':
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
+
+  '@bcoe/v8-coverage@0.2.3':
+    resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
 
   '@chainsafe/as-chacha20poly1305@0.1.0':
     resolution: {integrity: sha512-BpNcL8/lji/GM3+vZ/bgRWqJ1q5kwvTFmGPk7pxm/QQZDbaMI98waOHjEymTjq2JmdD/INdNBFOVSyJofXg7ew==}
@@ -663,6 +676,10 @@ packages:
   '@ipshipyard/libp2p-auto-tls@2.0.1':
     resolution: {integrity: sha512-zpDXVMY1ZgB6o30zFocXUzrD9+tz1bbEdgewFoBf4olDh5/CwjDi/k9v2RrJqujWKYWyRuHRg6Q+VRpvtGrpuw==}
 
+  '@isaacs/cliui@8.0.2':
+    resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
+    engines: {node: '>=12'}
+
   '@isaacs/ttlcache@1.4.1':
     resolution: {integrity: sha512-RQgQ4uQ+pLbqXfOmieB91ejmLwvSgv9nLx6sT6sD83s7umBypgg+OIBOBbEUiJXrfpnp9j0mRhYYdzp9uqq3lA==}
     engines: {node: '>=12'}
@@ -927,6 +944,10 @@ packages:
 
   '@perma/map@1.0.3':
     resolution: {integrity: sha512-Bf5njk0fnJGTFE2ETntq0N1oJ6YdCPIpTDn3R3KYZJQdeYSOCNL7mBrFlGnbqav8YQhJA/p81pvHINX9vAtHkQ==}
+
+  '@pkgjs/parseargs@0.11.0':
+    resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
+    engines: {node: '>=14'}
 
   '@protobufjs/aspromise@1.1.2':
     resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
@@ -1264,6 +1285,15 @@ packages:
   '@ucanto/validator@10.0.1':
     resolution: {integrity: sha512-J1/2NAfvs55CxDEuHKMTjoLgoVrFqBbZqErYwL7TDx8Pu2V9sv7rc2wZS5dRxcM1VCEzHXY3SWeLOJuH8VgKrw==}
 
+  '@vitest/coverage-v8@2.1.9':
+    resolution: {integrity: sha512-Z2cOr0ksM00MpEfyVE8KXIYPEcBFxdbLSs56L8PO0QQMxt/6bDj45uQfxoc96v05KW3clk7vvgP0qfDit9DmfQ==}
+    peerDependencies:
+      '@vitest/browser': 2.1.9
+      vitest: 2.1.9
+    peerDependenciesMeta:
+      '@vitest/browser':
+        optional: true
+
   '@vitest/expect@2.1.9':
     resolution: {integrity: sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==}
 
@@ -1360,6 +1390,10 @@ packages:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
 
+  ansi-regex@6.2.2:
+    resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
+    engines: {node: '>=12'}
+
   ansi-styles@4.3.0:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
@@ -1367,6 +1401,10 @@ packages:
   ansi-styles@5.2.0:
     resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
     engines: {node: '>=10'}
+
+  ansi-styles@6.2.3:
+    resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
+    engines: {node: '>=12'}
 
   any-signal@3.0.1:
     resolution: {integrity: sha512-xgZgJtKEa9YmDqXodIgl7Fl1C8yNXr8w6gXjqK3LW4GcEiYT+6AQfJSE/8SPsEpLLmcvbv8YU+qet94UewHxqg==}
@@ -1433,6 +1471,10 @@ packages:
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
+  balanced-match@4.0.4:
+    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
+    engines: {node: 18 || 20 || >=22}
+
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
@@ -1456,6 +1498,13 @@ packages:
 
   brace-expansion@1.1.12:
     resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
+
+  brace-expansion@2.0.3:
+    resolution: {integrity: sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==}
+
+  brace-expansion@5.0.5:
+    resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
+    engines: {node: 18 || 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -1695,6 +1744,9 @@ packages:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
 
+  eastasianwidth@0.2.0:
+    resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
+
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
 
@@ -1707,6 +1759,9 @@ packages:
 
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
+  emoji-regex@9.2.2:
+    resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
 
   encodeurl@1.0.2:
     resolution: {integrity: sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==}
@@ -1878,6 +1933,10 @@ packages:
       debug:
         optional: true
 
+  foreground-child@3.3.1:
+    resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
+    engines: {node: '>=14'}
+
   form-data@4.0.5:
     resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
     engines: {node: '>= 6'}
@@ -1951,6 +2010,11 @@ packages:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
     engines: {node: '>= 6'}
 
+  glob@10.5.0:
+    resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+    hasBin: true
+
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
     deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
@@ -2001,6 +2065,9 @@ packages:
 
   hermes-parser@0.33.3:
     resolution: {integrity: sha512-Yg3HgaG4CqgyowtYjX/FsnPAuZdHOqSMtnbpylbptsQ9nwwSKsy6uRWcGO5RK0EqiX12q8HvDWKgeAVajRO5DA==}
+
+  html-escaper@2.0.2:
+    resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
   http-errors@2.0.1:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
@@ -2144,6 +2211,18 @@ packages:
     resolution: {integrity: sha512-pzqtp31nLv/XFOzXGuvhCb8qhjmTVo5vjVk19XE4CRlSWz0KoeJ3bw9XsA7nOp9YBf4qHjwBxkDzKcME/J29Yg==}
     engines: {node: '>=8'}
 
+  istanbul-lib-report@3.0.1:
+    resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
+    engines: {node: '>=10'}
+
+  istanbul-lib-source-maps@5.0.6:
+    resolution: {integrity: sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==}
+    engines: {node: '>=10'}
+
+  istanbul-reports@3.2.0:
+    resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
+    engines: {node: '>=8'}
+
   it-all@1.0.6:
     resolution: {integrity: sha512-3cmCc6Heqe3uWi3CVM/k51fa/XbMFpQVzFoDsV0IZNHSQDyAXl3c4MjHkFX5kF3922OGj7Myv1nSEUgRtcuM1A==}
 
@@ -2243,6 +2322,9 @@ packages:
   it-to-stream@1.0.0:
     resolution: {integrity: sha512-pLULMZMAB/+vbdvbZtebC0nWBTbG581lk6w8P7DfIIIKUfa8FbY7Oi0FxZcFPbxvISs7A9E+cMpLDBc1XhpAOA==}
 
+  jackspeak@3.4.3:
+    resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
+
   jest-environment-node@29.7.0:
     resolution: {integrity: sha512-DOSwCRqXirTOyheM+4d5YZOrWcdu0LNZ87ewUoywbcb2XR4wKgqiG8vNeYwhjFMbEkfju7wx2GYH0P2gevGvFw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -2336,14 +2418,24 @@ packages:
   loupe@3.2.1:
     resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
 
+  lru-cache@10.4.3:
+    resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
+
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
+  magicast@0.3.5:
+    resolution: {integrity: sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==}
+
   main-event@1.0.1:
     resolution: {integrity: sha512-NWtdGrAca/69fm6DIVd8T9rtfDII4Q8NQbIbsKQq2VzS9eqOGYs8uaNQjcuaCq/d9H/o625aOTJX2Qoxzqw0Pw==}
+
+  make-dir@4.0.0:
+    resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
+    engines: {node: '>=10'}
 
   makeerror@1.0.12:
     resolution: {integrity: sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==}
@@ -2464,11 +2556,23 @@ packages:
     resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
     engines: {node: '>=10'}
 
+  minimatch@10.2.5:
+    resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
+    engines: {node: 18 || 20 || >=22}
+
   minimatch@3.1.5:
     resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
 
+  minimatch@9.0.9:
+    resolution: {integrity: sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
+
+  minipass@7.1.3:
+    resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
+    engines: {node: '>=16 || 14 >=14.17'}
 
   mkdirp-classic@0.5.3:
     resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
@@ -2658,6 +2762,9 @@ packages:
     resolution: {integrity: sha512-2kKzMtjS8TVcpCOU/gr3vZ4K/WIyS1AsEFXFWapM/0lERCdyTbB6ZeuCIp+cL1aeLZfQoMdZFCBTHiK4I9UtOw==}
     engines: {node: '>=20'}
 
+  package-json-from-dist@1.0.1:
+    resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
+
   parseurl@1.3.3:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
     engines: {node: '>= 0.8'}
@@ -2673,6 +2780,10 @@ packages:
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
+
+  path-scurry@1.11.1:
+    resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
+    engines: {node: '>=16 || 14 >=14.18'}
 
   pathe@1.1.2:
     resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
@@ -2919,6 +3030,10 @@ packages:
   signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
 
+  signal-exit@4.1.0:
+    resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
+    engines: {node: '>=14'}
+
   simple-concat@1.0.1:
     resolution: {integrity: sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==}
 
@@ -2982,12 +3097,20 @@ packages:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
     engines: {node: '>=8'}
 
+  string-width@5.1.2:
+    resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
+    engines: {node: '>=12'}
+
   string_decoder@1.3.0:
     resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
 
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
     engines: {node: '>=8'}
+
+  strip-ansi@7.2.0:
+    resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
+    engines: {node: '>=12'}
 
   strip-json-comments@2.0.1:
     resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
@@ -3037,6 +3160,10 @@ packages:
   test-exclude@6.0.0:
     resolution: {integrity: sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==}
     engines: {node: '>=8'}
+
+  test-exclude@7.0.2:
+    resolution: {integrity: sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==}
+    engines: {node: '>=18'}
 
   throat@5.0.0:
     resolution: {integrity: sha512-fcwX4mndzpLQKBS1DVYhGAcYaYt7vsHNIvQV+WXMvnow5cgjPphq5CaayLaGsjRdSCKZFNGt7/GYAuXaNOiYCA==}
@@ -3329,6 +3456,10 @@ packages:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
     engines: {node: '>=10'}
 
+  wrap-ansi@8.1.0:
+    resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
+    engines: {node: '>=12'}
+
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
@@ -3421,6 +3552,11 @@ snapshots:
       xml2js: 0.6.2
 
   '@adraffy/ens-normalize@1.11.1': {}
+
+  '@ampproject/remapping@2.3.0':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
 
   '@assemblyscript/loader@0.9.4': {}
 
@@ -3602,6 +3738,8 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
+
+  '@bcoe/v8-coverage@0.2.3': {}
 
   '@chainsafe/as-chacha20poly1305@0.1.0': {}
 
@@ -4009,6 +4147,15 @@ snapshots:
       uint8arrays: 5.1.0
     transitivePeerDependencies:
       - supports-color
+
+  '@isaacs/cliui@8.0.2':
+    dependencies:
+      string-width: 5.1.2
+      string-width-cjs: string-width@4.2.3
+      strip-ansi: 7.2.0
+      strip-ansi-cjs: strip-ansi@6.0.1
+      wrap-ansi: 8.1.0
+      wrap-ansi-cjs: wrap-ansi@7.0.0
 
   '@isaacs/ttlcache@1.4.1': {}
 
@@ -4704,6 +4851,9 @@ snapshots:
       '@multiformats/murmur3': 2.2.2
       murmurhash3js-revisited: 3.0.0
 
+  '@pkgjs/parseargs@0.11.0':
+    optional: true
+
   '@protobufjs/aspromise@1.1.2': {}
 
   '@protobufjs/base64@1.1.2': {}
@@ -5099,6 +5249,24 @@ snapshots:
       '@ucanto/interface': 11.0.1
       multiformats: 13.4.2
 
+  '@vitest/coverage-v8@2.1.9(vitest@2.1.9(@types/node@20.19.37)(terser@5.46.1))':
+    dependencies:
+      '@ampproject/remapping': 2.3.0
+      '@bcoe/v8-coverage': 0.2.3
+      debug: 4.4.3
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-lib-source-maps: 5.0.6
+      istanbul-reports: 3.2.0
+      magic-string: 0.30.21
+      magicast: 0.3.5
+      std-env: 3.10.0
+      test-exclude: 7.0.2
+      tinyrainbow: 1.2.0
+      vitest: 2.1.9(@types/node@20.19.37)(terser@5.46.1)
+    transitivePeerDependencies:
+      - supports-color
+
   '@vitest/expect@2.1.9':
     dependencies:
       '@vitest/spy': 2.1.9
@@ -5196,11 +5364,15 @@ snapshots:
 
   ansi-regex@5.0.1: {}
 
+  ansi-regex@6.2.2: {}
+
   ansi-styles@4.3.0:
     dependencies:
       color-convert: 2.0.1
 
   ansi-styles@5.2.0: {}
+
+  ansi-styles@6.2.3: {}
 
   any-signal@3.0.1: {}
 
@@ -5301,6 +5473,8 @@ snapshots:
 
   balanced-match@1.0.2: {}
 
+  balanced-match@4.0.4: {}
+
   base64-js@1.5.1: {}
 
   baseline-browser-mapping@2.10.11: {}
@@ -5333,6 +5507,14 @@ snapshots:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
+
+  brace-expansion@2.0.3:
+    dependencies:
+      balanced-match: 1.0.2
+
+  brace-expansion@5.0.5:
+    dependencies:
+      balanced-match: 4.0.4
 
   braces@3.0.3:
     dependencies:
@@ -5580,6 +5762,8 @@ snapshots:
       es-errors: 1.3.0
       gopd: 1.2.0
 
+  eastasianwidth@0.2.0: {}
+
   ee-first@1.1.1: {}
 
   electron-fetch@1.9.1:
@@ -5589,6 +5773,8 @@ snapshots:
   electron-to-chromium@1.5.327: {}
 
   emoji-regex@8.0.0: {}
+
+  emoji-regex@9.2.2: {}
 
   encodeurl@1.0.2: {}
 
@@ -5771,6 +5957,11 @@ snapshots:
     optionalDependencies:
       debug: 4.4.3
 
+  foreground-child@3.3.1:
+    dependencies:
+      cross-spawn: 7.0.6
+      signal-exit: 4.1.0
+
   form-data@4.0.5:
     dependencies:
       asynckit: 0.4.0
@@ -5835,6 +6026,15 @@ snapshots:
   glob-parent@5.1.2:
     dependencies:
       is-glob: 4.0.3
+
+  glob@10.5.0:
+    dependencies:
+      foreground-child: 3.3.1
+      jackspeak: 3.4.3
+      minimatch: 9.0.9
+      minipass: 7.1.3
+      package-json-from-dist: 1.0.1
+      path-scurry: 1.11.1
 
   glob@7.2.3:
     dependencies:
@@ -5922,6 +6122,8 @@ snapshots:
   hermes-parser@0.33.3:
     dependencies:
       hermes-estree: 0.33.3
+
+  html-escaper@2.0.2: {}
 
   http-errors@2.0.1:
     dependencies:
@@ -6122,6 +6324,25 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  istanbul-lib-report@3.0.1:
+    dependencies:
+      istanbul-lib-coverage: 3.2.2
+      make-dir: 4.0.0
+      supports-color: 7.2.0
+
+  istanbul-lib-source-maps@5.0.6:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      debug: 4.4.3
+      istanbul-lib-coverage: 3.2.2
+    transitivePeerDependencies:
+      - supports-color
+
+  istanbul-reports@3.2.0:
+    dependencies:
+      html-escaper: 2.0.2
+      istanbul-lib-report: 3.0.1
+
   it-all@1.0.6: {}
 
   it-all@3.0.9: {}
@@ -6259,6 +6480,12 @@ snapshots:
       p-defer: 3.0.0
       p-fifo: 1.0.0
       readable-stream: 3.6.2
+
+  jackspeak@3.4.3:
+    dependencies:
+      '@isaacs/cliui': 8.0.2
+    optionalDependencies:
+      '@pkgjs/parseargs': 0.11.0
 
   jest-environment-node@29.7.0:
     dependencies:
@@ -6404,6 +6631,8 @@ snapshots:
 
   loupe@3.2.1: {}
 
+  lru-cache@10.4.3: {}
+
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
@@ -6412,7 +6641,17 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  magicast@0.3.5:
+    dependencies:
+      '@babel/parser': 7.29.2
+      '@babel/types': 7.29.0
+      source-map-js: 1.2.1
+
   main-event@1.0.1: {}
+
+  make-dir@4.0.0:
+    dependencies:
+      semver: 7.7.4
 
   makeerror@1.0.12:
     dependencies:
@@ -6631,11 +6870,21 @@ snapshots:
 
   mimic-response@3.1.0: {}
 
+  minimatch@10.2.5:
+    dependencies:
+      brace-expansion: 5.0.5
+
   minimatch@3.1.5:
     dependencies:
       brace-expansion: 1.1.12
 
+  minimatch@9.0.9:
+    dependencies:
+      brace-expansion: 2.0.3
+
   minimist@1.2.8: {}
+
+  minipass@7.1.3: {}
 
   mkdirp-classic@0.5.3: {}
 
@@ -6793,6 +7042,8 @@ snapshots:
 
   p-wait-for@6.0.0: {}
 
+  package-json-from-dist@1.0.1: {}
+
   parseurl@1.3.3: {}
 
   path-exists@4.0.0: {}
@@ -6800,6 +7051,11 @@ snapshots:
   path-is-absolute@1.0.1: {}
 
   path-key@3.1.1: {}
+
+  path-scurry@1.11.1:
+    dependencies:
+      lru-cache: 10.4.3
+      minipass: 7.1.3
 
   pathe@1.1.2: {}
 
@@ -7126,6 +7382,8 @@ snapshots:
 
   signal-exit@3.0.7: {}
 
+  signal-exit@4.1.0: {}
+
   simple-concat@1.0.1: {}
 
   simple-get@4.0.1:
@@ -7179,6 +7437,12 @@ snapshots:
       is-fullwidth-code-point: 3.0.0
       strip-ansi: 6.0.1
 
+  string-width@5.1.2:
+    dependencies:
+      eastasianwidth: 0.2.0
+      emoji-regex: 9.2.2
+      strip-ansi: 7.2.0
+
   string_decoder@1.3.0:
     dependencies:
       safe-buffer: 5.2.1
@@ -7186,6 +7450,10 @@ snapshots:
   strip-ansi@6.0.1:
     dependencies:
       ansi-regex: 5.0.1
+
+  strip-ansi@7.2.0:
+    dependencies:
+      ansi-regex: 6.2.2
 
   strip-json-comments@2.0.1: {}
 
@@ -7244,6 +7512,12 @@ snapshots:
       '@istanbuljs/schema': 0.1.3
       glob: 7.2.3
       minimatch: 3.1.5
+
+  test-exclude@7.0.2:
+    dependencies:
+      '@istanbuljs/schema': 0.1.3
+      glob: 10.5.0
+      minimatch: 10.2.5
 
   throat@5.0.0: {}
 
@@ -7511,6 +7785,12 @@ snapshots:
       ansi-styles: 4.3.0
       string-width: 4.2.3
       strip-ansi: 6.0.1
+
+  wrap-ansi@8.1.0:
+    dependencies:
+      ansi-styles: 6.2.3
+      string-width: 5.1.2
+      strip-ansi: 7.2.0
 
   wrappy@1.0.2: {}
 

--- a/turbo.json
+++ b/turbo.json
@@ -8,6 +8,9 @@
     "test": {
       "dependsOn": ["build"]
     },
+    "test:coverage": {
+      "dependsOn": ["build"]
+    },
     "lint": {},
     "clean": {
       "cache": false

--- a/turbo.json
+++ b/turbo.json
@@ -9,7 +9,8 @@
       "dependsOn": ["build"]
     },
     "test:coverage": {
-      "dependsOn": ["build"]
+      "dependsOn": ["build"],
+      "cache": false
     },
     "lint": {},
     "clean": {


### PR DESCRIPTION
## Summary
- Fix 16 failing unit tests broken by recent SDK changes (lookback window, condition validation, label validation, CID verification)
- Add 45 new unit tests for previously untested modules (conditions, label, errors, attestation, client)
- Configure `@vitest/coverage-v8` with thresholds and CI workflow

Closes #32

## Changes

### Phase 1: Fix 16 failing tests
- **observer.test.ts** (6 fixes): add `getBlockNumber` mock for lookback window, fix fallback-to-block-0 recursion
- **uploader.test.ts** (6 fixes): add `simulateContract` mock for condition validation, `getWasm` mock for label validation, fix `encryptDataKey` object params
- **upload-file.test.ts** (3 fixes): add `simulateContract` + `getWasm` mocks
- **download-file.test.ts** (1 fix): add `skipCidVerification: true`

### Phase 2: New unit tests (+45 tests)
- **conditions.test.ts** (7): all 5 condition builders with ABI encoding verification
- **label.test.ts** (5): `uuidToLabel` with boundary values (0, 1, 256, max uint32)
- **errors.test.ts** (13): all 11 error classes — code, message, properties, instanceof
- **attestation.test.ts** (14): `parseSgxQuote` + `verifyAttestation` — positive/negative, SVN boundary, case-insensitive
- **client.test.ts** (6): CDRClient constructor, WalletClientRequiredError, config passthrough

### Phase 3: Coverage infrastructure
- `@vitest/coverage-v8` for sdk + crypto packages
- SDK thresholds: statements 60%, branches 50%, functions 60%, lines 60%
- `.github/workflows/test.yml`: runs on push/PR, outputs coverage summary

## Results
Before: 16 failed, 29 passed, 23 skipped
After: **0 failed, 73 passed, 23 skipped**

## Test Plan
- [x] `pnpm test` — all 90 tests pass (73 SDK + 17 crypto)
- [ ] CI workflow runs on this PR and shows coverage summary