### PR TITLE
fix: restrict condition register() to CDR vault creator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ dist/
 .DS_Store
 docs/superpowers
 package-lock.json
+
+contracts/out/
+contracts/cache/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "contracts/lib/forge-std"]
+	path = contracts/lib/forge-std
+	url = https://github.com/foundry-rs/forge-std

--- a/contracts/foundry.toml
+++ b/contracts/foundry.toml
@@ -1,0 +1,5 @@
+[profile.default]
+src = "src"
+out = "out"
+libs = ["lib"]
+solc = "0.8.26"

--- a/contracts/src/FixedFeeCondition.sol
+++ b/contracts/src/FixedFeeCondition.sol
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.26;
+
+import {ICDRVaultCreator} from "./interfaces/ICDRVaultCreator.sol";
+
+/// @title FixedFeeCondition
+/// @notice Generic CDR condition that gates vault access behind a one-time fee.
+///         Only the vault creator (verified via CDR.vaultCreator) can register.
+contract FixedFeeCondition {
+    ICDRVaultCreator public immutable cdr;
+
+    mapping(uint32 uuid => address creator) public vaultCreator;
+    mapping(uint32 uuid => uint256 fee) public vaultFee;
+    mapping(uint32 uuid => mapping(address => bool)) public hasPaid;
+    mapping(address creator => uint256 balance) public creatorBalance;
+
+    error AlreadyRegistered();
+    error NotRegistered();
+    error InsufficientFee();
+    error AlreadyPaid();
+    error NothingToWithdraw();
+    error TransferFailed();
+    error NotVaultCreator();
+
+    constructor(address _cdr) {
+        cdr = ICDRVaultCreator(_cdr);
+    }
+
+    /// @notice Register a vault UUID with a fixed access fee. Only the CDR vault creator can call.
+    function register(uint32 uuid, uint256 fee) external {
+        if (vaultCreator[uuid] != address(0)) revert AlreadyRegistered();
+        if (cdr.vaultCreator(uuid) != msg.sender) revert NotVaultCreator();
+        vaultCreator[uuid] = msg.sender;
+        vaultFee[uuid] = fee;
+    }
+
+    /// @notice Pay the fee to gain access to a vault.
+    /// @param uuid The CDR vault UUID
+    function payFee(uint32 uuid) external payable {
+        address creator = vaultCreator[uuid];
+        if (creator == address(0)) revert NotRegistered();
+        if (hasPaid[uuid][msg.sender]) revert AlreadyPaid();
+
+        uint256 fee = vaultFee[uuid];
+        if (msg.value < fee) revert InsufficientFee();
+
+        hasPaid[uuid][msg.sender] = true;
+        creatorBalance[creator] += fee;
+
+        // Refund excess
+        uint256 excess = msg.value - fee;
+        if (excess > 0) {
+            (bool sent, ) = msg.sender.call{value: excess}("");
+            if (!sent) revert TransferFailed();
+        }
+    }
+
+    /// @notice Withdraw accumulated fees.
+    function withdraw() external {
+        uint256 amount = creatorBalance[msg.sender];
+        if (amount == 0) revert NothingToWithdraw();
+
+        creatorBalance[msg.sender] = 0;
+        (bool sent, ) = msg.sender.call{value: amount}("");
+        if (!sent) revert TransferFailed();
+    }
+
+    /// @notice CDR write condition check. Returns true if caller is creator or has paid.
+    function checkWriteCondition(
+        uint32 uuid,
+        bytes calldata,
+        bytes calldata,
+        address caller
+    ) external view returns (bool) {
+        if (vaultCreator[uuid] == caller) return true;
+        return hasPaid[uuid][caller];
+    }
+
+    /// @notice CDR read condition check. Same logic as write.
+    function checkReadCondition(
+        uint32 uuid,
+        bytes calldata,
+        bytes calldata,
+        address caller
+    ) external view returns (bool) {
+        if (vaultCreator[uuid] == caller) return true;
+        return hasPaid[uuid][caller];
+    }
+}

--- a/contracts/src/TimeBasedCondition.sol
+++ b/contracts/src/TimeBasedCondition.sol
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.26;
+
+import {ICDRVaultCreator} from "./interfaces/ICDRVaultCreator.sol";
+
+/// @title TimeBasedCondition
+/// @notice Generic CDR condition that gates vault access to a specific time window.
+///         Only the vault creator (verified via CDR.vaultCreator) can register.
+contract TimeBasedCondition {
+    ICDRVaultCreator public immutable cdr;
+
+    struct TimeWindow {
+        uint256 startTime;
+        uint256 endTime;
+        bool registered;
+    }
+
+    mapping(uint32 uuid => TimeWindow) public vaultTimeWindow;
+
+    error AlreadyRegistered();
+    error InvalidTimeWindow();
+    error NotVaultCreator();
+
+    constructor(address _cdr) {
+        cdr = ICDRVaultCreator(_cdr);
+    }
+
+    /// @notice Register a vault UUID with an immutable time window. Only the CDR vault creator can call.
+    function register(uint32 uuid, uint256 startTime, uint256 endTime) external {
+        if (vaultTimeWindow[uuid].registered) revert AlreadyRegistered();
+        if (cdr.vaultCreator(uuid) != msg.sender) revert NotVaultCreator();
+        if (endTime != 0 && endTime <= startTime) revert InvalidTimeWindow();
+
+        vaultTimeWindow[uuid] = TimeWindow({
+            startTime: startTime,
+            endTime: endTime,
+            registered: true
+        });
+    }
+
+    /// @notice CDR write condition check. Returns true if current time is within the window.
+    function checkWriteCondition(
+        uint32 uuid,
+        bytes calldata,
+        bytes calldata,
+        address
+    ) external view returns (bool) {
+        return _isWithinWindow(uuid);
+    }
+
+    /// @notice CDR read condition check. Same logic as write.
+    function checkReadCondition(
+        uint32 uuid,
+        bytes calldata,
+        bytes calldata,
+        address
+    ) external view returns (bool) {
+        return _isWithinWindow(uuid);
+    }
+
+    function _isWithinWindow(uint32 uuid) internal view returns (bool) {
+        TimeWindow storage tw = vaultTimeWindow[uuid];
+        if (!tw.registered) return false;
+        if (block.timestamp < tw.startTime) return false;
+        if (tw.endTime != 0 && block.timestamp > tw.endTime) return false;
+        return true;
+    }
+}

--- a/contracts/src/WhitelistCondition.sol
+++ b/contracts/src/WhitelistCondition.sol
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.26;
+
+import {ICDRVaultCreator} from "./interfaces/ICDRVaultCreator.sol";
+
+/// @title WhitelistCondition
+/// @notice Generic CDR condition that gates vault access to an owner-managed allowlist.
+///         Only the vault creator (verified via CDR.vaultCreator) can register and manage the whitelist.
+contract WhitelistCondition {
+    ICDRVaultCreator public immutable cdr;
+
+    mapping(uint32 uuid => address creator) public vaultCreator;
+    mapping(uint32 uuid => mapping(address => bool)) public isWhitelisted;
+
+    error AlreadyRegistered();
+    error NotCreator();
+    error NotVaultCreator();
+
+    constructor(address _cdr) {
+        cdr = ICDRVaultCreator(_cdr);
+    }
+
+    /// @notice Register a vault UUID. Only the CDR vault creator can call.
+    function register(uint32 uuid) external {
+        if (vaultCreator[uuid] != address(0)) revert AlreadyRegistered();
+        if (cdr.vaultCreator(uuid) != msg.sender) revert NotVaultCreator();
+        vaultCreator[uuid] = msg.sender;
+        isWhitelisted[uuid][msg.sender] = true;
+    }
+
+    /// @notice Register a vault and seed the whitelist. Only the CDR vault creator can call.
+    function registerWithInitial(uint32 uuid, address[] calldata initial) external {
+        if (vaultCreator[uuid] != address(0)) revert AlreadyRegistered();
+        if (cdr.vaultCreator(uuid) != msg.sender) revert NotVaultCreator();
+        vaultCreator[uuid] = msg.sender;
+        isWhitelisted[uuid][msg.sender] = true;
+        for (uint256 i = 0; i < initial.length; i++) {
+            isWhitelisted[uuid][initial[i]] = true;
+        }
+    }
+
+    /// @notice Add an address to the vault's whitelist. Only the creator can call.
+    /// @param uuid The CDR vault UUID
+    /// @param account The address to whitelist
+    function addToWhitelist(uint32 uuid, address account) external {
+        if (vaultCreator[uuid] != msg.sender) revert NotCreator();
+        isWhitelisted[uuid][account] = true;
+    }
+
+    /// @notice Remove an address from the vault's whitelist. Only the creator can call.
+    /// @param uuid The CDR vault UUID
+    /// @param account The address to remove
+    function removeFromWhitelist(uint32 uuid, address account) external {
+        if (vaultCreator[uuid] != msg.sender) revert NotCreator();
+        isWhitelisted[uuid][account] = false;
+    }
+
+    /// @notice CDR write condition check. Returns true if caller is whitelisted.
+    function checkWriteCondition(
+        uint32 uuid,
+        bytes calldata,
+        bytes calldata,
+        address caller
+    ) external view returns (bool) {
+        return isWhitelisted[uuid][caller];
+    }
+
+    /// @notice CDR read condition check. Same logic as write.
+    function checkReadCondition(
+        uint32 uuid,
+        bytes calldata,
+        bytes calldata,
+        address caller
+    ) external view returns (bool) {
+        return isWhitelisted[uuid][caller];
+    }
+}

--- a/contracts/src/interfaces/ICDRVaultCreator.sol
+++ b/contracts/src/interfaces/ICDRVaultCreator.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.26;
+
+/// @notice Minimal interface for querying vault creator from CDR contract.
+///         CDR.sol needs to add `address creator` to Vault struct and expose this view.
+interface ICDRVaultCreator {
+    function vaultCreator(uint32 uuid) external view returns (address);
+}

--- a/contracts/test/RegisterFrontrun.t.sol
+++ b/contracts/test/RegisterFrontrun.t.sol
@@ -1,0 +1,200 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.26;
+
+import {Test} from "forge-std/Test.sol";
+import {WhitelistCondition} from "../src/WhitelistCondition.sol";
+import {FixedFeeCondition} from "../src/FixedFeeCondition.sol";
+import {TimeBasedCondition} from "../src/TimeBasedCondition.sol";
+import {ICDRVaultCreator} from "../src/interfaces/ICDRVaultCreator.sol";
+
+/// @notice Mock CDR contract that implements vaultCreator() for testing.
+contract MockCDR is ICDRVaultCreator {
+    mapping(uint32 => address) public override vaultCreator;
+
+    function setVaultCreator(uint32 uuid, address creator) external {
+        vaultCreator[uuid] = creator;
+    }
+}
+
+/// @title RegisterFrontrunTest
+/// @notice Tests that register() front-run attack is blocked after fix.
+///         The fix: condition contracts verify msg.sender == CDR.vaultCreator(uuid).
+contract RegisterFrontrunTest is Test {
+    MockCDR internal mockCDR;
+    WhitelistCondition internal wl;
+    FixedFeeCondition internal ff;
+    TimeBasedCondition internal tb;
+
+    address internal creator = address(0xC0FFEE);
+    address internal attacker = address(0xDEAD);
+    uint32 internal constant UUID = 42;
+
+    function setUp() public {
+        mockCDR = new MockCDR();
+        wl = new WhitelistCondition(address(mockCDR));
+        ff = new FixedFeeCondition(address(mockCDR));
+        tb = new TimeBasedCondition(address(mockCDR));
+
+        // Simulate: creator called CDR.allocate() → CDR recorded them as vault creator
+        mockCDR.setVaultCreator(UUID, creator);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // WhitelistCondition
+    // ═══════════════════════════════════════════════════════════════════════
+
+    /// @notice Attacker cannot front-run register() — reverts with NotVaultCreator.
+    function test_whitelist_attackerCannotRegister() public {
+        vm.prank(attacker);
+        vm.expectRevert(WhitelistCondition.NotVaultCreator.selector);
+        wl.register(UUID);
+    }
+
+    /// @notice Real vault creator can register successfully.
+    function test_whitelist_creatorCanRegister() public {
+        vm.prank(creator);
+        wl.register(UUID);
+
+        assertEq(wl.vaultCreator(UUID), creator, "creator registered");
+        assertTrue(wl.isWhitelisted(UUID, creator), "creator whitelisted");
+        assertFalse(wl.isWhitelisted(UUID, attacker), "attacker not whitelisted");
+    }
+
+    /// @notice Full attack scenario: attacker tries to front-run, fails, creator succeeds.
+    function test_whitelist_fullAttackScenario() public {
+        // Step 1: Attacker tries to front-run → BLOCKED
+        vm.prank(attacker);
+        vm.expectRevert(WhitelistCondition.NotVaultCreator.selector);
+        wl.register(UUID);
+
+        // Step 2: Creator registers → succeeds
+        vm.prank(creator);
+        wl.register(UUID);
+
+        // Step 3: Creator controls whitelist, attacker does not
+        vm.prank(creator);
+        wl.addToWhitelist(UUID, address(0xBEEF));
+        assertTrue(wl.isWhitelisted(UUID, address(0xBEEF)));
+
+        vm.prank(attacker);
+        vm.expectRevert(WhitelistCondition.NotCreator.selector);
+        wl.addToWhitelist(UUID, attacker);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // FixedFeeCondition
+    // ═══════════════════════════════════════════════════════════════════════
+
+    /// @notice Attacker cannot front-run register() with fee=0.
+    function test_fixedFee_attackerCannotRegister() public {
+        vm.prank(attacker);
+        vm.expectRevert(FixedFeeCondition.NotVaultCreator.selector);
+        ff.register(UUID, 0);
+    }
+
+    /// @notice Creator registers with correct fee.
+    function test_fixedFee_creatorCanRegister() public {
+        vm.prank(creator);
+        ff.register(UUID, 1 ether);
+
+        assertEq(ff.vaultCreator(UUID), creator, "creator registered");
+        assertEq(ff.vaultFee(UUID), 1 ether, "fee = 1 ether");
+    }
+
+    /// @notice Full attack scenario: attacker fee=0 blocked, creator fee=1eth works.
+    function test_fixedFee_fullAttackScenario() public {
+        // Attacker tries fee=0 → BLOCKED
+        vm.prank(attacker);
+        vm.expectRevert(FixedFeeCondition.NotVaultCreator.selector);
+        ff.register(UUID, 0);
+
+        // Creator sets proper fee
+        vm.prank(creator);
+        ff.register(UUID, 1 ether);
+        assertEq(ff.vaultFee(UUID), 1 ether);
+
+        // User must pay 1 ether to access
+        address user = address(0xF00D);
+        vm.deal(user, 2 ether);
+        vm.prank(user);
+        ff.payFee{value: 1 ether}(UUID);
+        assertTrue(ff.checkReadCondition(UUID, "", "", user), "paid user can read");
+
+        // Freeloader without payment cannot
+        assertFalse(ff.checkReadCondition(UUID, "", "", address(0xBAD)), "unpaid cannot read");
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // TimeBasedCondition
+    // ═══════════════════════════════════════════════════════════════════════
+
+    /// @notice Attacker cannot front-run register() with expired window (DoS).
+    function test_timeBased_attackerCannotRegister_DoS() public {
+        vm.warp(1700000000);
+        vm.prank(attacker);
+        vm.expectRevert(TimeBasedCondition.NotVaultCreator.selector);
+        tb.register(UUID, 0, 1);
+    }
+
+    /// @notice Attacker cannot front-run register() with open window.
+    function test_timeBased_attackerCannotRegister_OpenAccess() public {
+        vm.prank(attacker);
+        vm.expectRevert(TimeBasedCondition.NotVaultCreator.selector);
+        tb.register(UUID, 0, 0);
+    }
+
+    /// @notice Creator registers valid time window.
+    function test_timeBased_creatorCanRegister() public {
+        vm.warp(1700000000);
+        vm.prank(creator);
+        tb.register(UUID, block.timestamp, block.timestamp + 30 days);
+
+        (uint256 start, uint256 end, bool reg) = tb.vaultTimeWindow(UUID);
+        assertTrue(reg, "registered");
+        assertEq(start, 1700000000);
+        assertEq(end, 1700000000 + 30 days);
+    }
+
+    /// @notice Full attack scenario: DoS blocked, creator sets proper window.
+    function test_timeBased_fullAttackScenario() public {
+        vm.warp(1700000000);
+
+        // Attacker DoS attempt → BLOCKED
+        vm.prank(attacker);
+        vm.expectRevert(TimeBasedCondition.NotVaultCreator.selector);
+        tb.register(UUID, 0, 1);
+
+        // Creator sets proper 30-day window
+        vm.prank(creator);
+        tb.register(UUID, block.timestamp, block.timestamp + 30 days);
+
+        // Access works within window
+        assertTrue(tb.checkWriteCondition(UUID, "", "", creator), "within window");
+
+        // Access fails after window
+        vm.warp(1700000000 + 31 days);
+        assertFalse(tb.checkWriteCondition(UUID, "", "", creator), "after window");
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // Edge: unregistered UUID (no CDR vault creator set)
+    // ═══════════════════════════════════════════════════════════════════════
+
+    /// @notice register() on UUID with no CDR vault creator → reverts.
+    function test_unregisteredUUID_reverts() public {
+        uint32 unknownUUID = 999;
+        // mockCDR.vaultCreator(999) == address(0) → msg.sender != address(0) → revert
+
+        vm.prank(creator);
+        vm.expectRevert(WhitelistCondition.NotVaultCreator.selector);
+        wl.register(unknownUUID);
+
+        vm.prank(creator);
+        vm.expectRevert(FixedFeeCondition.NotVaultCreator.selector);
+        ff.register(unknownUUID, 1 ether);
+
+        vm.prank(creator);
+        vm.expectRevert(TimeBasedCondition.NotVaultCreator.selector);
+        tb.register(unknownUUID, 0, 0);
+    }
+}


### PR DESCRIPTION
## Summary

Fix front-run vulnerability in WhitelistCondition, FixedFeeCondition, and TimeBasedCondition where `register()` was callable by anyone — attacker could front-run the vault creator to hijack vault configuration (set fee=0, DoS time window, take whitelist ownership).

## Changes

- **New**: `ICDRVaultCreator` interface — minimal `vaultCreator(uuid)` view function
- **Fix**: All 3 condition contracts now take `cdr` address in constructor and verify `msg.sender == CDR.vaultCreator(uuid)` in `register()`
- **Test**: 11 Foundry test cases covering attacker-blocked, creator-succeeds, full attack scenarios, and edge cases

## Test plan

```bash
cd contracts && forge test --match-contract RegisterFrontrunTest -vv
```

All 11 tests pass — attacker `register()` reverts with `NotVaultCreator`, creator `register()` succeeds.

## CDR.sol dependency

> **NOTE**: CDR.sol needs a corresponding change to store vault creator in `allocate()` and expose `vaultCreator(uint32 uuid)` view function. Without this, the condition contracts cannot verify the caller.

## Related

- Issue: piplabs/lion-team-sync#533
- Attack: `register(uuid)` has no access control → attacker front-runs with fee=0 / expired time window / takes whitelist ownership

🤖 Generated with [Claude Code](https://claude.com/claude-code)