### PR TITLE
chore: bump version to 0.1.1

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@piplabs/cdr-cli",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "type": "module",
   "bin": {
     "cdr-cli": "dist/index.js"

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@piplabs/cdr-contracts",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@piplabs/cdr-crypto",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@piplabs/cdr-sdk",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Version bump for release 0.1.1.

Updates `version` in all 4 package.json files:
- `packages/sdk` → 0.1.1
- `packages/contracts` → 0.1.1
- `packages/crypto` → 0.1.1
- `apps/cli` → 0.1.1

Build and tests pass locally (SDK: 81 passed, crypto: 17 passed).