### PR TITLE
docs: update README and docs for 0.1.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,18 +4,32 @@ All notable changes to this project will be documented in this file.
 
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.1.0] - 2025-01-XX
+## [0.1.0] - 2026-04-10
 
 Initial release.
 
 ### Added
 
 - `CDRClient` with `observer`, `uploader`, and `consumer` sub-clients
-- `Observer` for read-only queries: vault info, DKG state, fee queries
-- `Uploader` with `uploadCDR()` high-level method (allocate + encrypt + write)
-- `Consumer` with `accessCDR()` high-level method (read + collect partials + decrypt)
-- `@piplabs/cdr-contracts` package with CDR and DKG ABIs and addresses
-- `@piplabs/cdr-crypto` package with TDH2 (WASM) and ECIES implementations
-- Testnet and mainnet network support
+- `Observer` for read-only queries: vault info, DKG state, fee queries, validator registrations, attestations
+- `Uploader` with `uploadCDR()` (allocate + encrypt + write) and `uploadFile()` (AES-encrypt file + store off-chain + protect key on-chain)
+- `Consumer` with `accessCDR()` (read + collect partials + decrypt) and `downloadFile()` (access vault + download + decrypt file)
+- `createVault` / `readVault` / `createFileVault` / `readFileVault` method aliases for backward compatibility
+- Dual DKG query mode: `evm-events` (default, scans EVM logs) and `cosmos-abci` (direct CometBFT abci_query, 6–20x faster) (#43, #45)
+- Condition helpers: `conditions.open()`, `ownerOnly()`, `tokenGate()`, `merkle()`, `custom()` (#28)
+- SGX attestation verification: `verifyAttestation()` and `parseSgxQuote()` with MRENCLAVE, MRSIGNER, ISV SVN checks (#31)
+- Storage providers: `HeliaProvider` (in-process IPFS), `GatewayProvider` (IPFS HTTP API + gateway), `StorachaProvider` (web3.storage), `SynapseProvider` (Filecoin via Synapse SDK)
+- Validation RPC: `validationRpcUrls` for cross-node `globalPubKey` verification (throws `RpcConsensusError` on mismatch)
+- `@piplabs/cdr-contracts` package with CDR and DKG ABIs and predeploy addresses
+- `@piplabs/cdr-crypto` package with TDH2 (WASM), ECIES, file encryption, and signature verification
+- Testnet (Aeneid, chain ID 1315) and mainnet (chain ID 1514) network support
 - CLI tool (`@piplabs/cdr-cli`) for command-line vault operations
 - Example scripts for upload, access, query, and end-to-end flows
+
+### Fixed
+
+- Observer uses `getActiveRound()` instead of latest Finalized event to determine active DKG round (#38)
+- HeliaProvider accepts caller-provided CID parser to avoid `multiformats` version mismatch (#41)
+- Synapse storage connection handling (#44)
+- Validation clients also use `getActiveRound()` to prevent false-positive `RpcConsensusError` (#38)
+- Deduplicate validators by address in `getActiveRound()` to prevent double-counting (#38)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.1.0] - 2026-04-10
+## [0.1.1] - 2026-04-10
 
 Initial release.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CDR SDK
 
-TypeScript SDK for **Confidential Data Recovery (CDR)** on Story L1. Encrypt data to a threshold DKG public key, store it in on-chain vaults, and recover it when a quorum of validators provide partial decryptions.
+TypeScript SDK for **Confidential Data Rails (CDR)** on Story L1. Encrypt data to a threshold DKG public key, store it in on-chain vaults, and recover it when a quorum of validators provide partial decryptions.
 
 ## Installation
 
@@ -15,7 +15,7 @@ import { createPublicClient, createWalletClient, http } from "viem";
 import { privateKeyToAccount } from "viem/accounts";
 import { CDRClient, initWasm } from "@piplabs/cdr-sdk";
 
-await initWasm();
+await initWasm(); // Required before any encryption
 
 const account = privateKeyToAccount("0xYOUR_PRIVATE_KEY");
 const publicClient = createPublicClient({ transport: http("https://aeneid.storyrpc.io") });
@@ -38,8 +38,24 @@ const { uuid } = await client.uploader.uploadCDR({
   accessAuxData: "0x",
 });
 
-console.log("Vault UUID:", uuid);
+// Access and decrypt
+const { dataKey: recovered } = await client.consumer.accessCDR({
+  uuid,
+  accessAuxData: "0x",
+  timeoutMs: 120_000,
+});
 ```
+
+## Features
+
+- **Data key vaults**: `uploadCDR` / `accessCDR` — encrypt and store small data (keys, secrets) directly on-chain
+- **File encryption**: `uploadFile` / `downloadFile` — AES-encrypt large files, store off-chain (IPFS/Filecoin), protect the key on-chain
+- **DKG Observer**: query global public key, threshold, participant count, validators, attestations, fees
+- **Dual DKG query mode**: `evm-events` (default) and `cosmos-abci` (6–20x faster via CometBFT RPC)
+- **Condition helpers**: `conditions.open()`, `ownerOnly()`, `tokenGate()`, `merkle()`, `custom()`
+- **SGX attestation verification**: `verifyAttestation()` with MRENCLAVE/MRSIGNER/SVN checks
+- **Storage providers**: `HeliaProvider` (IPFS), `GatewayProvider`, `StorachaProvider`, `SynapseProvider`
+- **Validation RPC**: cross-node `globalPubKey` verification via `validationRpcUrls`
 
 ## Networks
 
@@ -48,14 +64,77 @@ console.log("Vault UUID:", uuid);
 | Testnet  | `"testnet"`     | `https://aeneid.storyrpc.io`    |
 | Mainnet  | `"mainnet"`     | `https://rpc.story.foundation`   |
 
-Point to any Story-compatible RPC (devnets, local nodes) by changing the `http()` transport URL:
-
-```typescript
-const publicClient = createPublicClient({ transport: http("http://localhost:8545") });
-const client = new CDRClient({ network: "testnet", publicClient });
-```
+Point to any Story-compatible RPC (devnets, local nodes) by changing the `http()` transport URL.
 
 See the [User Guide](./USER_GUIDE.md) for full network configuration details.
+
+## DKG Query Modes
+
+The SDK supports two backends for querying DKG state:
+
+| Mode | How | Speed |
+|------|-----|-------|
+| `evm-events` (default) | Scans DKG contract events via `eth_getLogs` | Baseline |
+| `cosmos-abci` | Queries x/dkg keeper via CometBFT `abci_query` | 6–20x faster |
+
+```typescript
+// Use cosmos-abci mode for faster queries
+const client = new CDRClient({
+  network: "testnet",
+  publicClient,
+  walletClient,
+  dkgSource: "cosmos-abci",
+  cometRpcUrl: "http://your-node:26657",
+});
+```
+
+## File Operations
+
+Encrypt large files and store them off-chain with on-chain key protection:
+
+```typescript
+import { HeliaProvider } from "@piplabs/cdr-sdk";
+import { createHelia } from "helia";
+import { unixfs } from "@helia/unixfs";
+import { CID } from "multiformats/cid";
+
+const helia = await createHelia();
+const storage = new HeliaProvider({
+  helia, unixfs: unixfs(helia),
+  CID: (s) => CID.parse(s),
+});
+
+// Upload
+const { uuid, cid } = await client.uploader.uploadFile({
+  content: new TextEncoder().encode("Hello, CDR!"),
+  storageProvider: storage,
+  globalPubKey,
+  updatable: false,
+  writeConditionAddr: "0x...", readConditionAddr: "0x...",
+  writeConditionData: "0x", readConditionData: "0x",
+  accessAuxData: "0x",
+});
+
+// Download
+const { content } = await client.consumer.downloadFile({
+  uuid, accessAuxData: "0x",
+  storageProvider: storage,
+  timeoutMs: 120_000,
+});
+```
+
+Other storage providers: `GatewayProvider` (IPFS HTTP API), `StorachaProvider` (web3.storage), `SynapseProvider` (Filecoin).
+
+## Condition Contracts (Aeneid)
+
+Two condition contracts are deployed on Aeneid testnet:
+
+| Contract | Address | Description |
+|----------|---------|-------------|
+| OwnerWriteCondition | `0x4C9bFC96d7092b590D497A191826C3dA2277c34B` | Only the encoded address can write |
+| LicenseReadCondition | `0xC0640AD4CF2CaA9914C8e5C44234359a9102f7a3` | Only Story Protocol license holders can read |
+
+See [Condition Contracts](./docs/CONDITIONS.md) for the interface spec, more examples, and usage details.
 
 ## Packages
 
@@ -100,7 +179,7 @@ CDR_PRIVATE_KEY=0x... WRITE_CONDITION=0x... READ_CONDITION=0x... \
 
 - **[User Guide](./USER_GUIDE.md)** — Network configuration, API reference, examples, and error handling
 - **[Architecture](./docs/ARCHITECTURE.md)** — How CDR works end-to-end: DKG, threshold encryption, on-chain flow
-- **[Condition Contracts](./docs/CONDITIONS.md)** — Write and read access control: interface spec, example contracts, debugging
+- **[Condition Contracts](./docs/CONDITIONS.md)** — Write and read access control: interface spec, deployed contracts, debugging
 - **[Changelog](./CHANGELOG.md)** — Release history
 
 ## License

--- a/README.md
+++ b/README.md
@@ -64,7 +64,6 @@ const { dataKey: recovered } = await client.consumer.accessCDR({
 | Testnet  | `"testnet"`     | `https://aeneid.storyrpc.io`    |
 | Mainnet  | `"mainnet"`     | `https://rpc.story.foundation`   |
 
-Point to any Story-compatible RPC (devnets, local nodes) by changing the `http()` transport URL.
 
 See the [User Guide](./USER_GUIDE.md) for full network configuration details.
 

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -1,6 +1,6 @@
 # CDR SDK User Guide
 
-The **CDR (Confidential Data Recovery) SDK** provides a TypeScript interface for encrypting, storing, and recovering confidential data on Story L1 using threshold cryptography. Data is encrypted to a Distributed Key Generation (DKG) global public key and can only be decrypted when a threshold of validators provide partial decryptions.
+The **CDR (Confidential Data Rails) SDK** provides a TypeScript interface for encrypting, storing, and recovering confidential data on Story L1 using threshold cryptography. Data is encrypted to a Distributed Key Generation (DKG) global public key and can only be decrypted when a threshold of validators provide partial decryptions.
 
 ## Table of Contents
 
@@ -44,8 +44,8 @@ await initWasm();
 
 // 2. Set up viem clients
 const account = privateKeyToAccount("0xYOUR_PRIVATE_KEY");
-const publicClient = createPublicClient({ transport: http("https://odyssey.storyrpc.io") });
-const walletClient = createWalletClient({ account, transport: http("https://odyssey.storyrpc.io") });
+const publicClient = createPublicClient({ transport: http("https://aeneid.storyrpc.io") });
+const walletClient = createWalletClient({ account, transport: http("https://aeneid.storyrpc.io") });
 
 // 3. Create a CDR client
 const client = new CDRClient({ network: "testnet", publicClient, walletClient });
@@ -78,7 +78,7 @@ The SDK supports multiple Story L1 networks. You select a network when creating 
 
 | Network    | `network` param | Default RPC URL                     | Description                          |
 |------------|-----------------|-------------------------------------|--------------------------------------|
-| Testnet    | `"testnet"`     | `https://odyssey.storyrpc.io`       | Public testnet for development       |
+| Testnet    | `"testnet"`     | `https://aeneid.storyrpc.io`        | Aeneid testnet (chain ID 1315)       |
 | Mainnet    | `"mainnet"`     | `https://rpc.story.foundation`      | Production network                   |
 
 ### Contract Addresses
@@ -96,7 +96,7 @@ Both networks use the same pre-deployed system contract addresses:
 
 ```typescript
 const publicClient = createPublicClient({
-  transport: http("https://odyssey.storyrpc.io"),
+  transport: http("https://aeneid.storyrpc.io"),
 });
 const client = new CDRClient({ network: "testnet", publicClient });
 ```
@@ -140,7 +140,7 @@ const client = new CDRClient({ network: "testnet", publicClient, walletClient })
 A common pattern is to configure the network via environment variables:
 
 ```typescript
-const RPC_URL = process.env.RPC_URL ?? "https://odyssey.storyrpc.io";
+const RPC_URL = process.env.RPC_URL ?? "https://aeneid.storyrpc.io";
 const NETWORK = (process.env.NETWORK ?? "testnet") as "testnet" | "mainnet";
 
 const publicClient = createPublicClient({ transport: http(RPC_URL) });
@@ -149,7 +149,7 @@ const client = new CDRClient({ network: NETWORK, publicClient });
 
 ```bash
 # Testnet (default)
-RPC_URL=https://odyssey.storyrpc.io NETWORK=testnet node app.js
+RPC_URL=https://aeneid.storyrpc.io NETWORK=testnet node app.js
 
 # Mainnet
 RPC_URL=https://rpc.story.foundation NETWORK=mainnet node app.js
@@ -297,7 +297,7 @@ Read-only — no wallet or WASM needed.
 import { createPublicClient, http } from "viem";
 import { CDRClient } from "@piplabs/cdr-sdk";
 
-const publicClient = createPublicClient({ transport: http("https://odyssey.storyrpc.io") });
+const publicClient = createPublicClient({ transport: http("https://aeneid.storyrpc.io") });
 const client = new CDRClient({ network: "testnet", publicClient });
 
 const threshold = await client.observer.getOperationalThreshold();
@@ -325,8 +325,8 @@ import { CDRClient, initWasm } from "@piplabs/cdr-sdk";
 await initWasm();
 
 const account = privateKeyToAccount("0xYOUR_PRIVATE_KEY");
-const publicClient = createPublicClient({ transport: http("https://odyssey.storyrpc.io") });
-const walletClient = createWalletClient({ account, transport: http("https://odyssey.storyrpc.io") });
+const publicClient = createPublicClient({ transport: http("https://aeneid.storyrpc.io") });
+const walletClient = createWalletClient({ account, transport: http("https://aeneid.storyrpc.io") });
 const client = new CDRClient({ network: "testnet", publicClient, walletClient });
 
 // Fetch DKG global public key
@@ -365,8 +365,8 @@ await initWasm();
 
 const PRIVATE_KEY = "0xYOUR_PRIVATE_KEY";
 const account = privateKeyToAccount(PRIVATE_KEY as `0x${string}`);
-const publicClient = createPublicClient({ transport: http("https://odyssey.storyrpc.io") });
-const walletClient = createWalletClient({ account, transport: http("https://odyssey.storyrpc.io") });
+const publicClient = createPublicClient({ transport: http("https://aeneid.storyrpc.io") });
+const walletClient = createWalletClient({ account, transport: http("https://aeneid.storyrpc.io") });
 const client = new CDRClient({ network: "testnet", publicClient, walletClient });
 
 // Get DKG parameters

--- a/docs/CONDITIONS.md
+++ b/docs/CONDITIONS.md
@@ -2,6 +2,71 @@
 
 Vaults use **condition contracts** to control who can write data and who can request reads. When you allocate a vault, you specify a write condition address and a read condition address. The CDR contract calls into these before allowing the operation.
 
+## Deployed Contracts (Aeneid Testnet)
+
+The following condition contracts are deployed on Aeneid (chain ID 1315) and ready to use:
+
+| Contract | Address | Type | Description |
+|----------|---------|------|-------------|
+| OwnerWriteCondition | `0x4C9bFC96d7092b590D497A191826C3dA2277c34B` | Write | Only the address encoded in `writeConditionData` can write |
+| LicenseReadCondition | `0xC0640AD4CF2CaA9914C8e5C44234359a9102f7a3` | Read | Only Story Protocol license token holders for the specified IP can read |
+
+### OwnerWriteCondition Usage
+
+```typescript
+import { encodeAbiParameters } from "viem";
+
+const writeCondData = encodeAbiParameters(
+  [{ type: "address" }],
+  [uploaderAddress],  // Only this address can write
+);
+
+await client.uploader.uploadCDR({
+  // ...
+  writeConditionAddr: "0x4C9bFC96d7092b590D497A191826C3dA2277c34B",
+  writeConditionData: writeCondData,
+});
+```
+
+### LicenseReadCondition Usage
+
+At upload time, encode the LicenseToken contract address and IP ID:
+
+```typescript
+const readCondData = encodeAbiParameters(
+  [{ type: "address" }, { type: "address" }],
+  [
+    "0xFe3838BFb30B34170F00030B52eA4893d8aAC6bC",  // LicenseToken contract
+    "0x3Aa560C9072E0D4A1443CD192745C24A176b4925",  // Your IP ID
+  ],
+);
+
+await client.uploader.uploadCDR({
+  // ...
+  readConditionAddr: "0xC0640AD4CF2CaA9914C8e5C44234359a9102f7a3",
+  readConditionData: readCondData,
+});
+```
+
+At read time, pass the license token IDs as `accessAuxData`:
+
+```typescript
+const accessAuxData = encodeAbiParameters(
+  [{ type: "uint256[]" }],
+  [[BigInt(licenseTokenId)]],
+);
+
+const { dataKey } = await client.consumer.accessCDR({
+  uuid,
+  accessAuxData,
+  timeoutMs: 120_000,
+});
+```
+
+> **Note**: Minting license tokens requires wrapping IP to WIP and approving the RoyaltyModule. See the [Release Document](https://www.notion.so/storyprotocol/CDR-SDK-Aeneid-Release-Document-33e051299a548020b06efec9a4a01bcb) for the full manual flow.
+
+---
+
 ## How Conditions Work
 
 When someone calls `write()` or `read()` on the CDR contract, the contract:

--- a/docs/CONDITIONS.md
+++ b/docs/CONDITIONS.md
@@ -63,7 +63,6 @@ const { dataKey } = await client.consumer.accessCDR({
 });
 ```
 
-> **Note**: Minting license tokens requires wrapping IP to WIP and approving the RoyaltyModule. See the [Release Document](https://www.notion.so/storyprotocol/CDR-SDK-Aeneid-Release-Document-33e051299a548020b06efec9a4a01bcb) for the full manual flow.
 
 ---
 


### PR DESCRIPTION
## Summary

Update all documentation to reflect the current state of the SDK for the 0.1.0 release.

**README.md:**
- Add `accessCDR` example to Quick Start (previously only showed upload)
- Add Features section covering all SDK capabilities
- Add DKG Query Modes section (`evm-events` vs `cosmos-abci`)
- Add File Operations section (`uploadFile`/`downloadFile`)
- Add Condition Contracts section with Aeneid deployed addresses
- Fix CDR acronym: "Confidential Data Recovery" → "Confidential Data Rails"

**CHANGELOG.md:**
- Update release date to 2026-04-10
- Add all merged features: file ops, cosmos-abci (#43/#45), condition helpers (#28), SGX attestation (#31), storage providers, validation RPC, method aliases
- Add all bug fixes: getActiveRound (#38), HeliaProvider CID (#41), Synapse (#44)

**USER_GUIDE.md:**
- Replace all `odyssey.storyrpc.io` → `aeneid.storyrpc.io`
- Fix CDR acronym and testnet description

**docs/CONDITIONS.md:**
- Add "Deployed Contracts (Aeneid Testnet)" section with OwnerWriteCondition and LicenseReadCondition addresses and usage examples

## Reference
- Release Document: https://www.notion.so/storyprotocol/CDR-SDK-Aeneid-Release-Document-33e051299a548020b06efec9a4a01bcb