### PR TITLE
fix: HeliaProvider CID class mismatch with multiformats

### DIFF
--- a/packages/sdk/src/storage/helia.ts
+++ b/packages/sdk/src/storage/helia.ts
@@ -1,17 +1,35 @@
 import type { StorageProvider, UploadOptions } from "./types.js";
 
-/** IPFS storage provider using the Helia SDK. */
+/**
+ * IPFS storage provider using the Helia SDK.
+ *
+ * @example
+ * ```ts
+ * import { createHelia } from "helia";
+ * import { unixfs } from "@helia/unixfs";
+ * import { CID } from "multiformats/cid";
+ *
+ * const helia = await createHelia();
+ * const fs = unixfs(helia);
+ * const provider = new HeliaProvider({ helia, unixfs: fs, CID });
+ * ```
+ */
 export class HeliaProvider implements StorageProvider {
   private helia: any;
   private fs: any;
+  private cidClass: any;
 
   /**
    * @param params.helia - An initialized Helia node instance (used for pinning)
    * @param params.unixfs - A @helia/unixfs instance created from the Helia node
+   * @param params.CID - The CID class from the same multiformats package used by Helia.
+   *   This avoids CID class mismatch when the SDK and Helia resolve multiformats
+   *   from different locations. If not provided, falls back to dynamic import.
    */
-  constructor(params: { helia: any; unixfs: any }) {
+  constructor(params: { helia: any; unixfs: any; CID?: any }) {
     this.helia = params.helia;
     this.fs = params.unixfs;
+    this.cidClass = params.CID;
   }
 
   async upload(data: Uint8Array, options?: UploadOptions): Promise<string> {
@@ -24,8 +42,15 @@ export class HeliaProvider implements StorageProvider {
   }
 
   async download(cid: string): Promise<Uint8Array> {
-    const { CID } = await import("multiformats/cid");
-    const parsedCid = CID.parse(cid);
+    // Use caller-provided CID class to ensure compatibility with Helia's
+    // internal multiformats version. Falls back to dynamic import if not provided.
+    let CIDClass = this.cidClass;
+    if (!CIDClass) {
+      const mod = await import("multiformats/cid");
+      CIDClass = mod.CID;
+    }
+    const parsedCid = CIDClass.parse(cid);
+
     const chunks: Uint8Array[] = [];
     for await (const chunk of this.fs.cat(parsedCid)) {
       chunks.push(chunk);


### PR DESCRIPTION
## Problem
`HeliaProvider.download()` uses `import("multiformats/cid")` to dynamically import the CID class. In monorepo/CI environments where the SDK and Helia resolve `multiformats` from different paths, this produces a CID object from a different class instance than what Helia's `unixfs.cat()` expects, causing:
- `TypeError: Class constructor CID cannot be invoked without 'new'`
- `InvalidParametersError: Path must be string or CID`

## Fix
Accept an optional `CID` class in the `HeliaProvider` constructor. Users pass the same `CID` class they use with Helia, ensuring compatibility:

```typescript
import { CID } from "multiformats/cid";
const provider = new HeliaProvider({ helia, unixfs: fs, CID });
```

Falls back to dynamic import if `CID` is not provided (backward compatible).

## Test
Verified with file-demo.test.ts on Aeneid testnet using Helia v6 + Node 22.