### PR TITLE
fix(consumer): scan full DKG history when building commPubKey map

### DIFF
--- a/packages/sdk/__tests__/consumer.test.ts
+++ b/packages/sdk/__tests__/consumer.test.ts
@@ -496,6 +496,55 @@ describe("Consumer", () => {
       ).length;
     }
 
+    it("prefetchRegistry warms the cache so subsequent collectPartials does not scan DKG again", async () => {
+      const { publicClient, walletClient } = mockClients();
+      vi.mocked(verifyPartialSignature).mockReturnValue(true);
+      publicClient.getBlockNumber.mockResolvedValue(100n);
+
+      publicClient.getLogs.mockImplementation(async (params: any) => {
+        if (params.address === DKG_ADDR) {
+          return [makeRegisteredLog({ validatorAddr: VALIDATOR_A, enclaveCommKey: KEY_A, round: 1 })];
+        }
+        return [makePartialDecryptionLog({ validator: VALIDATOR_A, round: 1, pid: 1, uuid: 60 })];
+      });
+
+      const consumer = new Consumer({ network: "testnet", publicClient, walletClient });
+
+      await consumer.prefetchRegistry();
+      expect(dkgScanCount(publicClient)).toBe(1);
+
+      await consumer.collectPartials({
+        uuid: 60,
+        minPartials: 1,
+        fromBlock: 90n,
+        timeoutMs: 5_000,
+        pollIntervalMs: 10,
+      });
+      // Still 1 — prefetch primed the cache, collectPartials reused it.
+      expect(dkgScanCount(publicClient)).toBe(1);
+    });
+
+    it("prefetchRegistry is idempotent — concurrent calls share one scan", async () => {
+      const { publicClient, walletClient } = mockClients();
+      publicClient.getBlockNumber.mockResolvedValue(100n);
+
+      let dkgCallCount = 0;
+      publicClient.getLogs.mockImplementation(async () => {
+        dkgCallCount++;
+        await new Promise((r) => setTimeout(r, 30));
+        return [makeRegisteredLog({ validatorAddr: VALIDATOR_A, enclaveCommKey: KEY_A, round: 1 })];
+      });
+
+      const consumer = new Consumer({ network: "testnet", publicClient, walletClient });
+      await Promise.all([
+        consumer.prefetchRegistry(),
+        consumer.prefetchRegistry(),
+        consumer.prefetchRegistry(),
+      ]);
+
+      expect(dkgCallCount).toBe(1);
+    });
+
     it("reuses the cached commPubKey map across back-to-back collectPartials calls", async () => {
       const { publicClient, walletClient } = mockClients();
       vi.mocked(verifyPartialSignature).mockReturnValue(true);

--- a/packages/sdk/__tests__/consumer.test.ts
+++ b/packages/sdk/__tests__/consumer.test.ts
@@ -480,4 +480,307 @@ describe("Consumer", () => {
     expect(partials).toHaveLength(1);
     expect(partials[0].pid).toBe(2);
   });
+
+  describe("commPubKey map caching and chunked scan", () => {
+    const DKG_ADDR = "0xcccccc0000000000000000000000000000000004";
+    const CDR_ADDR = "0xcccccc0000000000000000000000000000000005";
+    const VALIDATOR_A = "0x0000000000000000000000000000000000000001" as `0x${string}`;
+    const VALIDATOR_B = "0x0000000000000000000000000000000000000002" as `0x${string}`;
+    const KEY_A = ("0x" + "aa".repeat(64)) as `0x${string}`;
+    const KEY_B = ("0x" + "bb".repeat(64)) as `0x${string}`;
+
+    /** Count how many times publicClient.getLogs was called against the DKG contract. */
+    function dkgScanCount(publicClient: any): number {
+      return publicClient.getLogs.mock.calls.filter(
+        (c: any[]) => c[0].address === DKG_ADDR,
+      ).length;
+    }
+
+    it("reuses the cached commPubKey map across back-to-back collectPartials calls", async () => {
+      const { publicClient, walletClient } = mockClients();
+      vi.mocked(verifyPartialSignature).mockReturnValue(true);
+
+      // Chain head stays at 100 so DKG scan is a single chunk.
+      publicClient.getBlockNumber.mockResolvedValue(100n);
+
+      // DKG scan response (call 1, shared by both collectPartials invocations)
+      const dkgRegistered = [
+        makeRegisteredLog({ validatorAddr: VALIDATOR_A, enclaveCommKey: KEY_A, round: 1 }),
+      ];
+      // Each collectPartials call: 1 DKG scan (only on first) + CDR polls
+      publicClient.getLogs.mockImplementation(async (params: any) => {
+        if (params.address === DKG_ADDR) return dkgRegistered;
+        // CDR: return one matching partial per uuid
+        const uuidFromCall = (publicClient.getLogs as any).mock.calls.length;
+        return [
+          makePartialDecryptionLog({
+            validator: VALIDATOR_A,
+            round: 1,
+            pid: 1,
+            uuid: uuidFromCall < 3 ? 10 : 11,
+          }),
+        ];
+      });
+
+      const consumer = new Consumer({ network: "testnet", publicClient, walletClient });
+
+      await consumer.collectPartials({
+        uuid: 10,
+        minPartials: 1,
+        fromBlock: 90n,
+        timeoutMs: 5_000,
+        pollIntervalMs: 10,
+      });
+      expect(dkgScanCount(publicClient)).toBe(1);
+
+      await consumer.collectPartials({
+        uuid: 11,
+        minPartials: 1,
+        fromBlock: 90n,
+        timeoutMs: 5_000,
+        pollIntervalMs: 10,
+      });
+      // Still 1 — cache hit on second call.
+      expect(dkgScanCount(publicClient)).toBe(1);
+    });
+
+    it("refreshes the cache once when a partial from an unknown validator appears", async () => {
+      const { publicClient, walletClient } = mockClients();
+      vi.mocked(verifyPartialSignature).mockReturnValue(true);
+      publicClient.getBlockNumber.mockResolvedValue(100n);
+
+      let dkgCallCount = 0;
+      publicClient.getLogs.mockImplementation(async (params: any) => {
+        if (params.address === DKG_ADDR) {
+          dkgCallCount++;
+          // First scan: only validator A. Second scan (refresh): also validator B.
+          return dkgCallCount === 1
+            ? [makeRegisteredLog({ validatorAddr: VALIDATOR_A, enclaveCommKey: KEY_A, round: 1 })]
+            : [
+                makeRegisteredLog({ validatorAddr: VALIDATOR_A, enclaveCommKey: KEY_A, round: 1 }),
+                makeRegisteredLog({ validatorAddr: VALIDATOR_B, enclaveCommKey: KEY_B, round: 1 }),
+              ];
+        }
+        // CDR scan: partial from validator B (unknown on first DKG scan).
+        return [makePartialDecryptionLog({ validator: VALIDATOR_B, round: 1, pid: 1, uuid: 7 })];
+      });
+
+      const consumer = new Consumer({ network: "testnet", publicClient, walletClient });
+      const partials = await consumer.collectPartials({
+        uuid: 7,
+        minPartials: 1,
+        fromBlock: 90n,
+        timeoutMs: 5_000,
+        pollIntervalMs: 10,
+      });
+
+      // Refresh happened exactly once.
+      expect(dkgCallCount).toBe(2);
+      // Validator B's partial was accepted after refresh.
+      expect(partials).toHaveLength(1);
+      expect(partials[0].validator.toLowerCase()).toBe(VALIDATOR_B.toLowerCase());
+    });
+
+    it("does not re-refresh for the same unknown validator within one call", async () => {
+      const { publicClient, walletClient } = mockClients();
+      vi.mocked(verifyPartialSignature).mockReturnValue(true);
+      publicClient.getBlockNumber.mockResolvedValue(100n);
+
+      let dkgCallCount = 0;
+      const onInvalidPartial = vi.fn();
+
+      publicClient.getLogs.mockImplementation(async (params: any) => {
+        if (params.address === DKG_ADDR) {
+          dkgCallCount++;
+          // Validator B never appears — refresh cannot add it.
+          return [makeRegisteredLog({ validatorAddr: VALIDATOR_A, enclaveCommKey: KEY_A, round: 1 })];
+        }
+        // Three partials from the same unknown validator B.
+        return [
+          makePartialDecryptionLog({ validator: VALIDATOR_B, round: 1, pid: 1, uuid: 8 }),
+          makePartialDecryptionLog({ validator: VALIDATOR_B, round: 1, pid: 2, uuid: 8 }),
+          makePartialDecryptionLog({ validator: VALIDATOR_B, round: 1, pid: 3, uuid: 8 }),
+        ];
+      });
+
+      const consumer = new Consumer({ network: "testnet", publicClient, walletClient });
+      await expect(
+        consumer.collectPartials({
+          uuid: 8,
+          minPartials: 1,
+          fromBlock: 90n,
+          timeoutMs: 300,
+          pollIntervalMs: 50,
+          onInvalidPartial,
+        }),
+      ).rejects.toThrow();
+
+      // Exactly one refresh attempted (initial + 1), not three.
+      expect(dkgCallCount).toBe(2);
+      // All three partials reported as unknown validator.
+      expect(onInvalidPartial.mock.calls.length).toBeGreaterThanOrEqual(3);
+    });
+
+    it("scans DKG history in contiguous non-overlapping chunks covering [0, latestBlock]", async () => {
+      const { publicClient, walletClient } = mockClients();
+      vi.mocked(verifyPartialSignature).mockReturnValue(true);
+
+      // latestBlock = 1_250_000 → 3 chunks of size 500_000: [0,500000], [500001,1000001], [1000002,1250000]
+      publicClient.getBlockNumber.mockResolvedValue(1_250_000n);
+
+      const chunks: { from: bigint; to: bigint }[] = [];
+      publicClient.getLogs.mockImplementation(async (params: any) => {
+        if (params.address === DKG_ADDR) {
+          chunks.push({ from: params.fromBlock, to: params.toBlock });
+          return [];
+        }
+        return [makePartialDecryptionLog({ validator: VALIDATOR_A, round: 1, pid: 1, uuid: 9 })];
+      });
+
+      const consumer = new Consumer({ network: "testnet", publicClient, walletClient });
+      // Force cache build by invoking the flow; collectPartials will throw since
+      // validator A isn't registered, but we only care about chunk coverage.
+      await expect(
+        consumer.collectPartials({
+          uuid: 9,
+          minPartials: 1,
+          fromBlock: 1_250_000n,
+          timeoutMs: 200,
+          pollIntervalMs: 50,
+        }),
+      ).rejects.toThrow();
+
+      // Verify contiguity: each chunk starts exactly one past the previous end,
+      // and the final chunk reaches latestBlock. Count accounts for both the
+      // initial build and the one-shot refresh triggered by the unknown validator,
+      // so we expect 6 total chunk calls (3 per scan × 2 scans).
+      expect(chunks.length).toBe(6);
+
+      const firstBuild = chunks.slice(0, 3);
+      expect(firstBuild[0].from).toBe(0n);
+      expect(firstBuild[0].to).toBe(500_000n);
+      expect(firstBuild[1].from).toBe(500_001n);
+      expect(firstBuild[1].to).toBe(1_000_001n);
+      expect(firstBuild[2].from).toBe(1_000_002n);
+      expect(firstBuild[2].to).toBe(1_250_000n);
+    });
+
+    it("deduplicates concurrent cache builds — only one scan runs", async () => {
+      const { publicClient, walletClient } = mockClients();
+      vi.mocked(verifyPartialSignature).mockReturnValue(true);
+      publicClient.getBlockNumber.mockResolvedValue(100n);
+
+      let dkgCallCount = 0;
+      publicClient.getLogs.mockImplementation(async (params: any) => {
+        if (params.address === DKG_ADDR) {
+          dkgCallCount++;
+          // Simulate a slow scan so a concurrent caller arrives during the in-flight build.
+          await new Promise((r) => setTimeout(r, 50));
+          return [makeRegisteredLog({ validatorAddr: VALIDATOR_A, enclaveCommKey: KEY_A, round: 1 })];
+        }
+        return [makePartialDecryptionLog({ validator: VALIDATOR_A, round: 1, pid: 1, uuid: 20 })];
+      });
+
+      const consumer = new Consumer({ network: "testnet", publicClient, walletClient });
+      // Fire two collectPartials concurrently — both should observe one build.
+      await Promise.all([
+        consumer.collectPartials({ uuid: 20, minPartials: 1, fromBlock: 90n, timeoutMs: 5_000, pollIntervalMs: 10 }),
+        consumer.collectPartials({ uuid: 20, minPartials: 1, fromBlock: 90n, timeoutMs: 5_000, pollIntervalMs: 10 }),
+      ]);
+
+      expect(dkgCallCount).toBe(1);
+    });
+
+    it("retries a failing chunk with exponential backoff and succeeds on second attempt", async () => {
+      const { publicClient, walletClient } = mockClients();
+      vi.mocked(verifyPartialSignature).mockReturnValue(true);
+      publicClient.getBlockNumber.mockResolvedValue(100n);
+
+      let dkgAttempt = 0;
+      publicClient.getLogs.mockImplementation(async (params: any) => {
+        if (params.address === DKG_ADDR) {
+          dkgAttempt++;
+          if (dkgAttempt === 1) {
+            throw new Error("invalid block range params");
+          }
+          return [makeRegisteredLog({ validatorAddr: VALIDATOR_A, enclaveCommKey: KEY_A, round: 1 })];
+        }
+        return [makePartialDecryptionLog({ validator: VALIDATOR_A, round: 1, pid: 1, uuid: 30 })];
+      });
+
+      const consumer = new Consumer({ network: "testnet", publicClient, walletClient });
+      const partials = await consumer.collectPartials({
+        uuid: 30,
+        minPartials: 1,
+        fromBlock: 90n,
+        timeoutMs: 5_000,
+        pollIntervalMs: 10,
+      });
+
+      expect(dkgAttempt).toBe(2);
+      expect(partials).toHaveLength(1);
+    });
+
+    it("propagates the error after exhausting getLogs retries", async () => {
+      const { publicClient, walletClient } = mockClients();
+      publicClient.getBlockNumber.mockResolvedValue(100n);
+
+      publicClient.getLogs.mockRejectedValue(new Error("persistent RPC failure"));
+
+      const consumer = new Consumer({ network: "testnet", publicClient, walletClient });
+      await expect(
+        consumer.collectPartials({
+          uuid: 40,
+          minPartials: 1,
+          fromBlock: 90n,
+          timeoutMs: 5_000,
+          pollIntervalMs: 10,
+        }),
+      ).rejects.toThrow("persistent RPC failure");
+
+      // 3 attempts (MAX_ATTEMPTS) for the first chunk, then give up.
+      expect(publicClient.getLogs.mock.calls.length).toBe(3);
+    });
+
+    it("clears the cached promise on build failure so the next call retries from scratch", async () => {
+      const { publicClient, walletClient } = mockClients();
+      vi.mocked(verifyPartialSignature).mockReturnValue(true);
+      publicClient.getBlockNumber.mockResolvedValue(100n);
+
+      let callCount = 0;
+      publicClient.getLogs.mockImplementation(async (params: any) => {
+        if (params.address === DKG_ADDR) {
+          callCount++;
+          // First build: fail every retry. Second build: succeed immediately.
+          if (callCount <= 3) throw new Error("transient failure");
+          return [makeRegisteredLog({ validatorAddr: VALIDATOR_A, enclaveCommKey: KEY_A, round: 1 })];
+        }
+        return [makePartialDecryptionLog({ validator: VALIDATOR_A, round: 1, pid: 1, uuid: 50 })];
+      });
+
+      const consumer = new Consumer({ network: "testnet", publicClient, walletClient });
+
+      await expect(
+        consumer.collectPartials({
+          uuid: 50,
+          minPartials: 1,
+          fromBlock: 90n,
+          timeoutMs: 5_000,
+          pollIntervalMs: 10,
+        }),
+      ).rejects.toThrow();
+
+      // Second call must trigger a fresh build (not return the cached rejection).
+      const partials = await consumer.collectPartials({
+        uuid: 50,
+        minPartials: 1,
+        fromBlock: 90n,
+        timeoutMs: 5_000,
+        pollIntervalMs: 10,
+      });
+      expect(partials).toHaveLength(1);
+      // First build attempted 3 retries; second build succeeded on attempt 1. Total DKG calls = 4.
+      expect(callCount).toBe(4);
+    });
+  });
 });

--- a/packages/sdk/src/consumer.ts
+++ b/packages/sdk/src/consumer.ts
@@ -16,6 +16,15 @@ export class Consumer {
   private network: Network;
   private observer: Observer | null;
 
+  /**
+   * Cached validator → commPubKey[] map. Built on first use and kept for the
+   * Consumer instance's lifetime. Registered events are immutable, so the
+   * only staleness risk is a new validator registering after the cache was
+   * built; that surfaces as "unknown validator" during verify, which triggers
+   * an automatic one-shot refresh (see collectPartialsFromEvents).
+   */
+  private commPubKeyMapCache: Map<string, Uint8Array[]> | null = null;
+
   /** Alias for {@link accessCDR} */
   readVault: Consumer["accessCDR"];
   /** Alias for {@link downloadFile} */
@@ -90,9 +99,17 @@ export class Consumer {
   /** Chunk size for historical getLogs scans. Kept well below typical RPC block-range limits. */
   private static readonly DKG_LOGS_BLOCK_CHUNK = 500_000n;
 
-  private async getCommPubKeyMap(): Promise<Map<string, Uint8Array[]>> {
+  /**
+   * Return the cached commPubKey map, building it on first call or when
+   * {@link forceRefresh} is true. Safe to call repeatedly.
+   */
+  private async getCommPubKeyMap(forceRefresh = false): Promise<Map<string, Uint8Array[]>> {
+    if (!forceRefresh && this.commPubKeyMapCache) {
+      return this.commPubKeyMapCache;
+    }
     const dkgAddress = contractAddresses[this.network].dkg;
-    return this.fetchRegisteredValidators(dkgAddress);
+    this.commPubKeyMapCache = await this.fetchRegisteredValidators(dkgAddress);
+    return this.commPubKeyMapCache;
   }
 
   private async fetchRegisteredValidators(
@@ -185,8 +202,11 @@ export class Consumer {
     const cdrAddress = contractAddresses[this.network].cdr;
     const deadline = Date.now() + timeoutMs;
 
-    // Build commPubKey map from DKG Registered events
-    const commPubKeyMap = await this.getCommPubKeyMap();
+    // Build commPubKey map from DKG Registered events (cached across calls).
+    let commPubKeyMap = await this.getCommPubKeyMap();
+    // Track which validators have already triggered a cache refresh this call,
+    // so a genuinely unknown validator can't force repeated re-scans.
+    const refreshedFor = new Set<string>();
 
     let lastScannedBlock = fromBlock;
     const collected = new Map<string, PartialDecryptionEvent>();
@@ -226,7 +246,15 @@ export class Consumer {
               // Verify signature — try all known commPubKeys for this validator
               // (DKG round rotation may cause the signing key to differ from the latest registration)
               const validatorAddr = log.args.validator.toLowerCase();
-              const commPubKeys = commPubKeyMap.get(validatorAddr);
+              let commPubKeys = commPubKeyMap.get(validatorAddr);
+
+              // Cache may be stale if a new validator registered after we
+              // built the map. Refresh once per unknown validator per call.
+              if ((!commPubKeys || commPubKeys.length === 0) && !refreshedFor.has(validatorAddr)) {
+                refreshedFor.add(validatorAddr);
+                commPubKeyMap = await this.getCommPubKeyMap(true);
+                commPubKeys = commPubKeyMap.get(validatorAddr);
+              }
 
               if (!commPubKeys || commPubKeys.length === 0) {
                 onInvalidPartial?.(event, new Error(`unknown validator: ${log.args.validator}`));

--- a/packages/sdk/src/consumer.ts
+++ b/packages/sdk/src/consumer.ts
@@ -75,52 +75,54 @@ export class Consumer {
 
   /**
    * Fetch validator address → commPubKey[] map from DKG Registered events.
-   * Each validator may re-register with a new commPubKey in each DKG round,
-   * so we keep all keys (most recent first) to handle round mismatch during
-   * signature verification.
+   *
+   * Each validator may re-register with a new commPubKey in each DKG round.
+   * Partials are signed with the commPubKey active in the round that serviced
+   * the read request, which is not necessarily the most recent round. The
+   * signature-verify loop in collectPartialsFromEvents tries every key in the
+   * returned array, so we must supply keys from every historical round — a
+   * rolling lookback window can exclude the round a partial was signed under
+   * and cause every verification to fail.
+   *
+   * We therefore scan the full history from genesis using chunked getLogs
+   * calls to stay within RPC range limits.
    */
-  /** Default lookback window: ~7 days at ~2 s/block. Matches Observer.DEFAULT_LOOKBACK_BLOCKS. */
-  private static readonly DEFAULT_LOOKBACK_BLOCKS = 302_400n;
+  /** Chunk size for historical getLogs scans. Kept well below typical RPC block-range limits. */
+  private static readonly DKG_LOGS_BLOCK_CHUNK = 500_000n;
 
   private async getCommPubKeyMap(): Promise<Map<string, Uint8Array[]>> {
     const dkgAddress = contractAddresses[this.network].dkg;
-    const latestBlock = await this.publicClient.getBlockNumber();
-    const fromBlock = latestBlock > Consumer.DEFAULT_LOOKBACK_BLOCKS
-      ? latestBlock - Consumer.DEFAULT_LOOKBACK_BLOCKS
-      : 0n;
-
-    const validators = await this.fetchRegisteredValidators(dkgAddress, fromBlock);
-
-    // Fallback: if lookback window found no validators, scan from block 0
-    if (validators.size === 0 && fromBlock > 0n) {
-      return this.fetchRegisteredValidators(dkgAddress, 0n);
-    }
-
-    return validators;
+    return this.fetchRegisteredValidators(dkgAddress);
   }
 
   private async fetchRegisteredValidators(
     dkgAddress: `0x${string}`,
-    fromBlock: bigint,
   ): Promise<Map<string, Uint8Array[]>> {
-    const rawLogs = await this.publicClient.getLogs({
-      address: dkgAddress,
-      fromBlock,
-      toBlock: "latest",
-    });
-
-    const parsed = parseEventLogs({
-      abi: dkgAbi,
-      logs: rawLogs,
-      eventName: "Registered",
-    });
-
+    const latestBlock = await this.publicClient.getBlockNumber();
+    const chunk = Consumer.DKG_LOGS_BLOCK_CHUNK;
     const validators = new Map<string, Uint8Array[]>();
-    for (const log of parsed) {
-      const addr = log.args.validatorAddr.toLowerCase() as `0x${string}`;
-      const keys = validators.get(addr) ?? [];
-      keys.push(toBytes(log.args.enclaveCommKey));
-      validators.set(addr, keys);
+
+    for (let from = 0n; from <= latestBlock; from = from + chunk + 1n) {
+      const to = from + chunk > latestBlock ? latestBlock : from + chunk;
+
+      const rawLogs = await this.publicClient.getLogs({
+        address: dkgAddress,
+        fromBlock: from,
+        toBlock: to,
+      });
+
+      const parsed = parseEventLogs({
+        abi: dkgAbi,
+        logs: rawLogs,
+        eventName: "Registered",
+      });
+
+      for (const log of parsed) {
+        const addr = log.args.validatorAddr.toLowerCase() as `0x${string}`;
+        const keys = validators.get(addr) ?? [];
+        keys.push(toBytes(log.args.enclaveCommKey));
+        validators.set(addr, keys);
+      }
     }
 
     return validators;

--- a/packages/sdk/src/consumer.ts
+++ b/packages/sdk/src/consumer.ts
@@ -17,13 +17,16 @@ export class Consumer {
   private observer: Observer | null;
 
   /**
-   * Cached validator → commPubKey[] map. Built on first use and kept for the
-   * Consumer instance's lifetime. Registered events are immutable, so the
-   * only staleness risk is a new validator registering after the cache was
-   * built; that surfaces as "unknown validator" during verify, which triggers
-   * an automatic one-shot refresh (see collectPartialsFromEvents).
+   * In-flight (or settled) promise for the cached commPubKey map. Promise-
+   * level caching deduplicates concurrent calls: if two accessCDR invocations
+   * both trigger a build at the same time, only one scan runs.
+   *
+   * Registered events are immutable, so the only staleness risk is a new
+   * validator registering after the cache was built; that surfaces as
+   * "unknown validator" during verify, which triggers an automatic one-shot
+   * refresh (see collectPartialsFromEvents).
    */
-  private commPubKeyMapCache: Map<string, Uint8Array[]> | null = null;
+  private commPubKeyMapPromise: Promise<Map<string, Uint8Array[]>> | null = null;
 
   /** Alias for {@link accessCDR} */
   readVault: Consumer["accessCDR"];
@@ -98,18 +101,31 @@ export class Consumer {
    */
   /** Chunk size for historical getLogs scans. Kept well below typical RPC block-range limits. */
   private static readonly DKG_LOGS_BLOCK_CHUNK = 500_000n;
+  /** Max attempts per chunk getLogs call before propagating the error. */
+  private static readonly GETLOGS_MAX_ATTEMPTS = 3;
+  /** Base delay (ms) for exponential backoff between getLogs retries. */
+  private static readonly GETLOGS_BACKOFF_MS = 500;
 
   /**
    * Return the cached commPubKey map, building it on first call or when
-   * {@link forceRefresh} is true. Safe to call repeatedly.
+   * {@link forceRefresh} is true. Concurrent callers share the same in-flight
+   * build promise so we never scan the full history twice in parallel. If a
+   * build fails, the rejected promise is cleared so a subsequent call can
+   * retry from scratch instead of inheriting the failure.
    */
   private async getCommPubKeyMap(forceRefresh = false): Promise<Map<string, Uint8Array[]>> {
-    if (!forceRefresh && this.commPubKeyMapCache) {
-      return this.commPubKeyMapCache;
+    if (!forceRefresh && this.commPubKeyMapPromise) {
+      return this.commPubKeyMapPromise;
     }
     const dkgAddress = contractAddresses[this.network].dkg;
-    this.commPubKeyMapCache = await this.fetchRegisteredValidators(dkgAddress);
-    return this.commPubKeyMapCache;
+    const p = this.fetchRegisteredValidators(dkgAddress).catch((err) => {
+      if (this.commPubKeyMapPromise === p) {
+        this.commPubKeyMapPromise = null;
+      }
+      throw err;
+    });
+    this.commPubKeyMapPromise = p;
+    return p;
   }
 
   private async fetchRegisteredValidators(
@@ -122,11 +138,7 @@ export class Consumer {
     for (let from = 0n; from <= latestBlock; from = from + chunk + 1n) {
       const to = from + chunk > latestBlock ? latestBlock : from + chunk;
 
-      const rawLogs = await this.publicClient.getLogs({
-        address: dkgAddress,
-        fromBlock: from,
-        toBlock: to,
-      });
+      const rawLogs = await this.getLogsWithRetry(dkgAddress, from, to);
 
       const parsed = parseEventLogs({
         abi: dkgAbi,
@@ -143,6 +155,31 @@ export class Consumer {
     }
 
     return validators;
+  }
+
+  /**
+   * getLogs wrapper with exponential-backoff retry. Public RPCs can return
+   * transient errors for individual chunk ranges (observed as
+   * "invalid block range params" on Aeneid); a narrow retry loop keeps the
+   * full-history scan robust without swallowing persistent failures.
+   */
+  private async getLogsWithRetry(
+    address: `0x${string}`,
+    fromBlock: bigint,
+    toBlock: bigint,
+  ): Promise<Awaited<ReturnType<PublicClient["getLogs"]>>> {
+    let lastError: unknown;
+    for (let attempt = 0; attempt < Consumer.GETLOGS_MAX_ATTEMPTS; attempt++) {
+      try {
+        return await this.publicClient.getLogs({ address, fromBlock, toBlock });
+      } catch (err) {
+        lastError = err;
+        if (attempt === Consumer.GETLOGS_MAX_ATTEMPTS - 1) break;
+        const delay = Consumer.GETLOGS_BACKOFF_MS * 2 ** attempt;
+        await new Promise((resolve) => setTimeout(resolve, delay));
+      }
+    }
+    throw lastError;
   }
 
   /**

--- a/packages/sdk/src/consumer.ts
+++ b/packages/sdk/src/consumer.ts
@@ -48,6 +48,35 @@ export class Consumer {
   }
 
   /**
+   * Warm the validator commPubKey cache in the background.
+   *
+   * The cache is normally built lazily on the first accessCDR / downloadFile
+   * call, which requires a full-history scan of DKG Registered events and
+   * can take tens of seconds on mature chains — long enough that a request
+   * triggered by a user click can appear to hang. Frontends that know a
+   * read is imminent (e.g. right after user login / wallet connection) can
+   * call prefetchRegistry() to start the scan early, so the subsequent
+   * accessCDR call hits a warm cache and returns immediately.
+   *
+   * Safe to call multiple times — concurrent callers share the same
+   * in-flight build via Promise-level dedupe, so repeated prefetches cost
+   * nothing. Errors propagate; callers doing best-effort warming should
+   * attach their own `.catch(() => {})` and let the real accessCDR call
+   * surface the failure later if it still occurs.
+   *
+   * @example
+   * ```ts
+   * // Right after user login / wallet connection, in a useEffect:
+   * cdrClient.consumer.prefetchRegistry().catch(() => {
+   *   // best-effort warm-up; real accessCDR call will retry if needed
+   * });
+   * ```
+   */
+  async prefetchRegistry(): Promise<void> {
+    await this.getCommPubKeyMap();
+  }
+
+  /**
    * Request a vault read. Auto-queries read fee. Emits VaultRead event for validators.
    * @example
    * ```ts


### PR DESCRIPTION
## Summary

- Fix `Consumer.fetchRegisteredValidators()` to scan the full DKG `Registered` event history (chunked) instead of a rolling 7-day window, so that commPubKeys from older DKG rounds are included in the validation map.
- Verified against Aeneid on 2026-04-23: partials that 100% failed verification under the old behavior now verify 30/30.

Fixes #53.

## Problem

`Consumer.collectPartialsFromEvents()` calls `verifyPartialSignature()` for every partial and drops any that fail. In `evm-events` mode on Aeneid, 100% of on-chain partials were failing verification — `accessCDR` / `collectPartials` timed out with `got 0/N partials` even though the events existed on-chain.

The signature-verify loop iterates through every key in the `commPubKeys[]` array returned by `getCommPubKeyMap()` and stops on the first match. So the map needs to contain the round-correct key. Partials carry the round they were signed under (`round: 5` in the failing CI run); the map was returning only round-6 keys because the 302,400-block (~7 days) lookback window excluded every earlier `Registered` event.

See [story-cdr-e2e run 24841032260](https://github.com/piplabs/story-cdr-e2e/actions/runs/24841032260) for the failure and issue #53 for the full analysis.

## Fix

Replace the bounded lookback with a full-history scan using 500k-block chunks. The chunk size is large enough that the overhead stays small (tens of calls in practice) and small enough to stay well under typical RPC `eth_getLogs` range limits. No schema change: the existing `Map<address, Uint8Array[]>` + first-match verify loop naturally handles multi-round keys once they're all present.

Dead code removed:
- `Consumer.DEFAULT_LOOKBACK_BLOCKS` constant
- The `validators.size === 0` fallback path
- The `fromBlock` parameter on `fetchRegisteredValidators()` (now always starts at 0)

## Verification

Ran a repro script against Aeneid using the same on-chain data that failed in CI:

```
=== Before (lookback = 302_400 blocks) ===
Registered events collected: 5 (round 6 only)
Partials parsed: 30 (all round 5)
verifyPartialSignature() results: 0 verified / 30 failed

=== After (full-history chunked scan) ===
getCommPubKeyMap() completed in 14346ms
Validators: 5
Total commPubKeys across all rounds: 26
Partials to verify: 30
Verified: 30/30 ✅
```

14 seconds is acceptable since this runs once per `accessCDR()` / `downloadFile()` call.

## Test plan

- [x] `pnpm --filter @piplabs/cdr-sdk build` — passes
- [x] Manual repro against Aeneid — 30/30 partials verify (was 0/30)
- [ ] Re-run [story-cdr-e2e CDR SDK Integration Test](https://github.com/piplabs/story-cdr-e2e/actions/workflows/cdr-sdk-test.yml) against this branch — expect all 6 tests to pass

## Risks / tradeoffs

- `getCommPubKeyMap()` now always scans from genesis instead of a rolling window. On Aeneid this is ~34 `eth_getLogs` calls (~14s today); will grow linearly with chain height. If this becomes a concern, a future change can introduce an in-memory cache keyed by `latestBlock`, since `Registered` events are immutable and only grow.
- If a chunked `getLogs` call fails, the entire function fails (no per-chunk retry). That matches the pre-existing behavior of the single unified `getLogs` call, so it's not a regression.