### PR TITLE
fix: use active round instead of latest Finalized event for DKG state

### DIFF
--- a/packages/sdk/__tests__/observer.test.ts
+++ b/packages/sdk/__tests__/observer.test.ts
@@ -11,7 +11,11 @@ function mockPublicClient(overrides: Record<string, any> = {}) {
   } as any;
 }
 
-function makeFinalizedLog(globalPubKey: `0x${string}`, validator: `0x${string}` = "0x0000000000000000000000000000000000000001") {
+function makeFinalizedLog(
+  globalPubKey: `0x${string}`,
+  validator: `0x${string}` = "0x0000000000000000000000000000000000000001",
+  round: number = 1,
+) {
   const topic0 = keccak256(
     toBytes("Finalized(uint32,address,bytes32,bytes32,bytes32,bytes,bytes[],bytes,bytes)"),
   );
@@ -29,7 +33,7 @@ function makeFinalizedLog(globalPubKey: `0x${string}`, validator: `0x${string}` 
       { name: "signature", type: "bytes" },
     ],
     [
-      1,
+      round,
       "0x0000000000000000000000000000000000000000000000000000000000000000",
       "0x0000000000000000000000000000000000000000000000000000000000000000",
       "0x0000000000000000000000000000000000000000000000000000000000000000",
@@ -164,11 +168,12 @@ describe("Observer", () => {
     const client = mockPublicClient();
     const oldPubKey = "0xaaaa";
     const newPubKey = "0xbbbb";
+    // Two different validators in the same round — both counted
     client.getLogs.mockResolvedValueOnce([
-      makeFinalizedLog(oldPubKey as `0x${string}`),
-      makeFinalizedLog(newPubKey as `0x${string}`),
+      makeFinalizedLog(oldPubKey as `0x${string}`, "0x0000000000000000000000000000000000000001"),
+      makeFinalizedLog(newPubKey as `0x${string}`, "0x0000000000000000000000000000000000000002"),
     ]);
-    // getActiveRound: minReqFinalizedParticipants = 1 (both events are round 1, so 2 >= 1 → active)
+    // getActiveRound: minReqFinalizedParticipants = 1 (2 unique validators >= 1 → active)
     client.readContract.mockResolvedValueOnce(1n);
 
     const observer = new Observer({ network: "testnet", publicClient: client });
@@ -227,5 +232,68 @@ describe("Observer", () => {
     const validators = await observer.getRegisteredValidators();
 
     expect(validators.size).toBe(0);
+  });
+
+  // --- Multi-round tests for getActiveRound (Issue #36) ---
+
+  it("getGlobalPubKey skips failed round and uses active round", async () => {
+    const client = mockPublicClient();
+    const activeKey = "0xaaaa";
+    const failedKey = "0xbbbb";
+    // Round 1: 3 validators (meets threshold) — active round
+    // Round 2: 1 validator (below threshold) — failed round
+    client.getLogs.mockResolvedValueOnce([
+      makeFinalizedLog(activeKey as `0x${string}`, "0x0000000000000000000000000000000000000001", 1),
+      makeFinalizedLog(activeKey as `0x${string}`, "0x0000000000000000000000000000000000000002", 1),
+      makeFinalizedLog(activeKey as `0x${string}`, "0x0000000000000000000000000000000000000003", 1),
+      makeFinalizedLog(failedKey as `0x${string}`, "0x0000000000000000000000000000000000000001", 2),
+    ]);
+    // getActiveRound calls readContract for minReqFinalizedParticipants = 3
+    client.readContract.mockResolvedValueOnce(3n);
+
+    const observer = new Observer({ network: "testnet", publicClient: client });
+    const pubKey = await observer.getGlobalPubKey();
+
+    // Should return round 1's key (active), not round 2's (failed)
+    expect(toHex(pubKey)).toBe(activeKey);
+  });
+
+  it("getParticipantCount returns count from active round, not failed round", async () => {
+    const client = mockPublicClient();
+    // Round 1: 3 validators — active
+    // Round 2: 2 validators — failed (minReq=3)
+    client.getLogs.mockResolvedValueOnce([
+      makeFinalizedLog("0xaa" as `0x${string}`, "0x0000000000000000000000000000000000000001", 1),
+      makeFinalizedLog("0xaa" as `0x${string}`, "0x0000000000000000000000000000000000000002", 1),
+      makeFinalizedLog("0xaa" as `0x${string}`, "0x0000000000000000000000000000000000000003", 1),
+      makeFinalizedLog("0xbb" as `0x${string}`, "0x0000000000000000000000000000000000000001", 2),
+      makeFinalizedLog("0xbb" as `0x${string}`, "0x0000000000000000000000000000000000000002", 2),
+    ]);
+    // minReqFinalizedParticipants = 3
+    client.readContract.mockResolvedValueOnce(3n);
+
+    const observer = new Observer({ network: "testnet", publicClient: client });
+    const count = await observer.getParticipantCount();
+
+    // Should return 3 (round 1), not 2 (round 2)
+    expect(count).toBe(3);
+  });
+
+  it("getActiveRound deduplicates by validatorAddr", async () => {
+    const client = mockPublicClient();
+    // Round 1: same validator emits twice (duplicate/reorg)
+    client.getLogs.mockResolvedValueOnce([
+      makeFinalizedLog("0xcc" as `0x${string}`, "0x0000000000000000000000000000000000000001", 1),
+      makeFinalizedLog("0xcc" as `0x${string}`, "0x0000000000000000000000000000000000000001", 1), // duplicate
+      makeFinalizedLog("0xcc" as `0x${string}`, "0x0000000000000000000000000000000000000002", 1),
+    ]);
+    // minReqFinalizedParticipants = 3 — only 2 unique validators, should NOT meet threshold
+    client.readContract.mockResolvedValueOnce(3n);
+
+    const observer = new Observer({ network: "testnet", publicClient: client });
+    const count = await observer.getParticipantCount();
+
+    // Should be 2 (deduplicated), not 3 (raw count)
+    expect(count).toBe(2);
   });
 });

--- a/packages/sdk/__tests__/observer.test.ts
+++ b/packages/sdk/__tests__/observer.test.ts
@@ -132,12 +132,14 @@ describe("Observer", () => {
     expect(threshold).toBe(3n);
   });
 
-  it("getGlobalPubKey returns globalPubKey from latest Finalized event", async () => {
+  it("getGlobalPubKey returns globalPubKey from active round", async () => {
     const client = mockPublicClient();
     const expectedPubKey = "0xdeadbeefcafebabe";
     client.getLogs.mockResolvedValueOnce([
       makeFinalizedLog(expectedPubKey as `0x${string}`),
     ]);
+    // getActiveRound calls readContract for minReqFinalizedParticipants
+    client.readContract.mockResolvedValueOnce(1n);
 
     const observer = new Observer({ network: "testnet", publicClient: client });
     const pubKey = await observer.getGlobalPubKey();
@@ -158,7 +160,7 @@ describe("Observer", () => {
     );
   });
 
-  it("getGlobalPubKey uses the most recent Finalized event", async () => {
+  it("getGlobalPubKey uses the most recent Finalized event from active round", async () => {
     const client = mockPublicClient();
     const oldPubKey = "0xaaaa";
     const newPubKey = "0xbbbb";
@@ -166,6 +168,8 @@ describe("Observer", () => {
       makeFinalizedLog(oldPubKey as `0x${string}`),
       makeFinalizedLog(newPubKey as `0x${string}`),
     ]);
+    // getActiveRound: minReqFinalizedParticipants = 1 (both events are round 1, so 2 >= 1 → active)
+    client.readContract.mockResolvedValueOnce(1n);
 
     const observer = new Observer({ network: "testnet", publicClient: client });
     const pubKey = await observer.getGlobalPubKey();

--- a/packages/sdk/src/observer.ts
+++ b/packages/sdk/src/observer.ts
@@ -180,6 +180,48 @@ export class Observer {
   }
 
   /**
+   * Find the highest DKG round that has enough finalized participants to be
+   * considered "active". A round is active when its finalized count >=
+   * minReqFinalizedParticipants (on-chain threshold).
+   *
+   * This fixes issue #36: the previous logic used the latest Finalized event
+   * which could be from a failed round (not enough participants).
+   */
+  private async getActiveRound(
+    allEvents: Array<{ args: { round: number; globalPubKey: `0x${string}`; validatorAddr: `0x${string}` } }>,
+  ): Promise<{ round: number; events: typeof allEvents }> {
+    // Get the on-chain minimum finalized participants threshold
+    const minReq = await this.publicClient.readContract({
+      address: contractAddresses[this.network].dkg,
+      abi: dkgAbi,
+      functionName: "minReqFinalizedParticipants",
+    }) as bigint;
+    const minRequired = Number(minReq);
+
+    // Group events by round
+    const byRound = new Map<number, typeof allEvents>();
+    for (const e of allEvents) {
+      const round = e.args.round;
+      if (!byRound.has(round)) byRound.set(round, []);
+      byRound.get(round)!.push(e);
+    }
+
+    // Find the highest round that meets the threshold (descending order)
+    const rounds = [...byRound.keys()].sort((a, b) => b - a);
+    for (const round of rounds) {
+      const events = byRound.get(round)!;
+      if (events.length >= minRequired) {
+        return { round, events };
+      }
+    }
+
+    // Fallback: no round meets threshold — use the highest round available
+    // (this preserves backward compatibility for devnets with relaxed thresholds)
+    const highestRound = rounds[0];
+    return { round: highestRound, events: byRound.get(highestRound)! };
+  }
+
+  /**
    * Get the DKG global public key from the most recent Finalized event.
    * Returns the raw bytes of the globalPubKey (Ed25519 point with curve-code prefix).
    * @example
@@ -190,7 +232,11 @@ export class Observer {
   async getGlobalPubKey(params?: { fromBlock?: bigint }): Promise<Uint8Array> {
     const toBlock = await this.publicClient.getBlockNumber();
     const parsed = await this.getFinalizedEvents({ ...params, toBlock });
-    const latest = parsed[parsed.length - 1];
+
+    // Issue #36: Use the highest round that meets minReqFinalizedParticipants,
+    // not just the latest Finalized event (which could be from a failed round).
+    const { events: activeEvents } = await this.getActiveRound(parsed);
+    const latest = activeEvents[activeEvents.length - 1];
     const rawPoint = toBytes(latest.args.globalPubKey);
 
     // Cross-validate against additional RPCs if configured
@@ -245,8 +291,9 @@ export class Observer {
    */
   async getParticipantCount(params?: { fromBlock?: bigint }): Promise<number> {
     const parsed = await this.getFinalizedEvents(params);
-    const latestRound = parsed[parsed.length - 1].args.round;
-    return parsed.filter((e) => e.args.round === latestRound).length;
+    // Issue #36: Count participants from the active round, not just the latest round.
+    const { events: activeEvents } = await this.getActiveRound(parsed);
+    return activeEvents.length;
   }
 
   /**

--- a/packages/sdk/src/observer.ts
+++ b/packages/sdk/src/observer.ts
@@ -198,12 +198,17 @@ export class Observer {
     }) as bigint;
     const minRequired = Number(minReq);
 
-    // Group events by round
+    // Group events by round, deduplicate by validatorAddr within each round
     const byRound = new Map<number, typeof allEvents>();
     for (const e of allEvents) {
       const round = e.args.round;
       if (!byRound.has(round)) byRound.set(round, []);
-      byRound.get(round)!.push(e);
+      const existing = byRound.get(round)!;
+      // Deduplicate: skip if this validator already has an event in this round
+      const alreadySeen = existing.some(
+        (prev) => prev.args.validatorAddr.toLowerCase() === e.args.validatorAddr.toLowerCase(),
+      );
+      if (!alreadySeen) existing.push(e);
     }
 
     // Find the highest round that meets the threshold (descending order)
@@ -215,9 +220,14 @@ export class Observer {
       }
     }
 
-    // Fallback: no round meets threshold — use the highest round available
-    // (this preserves backward compatibility for devnets with relaxed thresholds)
+    // Fallback: no round meets threshold — warn and use the highest round available.
+    // This preserves backward compatibility for devnets with relaxed thresholds,
+    // but signals that no round is confirmed active.
     const highestRound = rounds[0];
+    console.warn(
+      `[CDR SDK] Warning: no DKG round meets minReqFinalizedParticipants (${minRequired}). ` +
+      `Using highest round ${highestRound} as fallback. Data encrypted with this key may not be recoverable.`,
+    );
     return { round: highestRound, events: byRound.get(highestRound)! };
   }
 
@@ -257,7 +267,10 @@ export class Observer {
           );
           const events = parseEventLogs({ abi: dkgAbi, logs, eventName: "Finalized" });
           if (events.length === 0) return null;
-          return events[events.length - 1].args.globalPubKey;
+          // Use same getActiveRound logic as primary to avoid false-positive
+          // RpcConsensusError when the latest event is from a failed round
+          const { events: activeEvents } = await this.getActiveRound(events);
+          return activeEvents[activeEvents.length - 1].args.globalPubKey;
         }),
       );
 


### PR DESCRIPTION
## Summary
Fixes #36. `getGlobalPubKey()` and `getParticipantCount()` now use the highest DKG round that meets `minReqFinalizedParticipants`, instead of the latest `Finalized` event which could be from a failed round.

## Problem
When a DKG round fails (not enough validators finalize), validators still emit `Finalized` events. The SDK returned the `globalPubKey` from these events, causing:
- Data encrypted with this key **cannot be decrypted** (validators don't hold key shares for failed rounds)
- `getParticipantCount()` returned the count from a failed round

## Fix
New `getActiveRound()` method in `observer.ts`:
1. Groups all `Finalized` events by round number
2. Queries `minReqFinalizedParticipants` from the DKG contract on-chain
3. Returns the **highest round** where `finalizedCount >= minReqFinalizedParticipants`
4. Falls back to highest available round if none meets threshold (backward compat for relaxed devnets)

`getGlobalPubKey()` and `getParticipantCount()` now use `getActiveRound()` instead of taking the last event.

## Test Plan
- [x] Unit tests: 73 passed, 0 failed
- [x] Full integration test suite on DevNet (no regression)
- [x] OBS-08 regression test: encrypt+decrypt roundtrip with the returned globalPubKey