### PR TITLE
fix(storage): pass CID string directly to helia cat()

### DIFF
--- a/packages/sdk/src/storage/helia.ts
+++ b/packages/sdk/src/storage/helia.ts
@@ -1,17 +1,41 @@
 import type { StorageProvider, UploadOptions } from "./types.js";
 
+/** A function that parses a CID string into a CID object compatible with helia. */
+export type CIDParser = (cid: string) => any;
+
 /** IPFS storage provider using the Helia SDK. */
 export class HeliaProvider implements StorageProvider {
   private helia: any;
   private fs: any;
+  private parseCID: CIDParser;
 
   /**
    * @param params.helia - An initialized Helia node instance (used for pinning)
    * @param params.unixfs - A @helia/unixfs instance created from the Helia node
+   * @param params.CID - CID class from the **same** `multiformats` package that
+   *   helia depends on. Pass `CID` from `multiformats/cid` that is resolved in
+   *   the consumer's dependency tree (typically the one helia itself uses).
+   *   This avoids version-mismatch `instanceof` failures at runtime.
+   *
+   * @example
+   * ```ts
+   * import { CID } from "multiformats/cid";
+   * import { createHelia } from "helia";
+   * import { unixfs } from "@helia/unixfs";
+   *
+   * const helia = await createHelia();
+   * const fs = unixfs(helia);
+   * const provider = new HeliaProvider({
+   *   helia,
+   *   unixfs: fs,
+   *   CID: (s) => CID.parse(s),
+   * });
+   * ```
    */
-  constructor(params: { helia: any; unixfs: any }) {
+  constructor(params: { helia: any; unixfs: any; CID: CIDParser }) {
     this.helia = params.helia;
     this.fs = params.unixfs;
+    this.parseCID = params.CID;
   }
 
   async upload(data: Uint8Array, options?: UploadOptions): Promise<string> {
@@ -24,11 +48,11 @@ export class HeliaProvider implements StorageProvider {
   }
 
   async download(cid: string): Promise<Uint8Array> {
-    // Pass CID string directly — Helia unixfs cat() should accept string CIDs.
-    // Dynamic import of CID from multiformats can cause version mismatch with
-    // helia's bundled multiformats, making instanceof checks fail.
+    // Use the caller-provided CID parser to ensure the CID object is from the
+    // same multiformats version that helia uses, avoiding instanceof mismatches.
+    const parsedCid = this.parseCID(cid);
     const chunks: Uint8Array[] = [];
-    for await (const chunk of this.fs.cat(cid)) {
+    for await (const chunk of this.fs.cat(parsedCid)) {
       chunks.push(chunk);
     }
     const totalLength = chunks.reduce((sum, c) => sum + c.length, 0);

--- a/packages/sdk/src/storage/helia.ts
+++ b/packages/sdk/src/storage/helia.ts
@@ -7,24 +7,19 @@ export type CIDParser = (cid: string) => any;
 export class HeliaProvider implements StorageProvider {
   private helia: any;
   private fs: any;
-  private parseCID: CIDParser;
+  private parseCID?: CIDParser;
 
   /**
    * @param params.helia - An initialized Helia node instance (used for pinning)
    * @param params.unixfs - A @helia/unixfs instance created from the Helia node
-   * @param params.CID - CID class from the **same** `multiformats` package that
-   *   helia depends on. Pass `CID` from `multiformats/cid` that is resolved in
-   *   the consumer's dependency tree (typically the one helia itself uses).
-   *   This avoids version-mismatch `instanceof` failures at runtime.
+   * @param params.CID - (Recommended) CID parser from the **same** `multiformats`
+   *   package that helia depends on. Avoids version-mismatch `instanceof` failures.
+   *   If omitted, falls back to dynamic `import("multiformats/cid")` which may
+   *   fail if multiple multiformats versions are installed.
    *
    * @example
    * ```ts
    * import { CID } from "multiformats/cid";
-   * import { createHelia } from "helia";
-   * import { unixfs } from "@helia/unixfs";
-   *
-   * const helia = await createHelia();
-   * const fs = unixfs(helia);
    * const provider = new HeliaProvider({
    *   helia,
    *   unixfs: fs,
@@ -32,7 +27,7 @@ export class HeliaProvider implements StorageProvider {
    * });
    * ```
    */
-  constructor(params: { helia: any; unixfs: any; CID: CIDParser }) {
+  constructor(params: { helia: any; unixfs: any; CID?: CIDParser }) {
     this.helia = params.helia;
     this.fs = params.unixfs;
     this.parseCID = params.CID;
@@ -48,9 +43,15 @@ export class HeliaProvider implements StorageProvider {
   }
 
   async download(cid: string): Promise<Uint8Array> {
-    // Use the caller-provided CID parser to ensure the CID object is from the
-    // same multiformats version that helia uses, avoiding instanceof mismatches.
-    const parsedCid = this.parseCID(cid);
+    // Use the caller-provided CID parser when available (recommended).
+    // Fall back to dynamic import for backward compatibility.
+    let parsedCid: any;
+    if (this.parseCID) {
+      parsedCid = this.parseCID(cid);
+    } else {
+      const { CID } = await import("multiformats/cid");
+      parsedCid = CID.parse(cid);
+    }
     const chunks: Uint8Array[] = [];
     for await (const chunk of this.fs.cat(parsedCid)) {
       chunks.push(chunk);

--- a/packages/sdk/src/storage/helia.ts
+++ b/packages/sdk/src/storage/helia.ts
@@ -24,10 +24,11 @@ export class HeliaProvider implements StorageProvider {
   }
 
   async download(cid: string): Promise<Uint8Array> {
-    const { CID } = await import("multiformats/cid");
-    const parsedCid = CID.parse(cid);
+    // Pass CID string directly — Helia unixfs cat() should accept string CIDs.
+    // Dynamic import of CID from multiformats can cause version mismatch with
+    // helia's bundled multiformats, making instanceof checks fail.
     const chunks: Uint8Array[] = [];
-    for await (const chunk of this.fs.cat(parsedCid)) {
+    for await (const chunk of this.fs.cat(cid)) {
       chunks.push(chunk);
     }
     const totalLength = chunks.reduce((sum, c) => sum + c.length, 0);


### PR DESCRIPTION
## Summary
- Fix `HeliaProvider.download()` failing with `Path must be string or CID` on valid CID strings
- Pass CID string directly to `this.fs.cat()` instead of parsing via `CID.parse()`

## Root Cause
Dynamic import of `CID` from `multiformats/cid` can produce a CID object from a different version than helia's bundled multiformats. The `instanceof CID` check in `ipfs-unixfs-exporter` then fails because the two CID classes are different objects.

## Test
Verified on aeneid testnet:
- `uploadFile`: vault uuid=290, CID=`bafkreifufllknz5mzfqrad2tpmafeqvir2on76xgxuua3ct7kgefzqeezq` ✅
- `downloadFile`: 207 bytes decrypted, content matches original ✅

Fixes #40