### PR TITLE
feat: query x/dkg directly via CometBFT abci_query

### DIFF
--- a/packages/sdk/__tests__/observer.test.ts
+++ b/packages/sdk/__tests__/observer.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect, vi } from "vitest";
 import { encodeAbiParameters, keccak256, toBytes, padHex, toHex } from "viem";
 import { Observer } from "../src/observer.js";
+import {
+  encodeLatestActiveResponse,
+  encodeVerifiedRegistrationsResponse,
+} from "../src/cosmos/dkg-proto.js";
 
 function mockPublicClient(overrides: Record<string, any> = {}) {
   return {
@@ -297,81 +301,127 @@ describe("Observer", () => {
     expect(count).toBe(2);
   });
 
-  // --- Cosmos REST API mode (dkgSource: "cosmos-api") ---
+  // --- CometBFT abci_query mode (dkgSource: "cosmos-abci") ---
 
-  describe("cosmos-api mode", () => {
-    function mockFetch(responses: Record<string, unknown>) {
+  describe("cosmos-abci mode", () => {
+    const RPC = "http://localhost:26657";
+
+    function mockAbciFetch(
+      handlers: Array<{
+        match: string;
+        response: Uint8Array;
+      }>,
+    ) {
       return vi.fn(async (url: string) => {
-        for (const [path, body] of Object.entries(responses)) {
-          if (url.includes(path)) {
-            return {
-              ok: true,
-              status: 200,
-              statusText: "OK",
-              json: async () => body,
-              text: async () => JSON.stringify(body),
-            } as Response;
-          }
+        const handler = handlers.find((h) => url.includes(encodeURIComponent(`"${h.match}"`)));
+        if (!handler) {
+          return {
+            ok: false,
+            status: 404,
+            statusText: "Not Found",
+            text: async () => `no mock for ${url}`,
+          } as Response;
         }
+        const valueB64 = Buffer.from(handler.response).toString("base64");
         return {
-          ok: false,
-          status: 404,
-          statusText: "Not Found",
-          text: async () => "not found",
+          ok: true,
+          status: 200,
+          statusText: "OK",
+          json: async () => ({
+            jsonrpc: "2.0",
+            result: {
+              response: { code: 0, log: "", value: valueB64 },
+            },
+          }),
+          text: async () => "",
         } as Response;
       });
     }
 
-    it("getGlobalPubKey fetches from /api/dkg/latest_active", async () => {
+    function encodedLatestActive(n: {
+      round: number;
+      total: number;
+      threshold: number;
+      globalPublicKey: Uint8Array;
+    }): Uint8Array {
+      return encodeLatestActiveResponse({
+        round: n.round,
+        startBlockHeight: 0n,
+        startBlockHash: new Uint8Array(),
+        activeValSet: [],
+        total: n.total,
+        threshold: n.threshold,
+        stage: 0,
+        isResharing: false,
+        globalPublicKey: n.globalPublicKey,
+        publicCoeffs: [],
+        isUpgrade: false,
+      });
+    }
+
+    it("constructor throws when cometRpcUrl is missing", () => {
+      const client = mockPublicClient();
+      expect(
+        () =>
+          new Observer({
+            network: "testnet",
+            publicClient: client,
+            dkgSource: "cosmos-abci",
+          }),
+      ).toThrow(/cometRpcUrl is required/);
+    });
+
+    it("getGlobalPubKey queries GetLatestActiveDKGNetwork via abci_query", async () => {
       const client = mockPublicClient();
       const originalFetch = globalThis.fetch;
-      globalThis.fetch = mockFetch({
-        latest_active: {
-          network: {
+      globalThis.fetch = mockAbciFetch([
+        {
+          match: "/story.dkg.v1.types.Query/GetLatestActiveDKGNetwork",
+          response: encodedLatestActive({
             round: 7,
             total: 3,
             threshold: 2,
-            globalPublicKeyHex: "0x" + "ab".repeat(32),
-          },
+            globalPublicKey: new Uint8Array(32).fill(0xab),
+          }),
         },
-      }) as unknown as typeof fetch;
+      ]) as unknown as typeof fetch;
 
       try {
         const observer = new Observer({
           network: "testnet",
           publicClient: client,
-          dkgSource: "cosmos-api",
-          apiBase: "http://localhost:3000/api/dkg",
+          dkgSource: "cosmos-abci",
+          cometRpcUrl: RPC,
         });
         const pubKey = await observer.getGlobalPubKey();
-        // 2-byte curve prefix + 32-byte point
-        expect(pubKey.length).toBe(34);
+        expect(pubKey.length).toBe(34); // 2-byte curve prefix + 32-byte point
         expect(client.getLogs).not.toHaveBeenCalled();
       } finally {
         globalThis.fetch = originalFetch;
       }
     });
 
-    it("getParticipantCount and getThreshold read from cosmos API", async () => {
+    it("getParticipantCount and getThreshold read from latest_active", async () => {
       const client = mockPublicClient();
       const originalFetch = globalThis.fetch;
-      globalThis.fetch = mockFetch({
-        latest_active: {
-          network: {
+      globalThis.fetch = mockAbciFetch([
+        {
+          match: "/story.dkg.v1.types.Query/GetLatestActiveDKGNetwork",
+          response: encodedLatestActive({
             round: 7,
             total: 5,
             threshold: 3,
-            globalPublicKeyHex: "0x" + "cc".repeat(32),
-          },
+            globalPublicKey: new Uint8Array(32).fill(0xcc),
+          }),
         },
-      }) as unknown as typeof fetch;
+      ]) as unknown as typeof fetch;
 
       try {
         const observer = new Observer({
           network: "testnet",
           publicClient: client,
-          dkgSource: "cosmos-api",
-          apiBase: "http://localhost:3000/api/dkg",
+          dkgSource: "cosmos-abci",
+          cometRpcUrl: RPC,
         });
         expect(await observer.getParticipantCount()).toBe(5);
         expect(await observer.getThreshold()).toBe(3);
@@ -381,65 +431,75 @@ describe("Observer", () => {
       }
     });
 
-    it("minThresholdRatio override applies in cosmos-api mode", async () => {
+    it("minThresholdRatio override applies in cosmos-abci mode", async () => {
       const client = mockPublicClient();
       const originalFetch = globalThis.fetch;
-      globalThis.fetch = mockFetch({
-        latest_active: {
-          network: {
+      globalThis.fetch = mockAbciFetch([
+        {
+          match: "/story.dkg.v1.types.Query/GetLatestActiveDKGNetwork",
+          response: encodedLatestActive({
             round: 1,
             total: 6,
-            threshold: 2, // API says 2, but ceil(6 * 0.67) = 5 takes precedence
-            globalPublicKeyHex: "0x" + "dd".repeat(32),
-          },
+            threshold: 2,
+            globalPublicKey: new Uint8Array(32).fill(0xdd),
+          }),
         },
-      }) as unknown as typeof fetch;
+      ]) as unknown as typeof fetch;
 
       try {
         const observer = new Observer({
           network: "testnet",
           publicClient: client,
-          dkgSource: "cosmos-api",
+          dkgSource: "cosmos-abci",
+          cometRpcUrl: RPC,
           minThresholdRatio: 0.67,
         });
+        // Source says 2; ceil(6 * 0.67) = 5 wins.
         expect(await observer.getThreshold()).toBe(5);
       } finally {
         globalThis.fetch = originalFetch;
       }
     });
 
-    it("getRegisteredValidators fetches from verified_registrations", async () => {
+    it("getRegisteredValidators queries GetAllVerifiedDKGRegistrations", async () => {
       const client = mockPublicClient();
       const originalFetch = globalThis.fetch;
-      globalThis.fetch = mockFetch({
-        latest_active: {
-          network: {
+      const commKey = new Uint8Array(64).fill(0x11);
+      globalThis.fetch = mockAbciFetch([
+        {
+          match: "/story.dkg.v1.types.Query/GetLatestActiveDKGNetwork",
+          response: encodedLatestActive({
             round: 4,
             total: 1,
             threshold: 1,
-            globalPublicKeyHex: "0x" + "ee".repeat(32),
-          },
+            globalPublicKey: new Uint8Array(32).fill(0xee),
+          }),
         },
-        verified_registrations: {
-          registrations: [
+        {
+          match: "/story.dkg.v1.types.Query/GetAllVerifiedDKGRegistrations",
+          response: encodeVerifiedRegistrationsResponse([
             {
               round: 4,
               validatorAddr: "0xAAAAaaaaaaaaaAAAAaaaaaaAaaAaAaAaAAaAAaaA",
               index: 0,
-              commPubKeyHex: "0x" + "11".repeat(64),
-              pubKeyShareHex: "0x",
+              dkgPubKey: new Uint8Array(),
+              commPubKey: commKey,
+              pubKeyShare: new Uint8Array(),
+              enclaveReport: new Uint8Array(),
               status: 1,
-              codeCommitmentHex: "0x",
+              codeCommitment: new Uint8Array(),
+              enclaveType: new Uint8Array(),
             },
-          ],
+          ]),
         },
-      }) as unknown as typeof fetch;
+      ]) as unknown as typeof fetch;
 
       try {
         const observer = new Observer({
           network: "testnet",
           publicClient: client,
-          dkgSource: "cosmos-api",
+          dkgSource: "cosmos-abci",
+          cometRpcUrl: RPC,
         });
         const validators = await observer.getRegisteredValidators();
         expect(validators.size).toBe(1);

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -16,20 +16,23 @@ export class CDRClient {
     walletClient?: WalletClient;
     /**
      * Which backend to use for DKG queries (globalPubKey, participant count,
-     * threshold, registered validators). Defaults to "evm-events" which scans
-     * DKG contract events via the provided publicClient. Use "cosmos-api"
-     * when the demo's /api/dkg routes (backed by CometBFT abci_query) are
-     * reachable — it avoids wide eth_getLogs ranges.
+     * threshold, registered validators, and — in Consumer.collectPartials —
+     * partial decryption submissions). Defaults to `"evm-events"`, which
+     * scans DKG/CDR contract events via the provided publicClient.
+     *
+     * Use `"cosmos-abci"` to query the x/dkg keeper directly via CometBFT
+     * abci_query (port 26657). This avoids wide eth_getLogs ranges and removes
+     * the need for any auxiliary HTTP proxy.
      */
     dkgSource?: DkgSource;
-    /** Override the base path for DKG queries when dkgSource === "cosmos-api" (defaults to "/api/dkg"). */
-    dkgApiBase?: string;
+    /** CometBFT RPC base URL (e.g. `"http://node:26657"`). Required when `dkgSource === "cosmos-abci"`. */
+    cometRpcUrl?: string;
     /** Minimum threshold ratio override (0-1). The effective threshold is max(source threshold, ceil(participants * minThresholdRatio)). */
     minThresholdRatio?: number;
     /** Additional RPC URLs for cross-validating critical on-chain reads (used only in "evm-events" mode). */
     validationRpcUrls?: string[];
   }) {
-    const { network, publicClient, walletClient, dkgApiBase, dkgSource } = params;
+    const { network, publicClient, walletClient, cometRpcUrl, dkgSource } = params;
 
     const validationClients = params.validationRpcUrls?.map(url =>
       createPublicClient({ transport: http(url) }),
@@ -39,7 +42,7 @@ export class CDRClient {
       network,
       publicClient,
       dkgSource,
-      apiBase: dkgApiBase,
+      cometRpcUrl,
       minThresholdRatio: params.minThresholdRatio,
       validationClients,
     });

--- a/packages/sdk/src/consumer.ts
+++ b/packages/sdk/src/consumer.ts
@@ -7,6 +7,8 @@ import { uuidToLabel } from "./label.js";
 import type { StorageProvider } from "./storage/types.js";
 import { Observer } from "./observer.js";
 import type { AttestationConfig } from "./attestation.js";
+import { queryCDRPartials } from "./cosmos/abci-query.js";
+import { bytesToHex as cosmosBytesToHex } from "./cosmos/protobuf.js";
 
 export class Consumer {
   private publicClient: PublicClient;
@@ -125,9 +127,20 @@ export class Consumer {
   }
 
   /**
-   * Poll for EncryptedPartialDecryptionSubmitted events until minPartials are collected.
-   * Filters by uuid to match events for this specific vault read request.
-   * Verifies each partial's TEE signature; invalid partials are skipped.
+   * Collect at least `minPartials` partial decryptions for this vault read.
+   *
+   * In the default evm-events mode: polls `EncryptedPartialDecryptionSubmitted`
+   * events from the CDR contract, filtered by uuid, and verifies each partial's
+   * TEE signature against the validator's registered commPubKey.
+   *
+   * In cosmos-abci mode (when the Observer is configured with
+   * `dkgSource: "cosmos-abci"`): polls the x/dkg keeper's GetCDRPartials
+   * query via CometBFT abci_query. Signature verification is performed by
+   * the keeper on ingress (see story/client/x/dkg/keeper/dkg_handler.go
+   * PartialDecryptionSubmitted), so the SDK trusts the keeper state returned
+   * by the node — the same trust level as any EVM RPC read.
+   * The caller must supply `requesterPubKey` in this mode.
+   *
    * @example
    * ```ts
    * const partials = await consumer.collectPartials({
@@ -144,9 +157,26 @@ export class Consumer {
     fromBlock: bigint;
     timeoutMs?: number;
     pollIntervalMs?: number;
-    /** Called when a partial fails signature verification. If not provided, invalid partials are silently skipped. */
+    /** Required in cosmos-abci mode; ignored in evm-events mode. */
+    requesterPubKey?: `0x${string}`;
+    /** Called when a partial fails signature verification. evm-events mode only. */
     onInvalidPartial?: (event: PartialDecryptionEvent, error: Error) => void;
     /** If provided, verify each validator's attestation report. Invalid attestations trigger onInvalidPartial. */
+    attestationConfig?: AttestationConfig;
+  }): Promise<PartialDecryptionEvent[]> {
+    if (this.observer?.dkgSource === "cosmos-abci") {
+      return this.collectPartialsFromCosmos(params);
+    }
+    return this.collectPartialsFromEvents(params);
+  }
+
+  private async collectPartialsFromEvents(params: {
+    uuid: number;
+    minPartials: number;
+    fromBlock: bigint;
+    timeoutMs?: number;
+    pollIntervalMs?: number;
+    onInvalidPartial?: (event: PartialDecryptionEvent, error: Error) => void;
     attestationConfig?: AttestationConfig;
   }): Promise<PartialDecryptionEvent[]> {
     const { uuid, minPartials, fromBlock, timeoutMs = 60_000, pollIntervalMs = 3_000, onInvalidPartial } = params;
@@ -209,7 +239,7 @@ export class Consumer {
                   encryptedPartial: toBytes(event.encryptedPartial),
                   ephemeralPubKey: toBytes(event.ephemeralPubKey),
                   pubShare: toBytes(event.pubShare),
-                  signature: toBytes(event.signature),
+                  signature: toBytes(log.args.signature),
                   commPubKey: commPubKeys[ki],
                 });
                 if (valid) break;
@@ -234,6 +264,62 @@ export class Consumer {
     }
 
     throw new PartialCollectionTimeoutError(collected.size, minPartials, timeoutMs);
+  }
+
+  private async collectPartialsFromCosmos(params: {
+    uuid: number;
+    minPartials: number;
+    timeoutMs?: number;
+    pollIntervalMs?: number;
+    requesterPubKey?: `0x${string}`;
+  }): Promise<PartialDecryptionEvent[]> {
+    const { uuid, minPartials, timeoutMs = 60_000, pollIntervalMs = 3_000, requesterPubKey } = params;
+    if (!requesterPubKey) {
+      throw new InvalidParamsError(
+        'collectPartials: requesterPubKey is required when observer is configured with dkgSource: "cosmos-abci"',
+      );
+    }
+    const rpcUrl = this.observer?.cometRpcUrl;
+    if (!rpcUrl) {
+      throw new InvalidParamsError(
+        'collectPartials: observer.cometRpcUrl is required when observer is configured with dkgSource: "cosmos-abci"',
+      );
+    }
+    const requesterPubKeyHex = requesterPubKey.replace(/^0x/i, "");
+    const deadline = Date.now() + timeoutMs;
+    let lastCount = 0;
+
+    while (Date.now() < deadline) {
+      const rounds = await queryCDRPartials(rpcUrl, uuid, requesterPubKeyHex);
+
+      // Pick the highest-round bucket with submissions — that's the round
+      // this decrypt request was serviced under.
+      const active = rounds
+        .filter((r) => r.submissions.length > 0)
+        .sort((a, b) => b.round - a.round)[0];
+
+      const subs = active?.submissions ?? [];
+      lastCount = subs.length;
+
+      if (subs.length >= minPartials || (active && active.thresholdMet)) {
+        return subs.slice(0, minPartials).map((s) => {
+          const validatorHex = s.validator.startsWith("0x") ? s.validator : `0x${s.validator}`;
+          return {
+            validator: validatorHex.toLowerCase() as `0x${string}`,
+            round: s.round,
+            pid: s.pid,
+            encryptedPartial: `0x${cosmosBytesToHex(s.encryptedPartial)}` as `0x${string}`,
+            ephemeralPubKey: `0x${cosmosBytesToHex(s.ephemeralPubKey)}` as `0x${string}`,
+            pubShare: `0x${cosmosBytesToHex(s.pubShare)}` as `0x${string}`,
+            uuid,
+          };
+        });
+      }
+
+      await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
+    }
+
+    throw new PartialCollectionTimeoutError(lastCount, minPartials, timeoutMs);
   }
 
   /**
@@ -362,6 +448,7 @@ export class Consumer {
         minPartials: threshold,
         fromBlock,
         timeoutMs: params.timeoutMs,
+        requesterPubKey,
         onInvalidPartial: params.onInvalidPartial,
       });
 

--- a/packages/sdk/src/cosmos/abci-query.ts
+++ b/packages/sdk/src/cosmos/abci-query.ts
@@ -1,0 +1,124 @@
+/**
+ * CometBFT abci_query client for the x/dkg module.
+ *
+ * story nodes expose x/dkg's gRPC query service but don't run a full
+ * gRPC-gateway REST API. CometBFT RPC (port 26657 by default) lets us invoke
+ * any registered gRPC query method by sending a protobuf-encoded request as
+ * the `data` field and decoding the protobuf response.
+ */
+
+import { base64ToBytes } from "./protobuf.js";
+import {
+  type DKGNetwork,
+  type DKGRegistration,
+  type DKGPartialDecryptionSubmissionsByRound,
+  decodeCDRPartialsResponse,
+  decodeLatestActiveResponse,
+  decodeVerifiedRegistrationsResponse,
+  encodeCDRPartialsRequest,
+  encodeLatestActiveRequest,
+  encodeVerifiedRegistrationsRequest,
+} from "./dkg-proto.js";
+
+interface AbciResponse {
+  code: number;
+  log: string;
+  value: string | null;
+}
+
+interface AbciEnvelope {
+  jsonrpc: string;
+  result?: { response: AbciResponse };
+  error?: { code: number; message: string; data?: string };
+}
+
+/**
+ * Send an abci_query to CometBFT and return the raw response value.
+ *
+ * @param rpcUrl  CometBFT RPC base URL, e.g. "http://node:26657"
+ * @param path    Full gRPC method path, e.g. "/story.dkg.v1.types.Query/GetLatestActiveDKGNetwork"
+ * @param data    Protobuf-encoded request bytes (empty for empty messages)
+ */
+export async function abciQuery(
+  rpcUrl: string,
+  path: string,
+  data: Uint8Array,
+): Promise<Uint8Array> {
+  const hex = data.length === 0
+    ? "0x"
+    : "0x" + Array.from(data, (b) => b.toString(16).padStart(2, "0")).join("");
+
+  const base = rpcUrl.replace(/\/+$/, "");
+  const url = `${base}/abci_query?path=${encodeURIComponent(`"${path}"`)}&data=${hex}`;
+
+  const resp = await fetch(url, { headers: { Accept: "application/json" } });
+  if (!resp.ok) {
+    throw new Error(`abci_query HTTP ${resp.status}: ${resp.statusText}`);
+  }
+  const env = (await resp.json()) as AbciEnvelope;
+  if (env.error) {
+    throw new Error(`abci_query RPC error: ${env.error.message}`);
+  }
+  if (!env.result) {
+    throw new Error("abci_query: empty result");
+  }
+  const r = env.result.response;
+  if (r.code !== 0) {
+    throw new Error(`abci_query ${path}: code=${r.code} log=${r.log}`);
+  }
+  if (!r.value) {
+    return new Uint8Array();
+  }
+  return base64ToBytes(r.value);
+}
+
+const SERVICE = "/story.dkg.v1.types.Query";
+
+export async function queryLatestActiveDKGNetwork(
+  rpcUrl: string,
+): Promise<DKGNetwork> {
+  const bytes = await abciQuery(
+    rpcUrl,
+    `${SERVICE}/GetLatestActiveDKGNetwork`,
+    encodeLatestActiveRequest(),
+  );
+  return decodeLatestActiveResponse(bytes);
+}
+
+export async function queryVerifiedRegistrations(
+  rpcUrl: string,
+  round: number,
+  codeCommitmentHex = "",
+): Promise<DKGRegistration[]> {
+  const bytes = await abciQuery(
+    rpcUrl,
+    `${SERVICE}/GetAllVerifiedDKGRegistrations`,
+    encodeVerifiedRegistrationsRequest(round, codeCommitmentHex),
+  );
+  return decodeVerifiedRegistrationsResponse(bytes);
+}
+
+/**
+ * Query all stored partial decryption submissions for a (uuid, requester) pair.
+ *
+ * The keeper returns NotFound when there are no submissions yet; this is
+ * surfaced as an empty array so pollers can simply retry.
+ */
+export async function queryCDRPartials(
+  rpcUrl: string,
+  uuid: number,
+  requesterPubKeyHex: string,
+): Promise<DKGPartialDecryptionSubmissionsByRound[]> {
+  const hex = requesterPubKeyHex.replace(/^0x/i, "");
+  try {
+    const bytes = await abciQuery(
+      rpcUrl,
+      `${SERVICE}/GetCDRPartials`,
+      encodeCDRPartialsRequest(uuid, hex),
+    );
+    return decodeCDRPartialsResponse(bytes);
+  } catch (e) {
+    if (e instanceof Error && /not found/i.test(e.message)) return [];
+    throw e;
+  }
+}

--- a/packages/sdk/src/cosmos/dkg-proto.ts
+++ b/packages/sdk/src/cosmos/dkg-proto.ts
@@ -1,0 +1,369 @@
+/**
+ * Hand-written protobuf codecs for the x/dkg query messages the SDK consumes.
+ *
+ * Schemas mirror story/client/proto/story/dkg/v1/types/{query,types}.proto.
+ * Only fields the SDK reads are decoded; unknown fields are skipped.
+ */
+
+import { Reader, Writer } from "./protobuf.js";
+
+// ---------------------------------------------------------------------------
+// Decoded shapes
+// ---------------------------------------------------------------------------
+
+export interface DKGNetwork {
+  round: number;
+  startBlockHeight: bigint;
+  startBlockHash: Uint8Array;
+  activeValSet: string[];
+  total: number;
+  threshold: number;
+  stage: number;
+  isResharing: boolean;
+  globalPublicKey: Uint8Array;
+  publicCoeffs: Uint8Array[];
+  isUpgrade: boolean;
+}
+
+export interface DKGRegistration {
+  round: number;
+  validatorAddr: string;
+  index: number;
+  dkgPubKey: Uint8Array;
+  commPubKey: Uint8Array;
+  pubKeyShare: Uint8Array;
+  enclaveReport: Uint8Array;
+  status: number;
+  codeCommitment: Uint8Array;
+  enclaveType: Uint8Array;
+}
+
+/**
+ * As stored by the x/dkg keeper. Note: the keeper does NOT persist the
+ * TEE signature or requester_pub_key — those are verified on ingress
+ * (see story/client/x/dkg/keeper/dkg_handler.go:PartialDecryptionSubmitted)
+ * and dropped before storage.
+ */
+export interface DKGPartialDecryptionSubmission {
+  validator: string;
+  round: number;
+  pid: number;
+  encryptedPartial: Uint8Array;
+  ephemeralPubKey: Uint8Array;
+  pubShare: Uint8Array;
+  label: Uint8Array;
+  ciphertext: Uint8Array;
+}
+
+export interface DKGPartialDecryptionSubmissionsByRound {
+  round: number;
+  submissions: DKGPartialDecryptionSubmission[];
+  ciphertext: Uint8Array;
+  threshold: number;
+  thresholdMet: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Decoders
+// ---------------------------------------------------------------------------
+
+export function decodeDKGNetwork(bytes: Uint8Array): DKGNetwork {
+  const r = new Reader(bytes);
+  const out: DKGNetwork = {
+    round: 0,
+    startBlockHeight: 0n,
+    startBlockHash: new Uint8Array(),
+    activeValSet: [],
+    total: 0,
+    threshold: 0,
+    stage: 0,
+    isResharing: false,
+    globalPublicKey: new Uint8Array(),
+    publicCoeffs: [],
+    isUpgrade: false,
+  };
+  while (!r.eof) {
+    const { field, wireType } = r.readTag();
+    switch (field) {
+      case 1: out.round = r.readUint32(); break;
+      case 2: out.startBlockHeight = r.readInt64(); break;
+      case 3: out.startBlockHash = copy(r.readLenDelim()); break;
+      case 4: out.activeValSet.push(r.readString()); break;
+      case 5: out.total = r.readUint32(); break;
+      case 6: out.threshold = r.readUint32(); break;
+      case 7: out.stage = r.readUint32(); break;
+      case 8: out.isResharing = r.readBool(); break;
+      case 9: out.globalPublicKey = copy(r.readLenDelim()); break;
+      case 10: out.publicCoeffs.push(copy(r.readLenDelim())); break;
+      case 11: out.isUpgrade = r.readBool(); break;
+      default: r.skipField(wireType);
+    }
+  }
+  return out;
+}
+
+export function decodeDKGRegistration(bytes: Uint8Array): DKGRegistration {
+  const r = new Reader(bytes);
+  const out: DKGRegistration = {
+    round: 0,
+    validatorAddr: "",
+    index: 0,
+    dkgPubKey: new Uint8Array(),
+    commPubKey: new Uint8Array(),
+    pubKeyShare: new Uint8Array(),
+    enclaveReport: new Uint8Array(),
+    status: 0,
+    codeCommitment: new Uint8Array(),
+    enclaveType: new Uint8Array(),
+  };
+  while (!r.eof) {
+    const { field, wireType } = r.readTag();
+    switch (field) {
+      case 1: out.round = r.readUint32(); break;
+      case 2: out.validatorAddr = r.readString(); break;
+      case 3: out.index = r.readUint32(); break;
+      case 4: out.dkgPubKey = copy(r.readLenDelim()); break;
+      case 5: out.commPubKey = copy(r.readLenDelim()); break;
+      case 6: out.pubKeyShare = copy(r.readLenDelim()); break;
+      case 7: out.enclaveReport = copy(r.readLenDelim()); break;
+      case 8: out.status = r.readUint32(); break;
+      case 9: out.codeCommitment = copy(r.readLenDelim()); break;
+      case 10: out.enclaveType = copy(r.readLenDelim()); break;
+      default: r.skipField(wireType);
+    }
+  }
+  return out;
+}
+
+export function decodePartialDecryptionSubmission(
+  bytes: Uint8Array,
+): DKGPartialDecryptionSubmission {
+  const r = new Reader(bytes);
+  const out: DKGPartialDecryptionSubmission = {
+    validator: "",
+    round: 0,
+    pid: 0,
+    encryptedPartial: new Uint8Array(),
+    ephemeralPubKey: new Uint8Array(),
+    pubShare: new Uint8Array(),
+    label: new Uint8Array(),
+    ciphertext: new Uint8Array(),
+  };
+  while (!r.eof) {
+    const { field, wireType } = r.readTag();
+    switch (field) {
+      case 1: out.validator = r.readString(); break;
+      case 2: out.round = r.readUint32(); break;
+      case 3: out.pid = r.readUint32(); break;
+      case 4: out.encryptedPartial = copy(r.readLenDelim()); break;
+      case 5: out.ephemeralPubKey = copy(r.readLenDelim()); break;
+      case 6: out.pubShare = copy(r.readLenDelim()); break;
+      case 7: out.label = copy(r.readLenDelim()); break;
+      case 8: out.ciphertext = copy(r.readLenDelim()); break;
+      default: r.skipField(wireType);
+    }
+  }
+  return out;
+}
+
+export function decodePartialsByRound(
+  bytes: Uint8Array,
+): DKGPartialDecryptionSubmissionsByRound {
+  const r = new Reader(bytes);
+  const out: DKGPartialDecryptionSubmissionsByRound = {
+    round: 0,
+    submissions: [],
+    ciphertext: new Uint8Array(),
+    threshold: 0,
+    thresholdMet: false,
+  };
+  while (!r.eof) {
+    const { field, wireType } = r.readTag();
+    switch (field) {
+      case 1: out.round = r.readUint32(); break;
+      case 2: out.submissions.push(decodePartialDecryptionSubmission(r.readLenDelim())); break;
+      case 3: out.ciphertext = copy(r.readLenDelim()); break;
+      case 4: out.threshold = r.readUint32(); break;
+      case 5: out.thresholdMet = r.readBool(); break;
+      default: r.skipField(wireType);
+    }
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Response envelope decoders
+// ---------------------------------------------------------------------------
+
+/** QueryGetLatestActiveDKGNetworkResponse { DKGNetwork network = 1; } */
+export function decodeLatestActiveResponse(bytes: Uint8Array): DKGNetwork {
+  const r = new Reader(bytes);
+  let network: DKGNetwork | null = null;
+  while (!r.eof) {
+    const { field, wireType } = r.readTag();
+    if (field === 1 && wireType === 2) {
+      network = decodeDKGNetwork(r.readLenDelim());
+    } else {
+      r.skipField(wireType);
+    }
+  }
+  if (!network) throw new Error("latest_active: missing network field");
+  return network;
+}
+
+/** QueryGetAllVerifiedDKGRegistrationsResponse { repeated DKGRegistration registrations = 1; } */
+export function decodeVerifiedRegistrationsResponse(
+  bytes: Uint8Array,
+): DKGRegistration[] {
+  const r = new Reader(bytes);
+  const out: DKGRegistration[] = [];
+  while (!r.eof) {
+    const { field, wireType } = r.readTag();
+    if (field === 1 && wireType === 2) {
+      out.push(decodeDKGRegistration(r.readLenDelim()));
+    } else {
+      r.skipField(wireType);
+    }
+  }
+  return out;
+}
+
+/** QueryGetCDRPartialsResponse { repeated DKGPartialDecryptionSubmissionsByRound submissions = 1; } */
+export function decodeCDRPartialsResponse(
+  bytes: Uint8Array,
+): DKGPartialDecryptionSubmissionsByRound[] {
+  const r = new Reader(bytes);
+  const out: DKGPartialDecryptionSubmissionsByRound[] = [];
+  while (!r.eof) {
+    const { field, wireType } = r.readTag();
+    if (field === 1 && wireType === 2) {
+      out.push(decodePartialsByRound(r.readLenDelim()));
+    } else {
+      r.skipField(wireType);
+    }
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Request encoders
+// ---------------------------------------------------------------------------
+
+/** QueryGetLatestActiveDKGNetworkRequest (empty) */
+export function encodeLatestActiveRequest(): Uint8Array {
+  return new Uint8Array();
+}
+
+/** QueryGetAllVerifiedDKGRegistrationsRequest { uint32 round = 1; string code_commitment_hex = 2; } */
+export function encodeVerifiedRegistrationsRequest(
+  round: number,
+  codeCommitmentHex: string,
+): Uint8Array {
+  return new Writer()
+    .writeUint32(1, round)
+    .writeString(2, codeCommitmentHex)
+    .finish();
+}
+
+/** QueryGetCDRPartialsRequest { uint32 uuid = 1; string requester_pub_key_hex = 2; } */
+export function encodeCDRPartialsRequest(
+  uuid: number,
+  requesterPubKeyHex: string,
+): Uint8Array {
+  return new Writer()
+    .writeUint32(1, uuid)
+    .writeString(2, requesterPubKeyHex)
+    .finish();
+}
+
+// ---------------------------------------------------------------------------
+// Encoders used only by tests to produce golden response bytes.
+// ---------------------------------------------------------------------------
+
+export function encodeDKGNetwork(n: DKGNetwork): Uint8Array {
+  const w = new Writer()
+    .writeUint32(1, n.round)
+    .writeBytes(3, n.startBlockHash);
+  // startBlockHeight (int64, field 2) — emit only if nonzero
+  if (n.startBlockHeight !== 0n) {
+    w.writeTag(2, 0).writeVarint(n.startBlockHeight);
+  }
+  for (const v of n.activeValSet) w.writeString(4, v);
+  w.writeUint32(5, n.total)
+    .writeUint32(6, n.threshold)
+    .writeUint32(7, n.stage)
+    .writeBool(8, n.isResharing)
+    .writeBytes(9, n.globalPublicKey);
+  for (const pc of n.publicCoeffs) w.writeBytes(10, pc);
+  w.writeBool(11, n.isUpgrade);
+  return w.finish();
+}
+
+export function encodeDKGRegistration(reg: DKGRegistration): Uint8Array {
+  return new Writer()
+    .writeUint32(1, reg.round)
+    .writeString(2, reg.validatorAddr)
+    .writeUint32(3, reg.index)
+    .writeBytes(4, reg.dkgPubKey)
+    .writeBytes(5, reg.commPubKey)
+    .writeBytes(6, reg.pubKeyShare)
+    .writeBytes(7, reg.enclaveReport)
+    .writeUint32(8, reg.status)
+    .writeBytes(9, reg.codeCommitment)
+    .writeBytes(10, reg.enclaveType)
+    .finish();
+}
+
+export function encodePartialDecryptionSubmission(
+  s: DKGPartialDecryptionSubmission,
+): Uint8Array {
+  return new Writer()
+    .writeString(1, s.validator)
+    .writeUint32(2, s.round)
+    .writeUint32(3, s.pid)
+    .writeBytes(4, s.encryptedPartial)
+    .writeBytes(5, s.ephemeralPubKey)
+    .writeBytes(6, s.pubShare)
+    .writeBytes(7, s.label)
+    .writeBytes(8, s.ciphertext)
+    .finish();
+}
+
+export function encodePartialsByRound(
+  p: DKGPartialDecryptionSubmissionsByRound,
+): Uint8Array {
+  const w = new Writer().writeUint32(1, p.round);
+  for (const s of p.submissions) {
+    w.writeMessage(2, encodePartialDecryptionSubmission(s));
+  }
+  w.writeBytes(3, p.ciphertext)
+    .writeUint32(4, p.threshold)
+    .writeBool(5, p.thresholdMet);
+  return w.finish();
+}
+
+export function encodeLatestActiveResponse(n: DKGNetwork): Uint8Array {
+  return new Writer().writeMessage(1, encodeDKGNetwork(n)).finish();
+}
+
+export function encodeVerifiedRegistrationsResponse(
+  regs: DKGRegistration[],
+): Uint8Array {
+  const w = new Writer();
+  for (const reg of regs) w.writeMessage(1, encodeDKGRegistration(reg));
+  return w.finish();
+}
+
+export function encodeCDRPartialsResponse(
+  rounds: DKGPartialDecryptionSubmissionsByRound[],
+): Uint8Array {
+  const w = new Writer();
+  for (const p of rounds) w.writeMessage(1, encodePartialsByRound(p));
+  return w.finish();
+}
+
+// ---------------------------------------------------------------------------
+
+function copy(view: Uint8Array): Uint8Array {
+  return new Uint8Array(view);
+}

--- a/packages/sdk/src/cosmos/protobuf.ts
+++ b/packages/sdk/src/cosmos/protobuf.ts
@@ -1,0 +1,156 @@
+/**
+ * Minimal protobuf wire-format primitives.
+ *
+ * Supports only what the x/dkg query messages need:
+ *   - wire type 0 (varint): uint32, int64, bool, enum
+ *   - wire type 2 (length-delimited): string, bytes, nested messages
+ */
+
+export class Writer {
+  private chunks: number[] = [];
+
+  writeVarint(n: number | bigint): this {
+    let value = typeof n === "bigint" ? n : BigInt(n);
+    if (value < 0n) value += 1n << 64n;
+    while (value >= 0x80n) {
+      this.chunks.push(Number(value & 0x7fn) | 0x80);
+      value >>= 7n;
+    }
+    this.chunks.push(Number(value));
+    return this;
+  }
+
+  writeTag(field: number, wireType: number): this {
+    return this.writeVarint((field << 3) | wireType);
+  }
+
+  writeUint32(field: number, value: number): this {
+    if (value === 0) return this;
+    return this.writeTag(field, 0).writeVarint(value);
+  }
+
+  writeBool(field: number, value: boolean): this {
+    if (!value) return this;
+    return this.writeTag(field, 0).writeVarint(1);
+  }
+
+  writeString(field: number, value: string): this {
+    if (value.length === 0) return this;
+    const bytes = new TextEncoder().encode(value);
+    return this.writeBytes(field, bytes);
+  }
+
+  writeBytes(field: number, value: Uint8Array): this {
+    if (value.length === 0) return this;
+    this.writeTag(field, 2).writeVarint(value.length);
+    for (let i = 0; i < value.length; i++) this.chunks.push(value[i]);
+    return this;
+  }
+
+  writeMessage(field: number, encoded: Uint8Array): this {
+    this.writeTag(field, 2).writeVarint(encoded.length);
+    for (let i = 0; i < encoded.length; i++) this.chunks.push(encoded[i]);
+    return this;
+  }
+
+  finish(): Uint8Array {
+    return Uint8Array.from(this.chunks);
+  }
+}
+
+export class Reader {
+  private offset = 0;
+
+  constructor(private readonly buf: Uint8Array) {}
+
+  get eof(): boolean {
+    return this.offset >= this.buf.length;
+  }
+
+  readVarint(): bigint {
+    let result = 0n;
+    let shift = 0n;
+    while (true) {
+      if (this.offset >= this.buf.length) throw new Error("varint: EOF");
+      const b = this.buf[this.offset++];
+      result |= BigInt(b & 0x7f) << shift;
+      if ((b & 0x80) === 0) return result;
+      shift += 7n;
+      if (shift > 63n) throw new Error("varint: too long");
+    }
+  }
+
+  readUint32(): number {
+    return Number(this.readVarint() & 0xffffffffn);
+  }
+
+  readInt64(): bigint {
+    return BigInt.asIntN(64, this.readVarint());
+  }
+
+  readBool(): boolean {
+    return this.readVarint() !== 0n;
+  }
+
+  readTag(): { field: number; wireType: number } {
+    const tag = Number(this.readVarint());
+    return { field: tag >>> 3, wireType: tag & 0x7 };
+  }
+
+  readLenDelim(): Uint8Array {
+    const len = Number(this.readVarint());
+    if (this.offset + len > this.buf.length) {
+      throw new Error("length-delim: out of bounds");
+    }
+    const out = this.buf.subarray(this.offset, this.offset + len);
+    this.offset += len;
+    return out;
+  }
+
+  readString(): string {
+    return new TextDecoder().decode(this.readLenDelim());
+  }
+
+  skipField(wireType: number): void {
+    switch (wireType) {
+      case 0:
+        this.readVarint();
+        return;
+      case 1:
+        this.offset += 8;
+        return;
+      case 2:
+        this.readLenDelim();
+        return;
+      case 5:
+        this.offset += 4;
+        return;
+      default:
+        throw new Error(`unsupported wire type: ${wireType}`);
+    }
+  }
+}
+
+export function bytesToHex(b: Uint8Array): string {
+  let s = "";
+  for (let i = 0; i < b.length; i++) {
+    s += b[i].toString(16).padStart(2, "0");
+  }
+  return s;
+}
+
+export function base64ToBytes(b64: string): Uint8Array {
+  if (typeof globalThis.atob === "function") {
+    return Uint8Array.from(atob(b64), (c) => c.charCodeAt(0));
+  }
+  return new Uint8Array(Buffer.from(b64, "base64"));
+}
+
+export function bytesToBase64(b: Uint8Array): string {
+  if (typeof globalThis.btoa === "function") {
+    let s = "";
+    for (let i = 0; i < b.length; i++) s += String.fromCharCode(b[i]);
+    return btoa(s);
+  }
+  return Buffer.from(b).toString("base64");
+}

--- a/packages/sdk/src/observer.ts
+++ b/packages/sdk/src/observer.ts
@@ -10,43 +10,22 @@ import { cdrAbi, dkgAbi, contractAddresses, type Network } from "@piplabs/cdr-co
 import { CURVE_ED25519 } from "@piplabs/cdr-crypto";
 import type { Vault } from "./types.js";
 import { RpcConsensusError } from "./errors.js";
+import {
+  queryLatestActiveDKGNetwork,
+  queryVerifiedRegistrations,
+} from "./cosmos/abci-query.js";
+import type { DKGNetwork } from "./cosmos/dkg-proto.js";
 
 /**
  * Which backend to use for DKG queries.
  *
  * - `evm-events`: scan DKG contract Finalized/Registered events via the
  *   provided publicClient. Works against any EVM RPC.
- * - `cosmos-api`: query the demo's Next.js /api/dkg routes, which use
- *   CometBFT abci_query under the hood. Avoids wide eth_getLogs ranges.
+ * - `cosmos-abci`: query the x/dkg keeper directly via CometBFT abci_query
+ *   (port 26657). Avoids wide eth_getLogs ranges and requires only one
+ *   non-EVM endpoint.
  */
-export type DkgSource = "evm-events" | "cosmos-api";
-
-// ---------------------------------------------------------------------------
-// Response shapes from /api/dkg/*
-// ---------------------------------------------------------------------------
-
-interface DKGNetworkJSON {
-  round: number;
-  startBlockHeight: string;
-  activeValSet: string[];
-  total: number;
-  threshold: number;
-  stage: number;
-  isResharing: boolean;
-  globalPublicKeyHex: string;
-  publicCoeffsHex: string[];
-  isUpgrade: boolean;
-}
-
-interface DKGRegistrationJSON {
-  round: number;
-  validatorAddr: string;
-  index: number;
-  commPubKeyHex: string;
-  pubKeyShareHex: string;
-  status: number;
-  codeCommitmentHex: string;
-}
+export type DkgSource = "evm-events" | "cosmos-abci";
 
 // ---------------------------------------------------------------------------
 
@@ -55,10 +34,10 @@ interface DKGRegistrationJSON {
  *
  * DKG state can come from two sources, selected via the `dkgSource` option:
  *   - `evm-events` (default): scans DKG contract events via viem
- *   - `cosmos-api`: queries the Next.js /api/dkg routes (CometBFT abci_query)
+ *   - `cosmos-abci`: queries the x/dkg keeper via CometBFT abci_query
  *
  * CDR reads (vault, fees, maxEncryptedDataSize) and validator attestation
- * reports always come from EVM — the cosmos API does not expose SGX quotes.
+ * reports always come from EVM — the x/dkg keeper does not expose SGX quotes.
  */
 export class Observer {
   /** Many RPCs reject or time out on wide eth_getLogs ranges; chunk to stay under typical caps. */
@@ -69,8 +48,8 @@ export class Observer {
 
   private publicClient: PublicClient;
   private network: Network;
-  private dkgSource: DkgSource;
-  private apiBase: string;
+  readonly dkgSource: DkgSource;
+  readonly cometRpcUrl: string | undefined;
   private minThresholdRatio?: number;
   private validationClients?: PublicClient[];
 
@@ -80,10 +59,10 @@ export class Observer {
     /** DKG query backend. Defaults to `"evm-events"`. */
     dkgSource?: DkgSource;
     /**
-     * Base path for the demo's DKG API routes. Used only when
-     * `dkgSource === "cosmos-api"`. Defaults to "/api/dkg".
+     * CometBFT RPC base URL (e.g. `"http://node:26657"`). Required when
+     * `dkgSource === "cosmos-abci"`.
      */
-    apiBase?: string;
+    cometRpcUrl?: string;
     /** Minimum threshold ratio override (0-1). */
     minThresholdRatio?: number;
     /** Additional RPC clients for cross-validating critical on-chain reads (evm-events mode only). */
@@ -92,9 +71,15 @@ export class Observer {
     this.publicClient = params.publicClient;
     this.network = params.network;
     this.dkgSource = params.dkgSource ?? "evm-events";
-    this.apiBase = params.apiBase ?? "/api/dkg";
+    this.cometRpcUrl = params.cometRpcUrl;
     this.minThresholdRatio = params.minThresholdRatio;
     this.validationClients = params.validationClients;
+
+    if (this.dkgSource === "cosmos-abci" && !this.cometRpcUrl) {
+      throw new Error(
+        'Observer: cometRpcUrl is required when dkgSource is "cosmos-abci"',
+      );
+    }
   }
 
   // =======================================================================
@@ -178,7 +163,7 @@ export class Observer {
    */
   async getGlobalPubKey(params?: { fromBlock?: bigint }): Promise<Uint8Array> {
     const rawPoint =
-      this.dkgSource === "cosmos-api"
+      this.dkgSource === "cosmos-abci"
         ? await this.getGlobalPubKeyFromCosmos()
         : await this.getGlobalPubKeyFromEvents(params);
 
@@ -203,7 +188,7 @@ export class Observer {
    * ```
    */
   async getParticipantCount(params?: { fromBlock?: bigint }): Promise<number> {
-    if (this.dkgSource === "cosmos-api") {
+    if (this.dkgSource === "cosmos-abci") {
       const network = await this.getLatestActiveNetwork();
       return network.total;
     }
@@ -215,14 +200,14 @@ export class Observer {
   /**
    * Get the absolute threshold (minimum number of partial decryptions needed).
    * - In `evm-events` mode: computes `ceil(participants * operationalThreshold / 1000)`.
-   * - In `cosmos-api` mode: reads `threshold` directly from DKG network state.
+   * - In `cosmos-abci` mode: reads `threshold` directly from DKG network state.
    * If `minThresholdRatio` was set, returns `max(sourceThreshold, ceil(participants * minThresholdRatio))`.
    */
   async getThreshold(params?: { fromBlock?: bigint }): Promise<number> {
     let sourceThreshold: number;
     let participantCount: number;
 
-    if (this.dkgSource === "cosmos-api") {
+    if (this.dkgSource === "cosmos-abci") {
       const network = await this.getLatestActiveNetwork();
       sourceThreshold = network.threshold;
       participantCount = network.total;
@@ -250,16 +235,16 @@ export class Observer {
    * validator's TEE to sign partial decryption responses.
    *
    * In `evm-events` mode, reads DKG `Registered` events; `fromBlock` controls
-   * the lookback window and `round` filters events. In `cosmos-api` mode,
-   * queries `/api/dkg/verified_registrations`; `codeCommitmentHex` narrows
-   * the result to a specific enclave code commitment.
+   * the lookback window and `round` filters events. In `cosmos-abci` mode,
+   * queries the x/dkg keeper's GetAllVerifiedDKGRegistrations via abci_query;
+   * `codeCommitmentHex` narrows the result to a specific enclave code commitment.
    */
   async getRegisteredValidators(params?: {
     fromBlock?: bigint;
     round?: number;
     codeCommitmentHex?: string;
   }): Promise<Map<string, Uint8Array>> {
-    if (this.dkgSource === "cosmos-api") {
+    if (this.dkgSource === "cosmos-abci") {
       return this.getRegisteredValidatorsFromCosmos(params);
     }
     return this.getRegisteredValidatorsFromEvents(params);
@@ -277,7 +262,7 @@ export class Observer {
    * before trusting their partial decryptions.
    *
    * Note: sourced from EVM events regardless of `dkgSource`, because the
-   * cosmos /api/dkg endpoint does not expose raw SGX quotes.
+   * x/dkg keeper does not expose raw SGX quotes.
    */
   async getValidatorAttestations(params?: {
     fromBlock?: bigint;
@@ -508,29 +493,25 @@ export class Observer {
   }
 
   // =======================================================================
-  // Private: cosmos REST API implementation
+  // Private: CometBFT abci_query implementation
   // =======================================================================
 
-  private async fetchJSON<T>(path: string): Promise<T> {
-    const url = `${this.apiBase}/${path}`;
-    const resp = await fetch(url, { headers: { Accept: "application/json" } });
-    if (!resp.ok) {
-      const text = await resp.text().catch(() => "");
-      throw new Error(`${url} → HTTP ${resp.status}: ${text || resp.statusText}`);
+  private requireCometRpcUrl(): string {
+    if (!this.cometRpcUrl) {
+      throw new Error(
+        'Observer: cometRpcUrl is required when dkgSource is "cosmos-abci"',
+      );
     }
-    return (await resp.json()) as T;
+    return this.cometRpcUrl;
   }
 
-  private async getLatestActiveNetwork(): Promise<DKGNetworkJSON> {
-    const { network } = await this.fetchJSON<{ network: DKGNetworkJSON }>(
-      "latest_active",
-    );
-    return network;
+  private async getLatestActiveNetwork(): Promise<DKGNetwork> {
+    return queryLatestActiveDKGNetwork(this.requireCometRpcUrl());
   }
 
   private async getGlobalPubKeyFromCosmos(): Promise<Uint8Array> {
     const network = await this.getLatestActiveNetwork();
-    return hexToBytes(network.globalPublicKeyHex);
+    return network.globalPublicKey;
   }
 
   private async getRegisteredValidatorsFromCosmos(params?: {
@@ -543,31 +524,16 @@ export class Observer {
       round = (await this.getLatestActiveNetwork()).round;
     }
 
-    const search = new URLSearchParams({
-      round: String(round),
-      code_commitment_hex: codeCommitmentHex,
-    });
-    const { registrations } = await this.fetchJSON<{
-      registrations: DKGRegistrationJSON[];
-    }>(`verified_registrations?${search.toString()}`);
+    const registrations = await queryVerifiedRegistrations(
+      this.requireCometRpcUrl(),
+      round,
+      codeCommitmentHex,
+    );
 
     const validators = new Map<string, Uint8Array>();
     for (const reg of registrations) {
-      validators.set(reg.validatorAddr.toLowerCase(), hexToBytes(reg.commPubKeyHex));
+      validators.set(reg.validatorAddr.toLowerCase(), reg.commPubKey);
     }
     return validators;
   }
-}
-
-// ---------------------------------------------------------------------------
-
-function hexToBytes(hex: string): Uint8Array {
-  const clean = hex.startsWith("0x") ? hex.slice(2) : hex;
-  if (clean.length === 0) return new Uint8Array();
-  if (clean.length % 2 !== 0) throw new Error(`invalid hex length: ${clean.length}`);
-  const out = new Uint8Array(clean.length / 2);
-  for (let i = 0; i < out.length; i++) {
-    out[i] = parseInt(clean.substring(i * 2, i * 2 + 2), 16);
-  }
-  return out;
 }

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -1,4 +1,13 @@
-/** Parsed EncryptedPartialDecryptionSubmitted event from the CDR contract */
+/**
+ * A collected partial decryption, either from an EVM
+ * EncryptedPartialDecryptionSubmitted event (evm-events mode) or from the
+ * x/dkg keeper via abci_query (cosmos-abci mode).
+ *
+ * `requesterPubKey` and `signature` are present only in evm-events mode.
+ * The keeper does not persist them: signatures are verified on ingress and
+ * dropped (see story/client/x/dkg/keeper/dkg_handler.go PartialDecryptionSubmitted),
+ * and the requester key is the query parameter that scopes the lookup.
+ */
 export interface PartialDecryptionEvent {
   /** Validator address (msg.sender of submitEncryptedPartialDecryption) */
   validator: `0x${string}`;
@@ -12,12 +21,12 @@ export interface PartialDecryptionEvent {
   ephemeralPubKey: `0x${string}`;
   /** Validator's Ed25519 public key share with curve code prefix (34 bytes) */
   pubShare: `0x${string}`;
-  /** Requester's public key */
-  requesterPubKey: `0x${string}`;
   /** Vault UUID */
   uuid: number;
-  /** Signature over the partial decryption payload */
-  signature: `0x${string}`;
+  /** Requester's public key. Populated from EVM events only. */
+  requesterPubKey?: `0x${string}`;
+  /** TEE signature over the partial decryption payload. Populated from EVM events only. */
+  signature?: `0x${string}`;
 }
 
 /** CDR Vault as stored on-chain */


### PR DESCRIPTION
## Summary

- Collapse DKG data fetching onto one non-EVM endpoint: CometBFT RPC on port 26657 via `abci_query`. Removes the need for any auxiliary HTTP proxy layer (the previous `cosmos-api` mode required running a Next.js `/api/dkg/*` server).
- `dkgSource: "cosmos-api"` → `"cosmos-abci"`; `apiBase` → `cometRpcUrl` (required in this mode).
- `Consumer.collectPartials` now fetches partial decryptions through `GetCDRPartials` when in `cosmos-abci` mode, instead of polling EVM `EncryptedPartialDecryptionSubmitted` events. `evm-events` remains the default.

## What changed

**New `packages/sdk/src/cosmos/`**
- `protobuf.ts` — minimal wire-format Reader/Writer + hex/base64 helpers.
- `dkg-proto.ts` — types, decoders, and request encoders for `DKGNetwork`, `DKGRegistration`, `DKGPartialDecryptionSubmission(sByRound)`. Mirrors `story/client/proto/story/dkg/v1/types/{query,types}.proto`. Only fields the SDK reads are decoded; unknown fields are skipped.
- `abci-query.ts` — `abciQuery(rpcUrl, path, data)` + typed wrappers `queryLatestActiveDKGNetwork`, `queryVerifiedRegistrations`, `queryCDRPartials`. `NotFound` from the keeper is surfaced as an empty array so pollers can retry.

**`Observer` (`packages/sdk/src/observer.ts`)**
- `DkgSource` is now `"evm-events" | "cosmos-abci"`. `evm-events` remains the default.
- Replaced `apiBase` with `cometRpcUrl`. Required when `dkgSource === "cosmos-abci"`; the constructor throws otherwise.
- Rewrote `getGlobalPubKeyFromCosmos`, `getRegisteredValidatorsFromCosmos`, and `getLatestActiveNetwork` to call the new typed wrappers. Deleted `fetchJSON`, `DKGNetworkJSON`, `DKGRegistrationJSON`.
- Exposed `dkgSource` and `cometRpcUrl` as readable properties so `Consumer` can route partials collection.

**`Consumer.collectPartials` (`packages/sdk/src/consumer.ts`)**
- Split into `collectPartialsFromEvents` (existing EVM path) and `collectPartialsFromCosmos` (new). The public `collectPartials` dispatches based on `observer.dkgSource`.
- The cosmos-abci path polls `queryCDRPartials(rpcUrl, uuid, requesterPubKeyHex)`, picks the highest-round bucket with submissions (the round the current decrypt request was serviced under), and returns as soon as `submissions.length >= minPartials` or the keeper reports `thresholdMet`.
- Added `requesterPubKey` to `collectPartials` params — required in cosmos-abci mode, ignored in evm-events mode. Threaded through from `accessCDR`.
- **No SDK-side signature verification in cosmos-abci mode.** The x/dkg keeper runs six checks on ingress before persisting a submission (`story/client/x/dkg/keeper/dkg_handler.go` `PartialDecryptionSubmitted`, lines 514–600): decrypt-request lookup, round match, ciphertext match, timeout, `pubShare == reg.PubKeyShare`, and `verifyPartialDecryptionSignature` using the same RLP-encoded keccak256 payload and commPubKey the SDK uses in evm-events mode. The signature is not persisted; the proto has no `signature` field. Net: the SDK trusts the CometBFT node's keeper state, which is the same trust level already placed in the EVM RPC for contract reads.

**`CDRClient` (`packages/sdk/src/client.ts`)**
- Swapped `dkgApiBase` → `cometRpcUrl`, threaded into `Observer`.

**`PartialDecryptionEvent` (`packages/sdk/src/types.ts`)**
- `signature` and `requesterPubKey` are now optional. Populated in evm-events mode, omitted in cosmos-abci mode. `decryptDataKey` reads neither field, so downstream code is unaffected.

**Tests**
- Rewrote the `cosmos-api mode` block in `observer.test.ts` to mock a real `abci_query` JSON-RPC envelope (`{result: {response: {code: 0, value: base64(protobufBytes)}}}`) with protobuf-encoded responses. This exercises the new decoder end-to-end, not just the HTTP transport.
- Added a test that the `Observer` constructor throws when `dkgSource: "cosmos-abci"` is passed without `cometRpcUrl`.

## Breaking changes

- `DkgSource` value `"cosmos-api"` is gone — use `"cosmos-abci"`.
- `Observer`/`CDRClient` config: `apiBase`/`dkgApiBase` removed — use `cometRpcUrl` (full CometBFT RPC base URL, e.g. `"http://node:26657"`).
- `cometRpcUrl` is **required** when `dkgSource === "cosmos-abci"`.

## Trust model note

In `cosmos-abci` mode the SDK does not cryptographically re-verify partial decryption signatures. The x/dkg keeper verifies them on ingress and drops them before storage, so a forgery would require a dishonest CometBFT node serving non-consensus state — the same threat model as a dishonest EVM RPC serving fabricated `eth_call` results. If you need stronger assurance (e.g. when querying an untrusted node), future work could use CometBFT `abci_query ?prove=true` with IAVL proof verification against a trusted header.