### PR TITLE
hybrid(consumer): ABCI-driven active-round filter + 10-day EVM lookback (Aeneid / mainnet)

### DIFF
--- a/packages/sdk/__tests__/consumer.test.ts
+++ b/packages/sdk/__tests__/consumer.test.ts
@@ -496,6 +496,55 @@ describe("Consumer", () => {
       ).length;
     }
 
+    it("prefetchRegistry warms the cache so subsequent collectPartials does not scan DKG again", async () => {
+      const { publicClient, walletClient } = mockClients();
+      vi.mocked(verifyPartialSignature).mockReturnValue(true);
+      publicClient.getBlockNumber.mockResolvedValue(100n);
+
+      publicClient.getLogs.mockImplementation(async (params: any) => {
+        if (params.address === DKG_ADDR) {
+          return [makeRegisteredLog({ validatorAddr: VALIDATOR_A, enclaveCommKey: KEY_A, round: 1 })];
+        }
+        return [makePartialDecryptionLog({ validator: VALIDATOR_A, round: 1, pid: 1, uuid: 60 })];
+      });
+
+      const consumer = new Consumer({ network: "testnet", publicClient, walletClient });
+
+      await consumer.prefetchRegistry();
+      expect(dkgScanCount(publicClient)).toBe(1);
+
+      await consumer.collectPartials({
+        uuid: 60,
+        minPartials: 1,
+        fromBlock: 90n,
+        timeoutMs: 5_000,
+        pollIntervalMs: 10,
+      });
+      // Still 1 — prefetch primed the cache, collectPartials reused it.
+      expect(dkgScanCount(publicClient)).toBe(1);
+    });
+
+    it("prefetchRegistry is idempotent — concurrent calls share one scan", async () => {
+      const { publicClient, walletClient } = mockClients();
+      publicClient.getBlockNumber.mockResolvedValue(100n);
+
+      let dkgCallCount = 0;
+      publicClient.getLogs.mockImplementation(async () => {
+        dkgCallCount++;
+        await new Promise((r) => setTimeout(r, 30));
+        return [makeRegisteredLog({ validatorAddr: VALIDATOR_A, enclaveCommKey: KEY_A, round: 1 })];
+      });
+
+      const consumer = new Consumer({ network: "testnet", publicClient, walletClient });
+      await Promise.all([
+        consumer.prefetchRegistry(),
+        consumer.prefetchRegistry(),
+        consumer.prefetchRegistry(),
+      ]);
+
+      expect(dkgCallCount).toBe(1);
+    });
+
     it("reuses the cached commPubKey map across back-to-back collectPartials calls", async () => {
       const { publicClient, walletClient } = mockClients();
       vi.mocked(verifyPartialSignature).mockReturnValue(true);

--- a/packages/sdk/__tests__/consumer.test.ts
+++ b/packages/sdk/__tests__/consumer.test.ts
@@ -1078,6 +1078,43 @@ describe("Consumer", () => {
       expect(dkgCallCount).toBe(1);
     });
 
+    it("retries a transient CDR-poll getLogs failure and still collects partials", async () => {
+      // Regression for PERF-05 flake: the partial-polling getLogs call used to
+      // bypass the retry wrapper, so a single transient "invalid block range
+      // params" from the public RPC would propagate all the way up as an
+      // accessCDR failure. With the wrapper, one bad attempt is absorbed and
+      // the poll loop keeps going.
+      const { publicClient, walletClient } = mockClients();
+      vi.mocked(verifyPartialSignature).mockReturnValue(true);
+      publicClient.getBlockNumber.mockResolvedValue(100n);
+
+      let cdrAttempt = 0;
+      publicClient.getLogs.mockImplementation(async (params: any) => {
+        if (params.address === DKG_ADDR) {
+          return [makeRegisteredLog({ validatorAddr: VALIDATOR_A, enclaveCommKey: KEY_A, round: 1 })];
+        }
+        // CDR scan: first attempt fails with the exact error observed in e2e.
+        cdrAttempt++;
+        if (cdrAttempt === 1) {
+          throw new Error("invalid block range params");
+        }
+        return [makePartialDecryptionLog({ validator: VALIDATOR_A, round: 1, pid: 1, uuid: 80 })];
+      });
+
+      const consumer = new Consumer({ network: "testnet", publicClient, walletClient });
+      const partials = await consumer.collectPartials({
+        uuid: 80,
+        minPartials: 1,
+        fromBlock: 90n,
+        timeoutMs: 5_000,
+        pollIntervalMs: 10,
+      });
+
+      // 1 transient failure + 1 successful retry.
+      expect(cdrAttempt).toBe(2);
+      expect(partials).toHaveLength(1);
+    });
+
     it("retries a failing chunk with exponential backoff and succeeds on second attempt", async () => {
       const { publicClient, walletClient } = mockClients();
       vi.mocked(verifyPartialSignature).mockReturnValue(true);

--- a/packages/sdk/__tests__/consumer.test.ts
+++ b/packages/sdk/__tests__/consumer.test.ts
@@ -687,6 +687,68 @@ describe("Consumer", () => {
       expect(partials).toHaveLength(1);
     });
 
+    it("warns exactly once per Consumer when falling back to the default CometBFT URL", async () => {
+      const { publicClient, walletClient } = mockClients();
+      vi.mocked(verifyPartialSignature).mockReturnValue(true);
+      vi.mocked(queryLatestActiveDKGNetwork).mockResolvedValue({
+        round: 1, globalPublicKey: new Uint8Array(), threshold: 3,
+      } as any);
+      publicClient.getBlockNumber.mockResolvedValue(100n);
+      publicClient.getLogs.mockImplementation(async (params: any) => {
+        if (params.address === DKG_ADDR) {
+          return [makeRegisteredLog({ validatorAddr: VALIDATOR_A, enclaveCommKey: KEY_A, round: 1 })];
+        }
+        return [makePartialDecryptionLog({ validator: VALIDATOR_A, round: 1, pid: 1, uuid: 70 })];
+      });
+
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      try {
+        // No observer → hybrid path uses the hardcoded default URL.
+        const consumer = new Consumer({ network: "testnet", publicClient, walletClient });
+        // First accessCDR: warning fires.
+        await consumer.collectPartials({ uuid: 70, minPartials: 1, fromBlock: 90n, timeoutMs: 5_000, pollIntervalMs: 10 });
+        // Trigger an explicit refresh to force another default-URL consultation.
+        await consumer.prefetchRegistry();
+
+        const defaultWarnings = warnSpy.mock.calls.filter(
+          (c) => typeof c[0] === "string" && c[0].includes("default CometBFT RPC URL"),
+        );
+        expect(defaultWarnings).toHaveLength(1);
+        expect(defaultWarnings[0][0]).toContain("http://172.192.41.96:26657");
+      } finally {
+        warnSpy.mockRestore();
+      }
+    });
+
+    it("does not warn when the caller supplies an explicit cometRpcUrl", async () => {
+      const { publicClient, walletClient } = mockClients();
+      vi.mocked(verifyPartialSignature).mockReturnValue(true);
+      vi.mocked(queryLatestActiveDKGNetwork).mockResolvedValue({
+        round: 1, globalPublicKey: new Uint8Array(), threshold: 3,
+      } as any);
+      publicClient.getBlockNumber.mockResolvedValue(100n);
+      publicClient.getLogs.mockImplementation(async (params: any) => {
+        if (params.address === DKG_ADDR) {
+          return [makeRegisteredLog({ validatorAddr: VALIDATOR_A, enclaveCommKey: KEY_A, round: 1 })];
+        }
+        return [makePartialDecryptionLog({ validator: VALIDATOR_A, round: 1, pid: 1, uuid: 71 })];
+      });
+
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      try {
+        const observer = makeObserverWithComet(publicClient, "https://my-own-cometbft.example:26657");
+        const consumer = new Consumer({ network: "testnet", publicClient, walletClient, observer });
+        await consumer.collectPartials({ uuid: 71, minPartials: 1, fromBlock: 90n, timeoutMs: 5_000, pollIntervalMs: 10 });
+
+        const defaultWarnings = warnSpy.mock.calls.filter(
+          (c) => typeof c[0] === "string" && c[0].includes("default CometBFT RPC URL"),
+        );
+        expect(defaultWarnings).toHaveLength(0);
+      } finally {
+        warnSpy.mockRestore();
+      }
+    });
+
     it("hybrid mode default: no observer → SDK still consults the default CometBFT URL", async () => {
       const { publicClient, walletClient } = mockClients();
       vi.mocked(verifyPartialSignature).mockReturnValue(true);

--- a/packages/sdk/__tests__/consumer.test.ts
+++ b/packages/sdk/__tests__/consumer.test.ts
@@ -374,30 +374,42 @@ describe("Consumer", () => {
 
   it("collectPartials rejects invalid signatures and invokes callback", async () => {
     const { publicClient, walletClient } = mockClients();
+    const KEY_A = ("0x" + "aa".repeat(64)) as `0x${string}`;
+    const KEY_B = ("0x" + "bb".repeat(64)) as `0x${string}`;
     const mockVerify = vi.mocked(verifyPartialSignature);
     mockVerify.mockReset();
-    mockVerify.mockReturnValueOnce(false).mockReturnValue(true);
+    // Deterministically accept only KEY_B; accept/reject follows the key, not call
+    // order, so the one-shot refresh on verification failure (for validator A)
+    // sees the same stable map and still rejects.
+    mockVerify.mockImplementation((args: any) => {
+      const kB = toBytes(KEY_B);
+      return args.commPubKey.length === kB.length && [...args.commPubKey].every((b, i) => b === kB[i]);
+    });
 
     publicClient.getBlockNumber.mockResolvedValueOnce(100n).mockResolvedValue(101n);
 
-    publicClient.getLogs
-      .mockResolvedValueOnce([
-        makeRegisteredLog({
-          validatorAddr: "0x0000000000000000000000000000000000000001",
-          enclaveCommKey: ("0x" + "aa".repeat(64)) as `0x${string}`,
-          round: 1,
-        }),
-        makeRegisteredLog({
-          validatorAddr: "0x0000000000000000000000000000000000000002",
-          enclaveCommKey: ("0x" + "bb".repeat(64)) as `0x${string}`,
-          round: 1,
-        }),
-      ])
-      .mockResolvedValueOnce([
-        makePartialDecryptionLog({ validator: "0x0000000000000000000000000000000000000001", round: 1, pid: 1, uuid: 1 }),
-        makePartialDecryptionLog({ validator: "0x0000000000000000000000000000000000000002", round: 1, pid: 2, uuid: 1 }),
-      ])
-      .mockResolvedValue([]);
+    const dkgLogs = [
+      makeRegisteredLog({
+        validatorAddr: "0x0000000000000000000000000000000000000001",
+        enclaveCommKey: KEY_A,
+        round: 1,
+      }),
+      makeRegisteredLog({
+        validatorAddr: "0x0000000000000000000000000000000000000002",
+        enclaveCommKey: KEY_B,
+        round: 1,
+      }),
+    ];
+    let cdrPoll = 0;
+    publicClient.getLogs.mockImplementation(async (params: any) => {
+      if (params.address === "0xcccccc0000000000000000000000000000000004") return dkgLogs;
+      return cdrPoll++ === 0
+        ? [
+            makePartialDecryptionLog({ validator: "0x0000000000000000000000000000000000000001", round: 1, pid: 1, uuid: 1 }),
+            makePartialDecryptionLog({ validator: "0x0000000000000000000000000000000000000002", round: 1, pid: 2, uuid: 1 }),
+          ]
+        : [];
+    });
 
     const onInvalidPartial = vi.fn();
     const consumer = new Consumer({ network: "testnet", publicClient, walletClient });
@@ -452,30 +464,39 @@ describe("Consumer", () => {
 
   it("collectPartials silently skips invalid partials when no callback provided", async () => {
     const { publicClient, walletClient } = mockClients();
+    const KEY_A = ("0x" + "aa".repeat(64)) as `0x${string}`;
+    const KEY_B = ("0x" + "bb".repeat(64)) as `0x${string}`;
     const mockVerify = vi.mocked(verifyPartialSignature);
     mockVerify.mockReset();
-    mockVerify.mockReturnValueOnce(false).mockReturnValue(true);
+    mockVerify.mockImplementation((args: any) => {
+      const kB = toBytes(KEY_B);
+      return args.commPubKey.length === kB.length && [...args.commPubKey].every((b, i) => b === kB[i]);
+    });
 
     publicClient.getBlockNumber.mockResolvedValueOnce(100n).mockResolvedValue(101n);
 
-    publicClient.getLogs
-      .mockResolvedValueOnce([
-        makeRegisteredLog({
-          validatorAddr: "0x0000000000000000000000000000000000000001",
-          enclaveCommKey: ("0x" + "aa".repeat(64)) as `0x${string}`,
-          round: 1,
-        }),
-        makeRegisteredLog({
-          validatorAddr: "0x0000000000000000000000000000000000000002",
-          enclaveCommKey: ("0x" + "bb".repeat(64)) as `0x${string}`,
-          round: 1,
-        }),
-      ])
-      .mockResolvedValueOnce([
-        makePartialDecryptionLog({ validator: "0x0000000000000000000000000000000000000001", round: 1, pid: 1, uuid: 1 }),
-        makePartialDecryptionLog({ validator: "0x0000000000000000000000000000000000000002", round: 1, pid: 2, uuid: 1 }),
-      ])
-      .mockResolvedValue([]);
+    const dkgLogs = [
+      makeRegisteredLog({
+        validatorAddr: "0x0000000000000000000000000000000000000001",
+        enclaveCommKey: KEY_A,
+        round: 1,
+      }),
+      makeRegisteredLog({
+        validatorAddr: "0x0000000000000000000000000000000000000002",
+        enclaveCommKey: KEY_B,
+        round: 1,
+      }),
+    ];
+    let cdrPoll = 0;
+    publicClient.getLogs.mockImplementation(async (params: any) => {
+      if (params.address === "0xcccccc0000000000000000000000000000000004") return dkgLogs;
+      return cdrPoll++ === 0
+        ? [
+            makePartialDecryptionLog({ validator: "0x0000000000000000000000000000000000000001", round: 1, pid: 1, uuid: 1 }),
+            makePartialDecryptionLog({ validator: "0x0000000000000000000000000000000000000002", round: 1, pid: 2, uuid: 1 }),
+          ]
+        : [];
+    });
 
     const consumer = new Consumer({ network: "testnet", publicClient, walletClient });
     const partials = await consumer.collectPartials({
@@ -790,6 +811,98 @@ describe("Consumer", () => {
       // Validator B's partial was accepted after refresh.
       expect(partials).toHaveLength(1);
       expect(partials[0].validator.toLowerCase()).toBe(VALIDATOR_B.toLowerCase());
+    });
+
+    it("refreshes once when a DKG rotation leaves every cached key stale", async () => {
+      // Scenario: cache built under round 5 (KEY_A), then rotation → active round 6
+      // (KEY_A_ROUND6). Partial comes in signed under round 6. The pre-fix code only
+      // refreshed when a validator was absent from the map, so stale-but-present keys
+      // silently dropped every partial. With the fix, verification failure against
+      // cached keys triggers a one-shot refresh, after which the round-6 key matches.
+      const { publicClient, walletClient } = mockClients();
+      publicClient.getBlockNumber.mockResolvedValue(100n);
+
+      // ABCI reports round 5 on first build, round 6 on refresh.
+      vi.mocked(queryLatestActiveDKGNetwork)
+        .mockResolvedValueOnce({ round: 5, globalPublicKey: new Uint8Array(), threshold: 3 } as any)
+        .mockResolvedValue({ round: 6, globalPublicKey: new Uint8Array(), threshold: 3 } as any);
+
+      let dkgScanNo = 0;
+      publicClient.getLogs.mockImplementation(async (params: any) => {
+        if (params.address === DKG_ADDR) {
+          dkgScanNo++;
+          // First scan: only the round-5 registration is returned (hybrid filter keeps it).
+          // Second scan (refresh): chain now shows both rounds; hybrid filter keeps only round-6.
+          return dkgScanNo === 1
+            ? [makeRegisteredLog({ validatorAddr: VALIDATOR_A, enclaveCommKey: KEY_A, round: 5 })]
+            : [
+                makeRegisteredLog({ validatorAddr: VALIDATOR_A, enclaveCommKey: KEY_A, round: 5 }),
+                makeRegisteredLog({ validatorAddr: VALIDATOR_A, enclaveCommKey: KEY_A_ROUND6, round: 6 }),
+              ];
+        }
+        return [makePartialDecryptionLog({ validator: VALIDATOR_A, round: 6, pid: 1, uuid: 60 })];
+      });
+
+      // verifyPartialSignature returns true only for the round-6 key; false for anything else.
+      vi.mocked(verifyPartialSignature).mockImplementation((args: any) => {
+        const round6 = toBytes(KEY_A_ROUND6);
+        return args.commPubKey.length === round6.length &&
+          [...args.commPubKey].every((b, i) => b === round6[i]);
+      });
+
+      const observer = makeObserverWithComet(publicClient, "http://abci-mock:26657");
+      const consumer = new Consumer({ network: "testnet", publicClient, walletClient, observer });
+
+      const partials = await consumer.collectPartials({
+        uuid: 60,
+        minPartials: 1,
+        fromBlock: 90n,
+        timeoutMs: 5_000,
+        pollIntervalMs: 10,
+      });
+
+      // Refresh happened exactly once; partial accepted after refresh.
+      expect(dkgScanNo).toBe(2);
+      expect(partials).toHaveLength(1);
+    });
+
+    it("does not re-refresh for the same validator on repeated verification failure", async () => {
+      // Three partials from the same validator, all fail signature. The first failure
+      // triggers a refresh; the next two must reuse the refreshed cache without
+      // kicking off another full-history scan (refreshedFor deduplication).
+      const { publicClient, walletClient } = mockClients();
+      publicClient.getBlockNumber.mockResolvedValue(100n);
+      vi.mocked(verifyPartialSignature).mockReturnValue(false);
+
+      let dkgScanNo = 0;
+      const onInvalidPartial = vi.fn();
+      publicClient.getLogs.mockImplementation(async (params: any) => {
+        if (params.address === DKG_ADDR) {
+          dkgScanNo++;
+          return [makeRegisteredLog({ validatorAddr: VALIDATOR_A, enclaveCommKey: KEY_A, round: 1 })];
+        }
+        return [
+          makePartialDecryptionLog({ validator: VALIDATOR_A, round: 1, pid: 1, uuid: 61 }),
+          makePartialDecryptionLog({ validator: VALIDATOR_A, round: 1, pid: 2, uuid: 61 }),
+          makePartialDecryptionLog({ validator: VALIDATOR_A, round: 1, pid: 3, uuid: 61 }),
+        ];
+      });
+
+      const consumer = new Consumer({ network: "testnet", publicClient, walletClient });
+      await expect(
+        consumer.collectPartials({
+          uuid: 61,
+          minPartials: 1,
+          fromBlock: 90n,
+          timeoutMs: 300,
+          pollIntervalMs: 50,
+          onInvalidPartial,
+        }),
+      ).rejects.toThrow();
+
+      // Initial build + 1 refresh (triggered by first failed verify). Not 4.
+      expect(dkgScanNo).toBe(2);
+      expect(onInvalidPartial.mock.calls.length).toBeGreaterThanOrEqual(3);
     });
 
     it("does not re-refresh for the same unknown validator within one call", async () => {

--- a/packages/sdk/__tests__/consumer.test.ts
+++ b/packages/sdk/__tests__/consumer.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { encodeAbiParameters, keccak256, toBytes, padHex } from "viem";
 
 // Mock @piplabs/cdr-crypto before importing Consumer so the WASM loader is never executed.
@@ -8,8 +8,17 @@ vi.mock("@piplabs/cdr-crypto", () => ({
   verifyPartialSignature: vi.fn(),
 }));
 
+// Mock the cosmos ABCI query so the hybrid path is exercised without a live RPC.
+vi.mock("../src/cosmos/abci-query.js", () => ({
+  queryCDRPartials: vi.fn(),
+  queryLatestActiveDKGNetwork: vi.fn(),
+  queryVerifiedRegistrations: vi.fn(),
+}));
+
 import { Consumer } from "../src/consumer.js";
+import { Observer } from "../src/observer.js";
 import { verifyPartialSignature } from "@piplabs/cdr-crypto";
+import { queryLatestActiveDKGNetwork } from "../src/cosmos/abci-query.js";
 
 function makePartialDecryptionLog(opts: {
   validator: `0x${string}`;
@@ -482,12 +491,36 @@ describe("Consumer", () => {
   });
 
   describe("commPubKey map caching and chunked scan", () => {
+    // Reset the ABCI mock between tests so state from one hybrid-mode test
+    // (e.g. mockRejectedValue) doesn't leak into the next and hang it.
+    // Default behavior: reject so non-hybrid tests don't accidentally hit a
+    // live mock — they should continue working via the ABCI-failure fallback.
+    beforeEach(() => {
+      vi.mocked(queryLatestActiveDKGNetwork).mockReset();
+      vi.mocked(queryLatestActiveDKGNetwork).mockRejectedValue(
+        new Error("ABCI not mocked for this test — fallback expected"),
+      );
+    });
+
     const DKG_ADDR = "0xcccccc0000000000000000000000000000000004";
     const CDR_ADDR = "0xcccccc0000000000000000000000000000000005";
     const VALIDATOR_A = "0x0000000000000000000000000000000000000001" as `0x${string}`;
     const VALIDATOR_B = "0x0000000000000000000000000000000000000002" as `0x${string}`;
     const KEY_A = ("0x" + "aa".repeat(64)) as `0x${string}`;
     const KEY_B = ("0x" + "bb".repeat(64)) as `0x${string}`;
+    const KEY_A_ROUND6 = ("0x" + "a6".repeat(64)) as `0x${string}`;
+
+    function makeObserverWithComet(publicClient: any, cometRpcUrl: string): Observer {
+      // Observer constructor requires cometRpcUrl only when dkgSource === "cosmos-abci".
+      // We pass "evm-events" here so the Observer itself stays on EVM but still carries
+      // a non-empty cometRpcUrl that the Consumer's hybrid path can pick up.
+      return new Observer({
+        network: "testnet",
+        publicClient: publicClient as any,
+        dkgSource: "evm-events",
+        cometRpcUrl,
+      });
+    }
 
     /** Count how many times publicClient.getLogs was called against the DKG contract. */
     function dkgScanCount(publicClient: any): number {
@@ -543,6 +576,135 @@ describe("Consumer", () => {
       ]);
 
       expect(dkgCallCount).toBe(1);
+    });
+
+    it("hybrid mode: queries ABCI for active round and filters Registered events to that round", async () => {
+      const { publicClient, walletClient } = mockClients();
+      vi.mocked(verifyPartialSignature).mockReturnValue(true);
+      vi.mocked(queryLatestActiveDKGNetwork).mockClear();
+      publicClient.getBlockNumber.mockResolvedValue(1_000_000n);
+
+      // ABCI says active round is 6.
+      vi.mocked(queryLatestActiveDKGNetwork).mockResolvedValue({
+        round: 6,
+        globalPublicKey: new Uint8Array(),
+        threshold: 3,
+      } as any);
+
+      const dkgRegistered = [
+        // Round 5 registrations (should be filtered out in hybrid mode).
+        makeRegisteredLog({ validatorAddr: VALIDATOR_A, enclaveCommKey: KEY_A, round: 5 }),
+        makeRegisteredLog({ validatorAddr: VALIDATOR_B, enclaveCommKey: KEY_B, round: 5 }),
+        // Round 6 registrations (active — these should be kept).
+        makeRegisteredLog({ validatorAddr: VALIDATOR_A, enclaveCommKey: KEY_A_ROUND6, round: 6 }),
+      ];
+      publicClient.getLogs.mockImplementation(async (params: any) => {
+        if (params.address === DKG_ADDR) return dkgRegistered;
+        // Partial signed under round 6 (matches active) — verify path runs through the map.
+        return [makePartialDecryptionLog({ validator: VALIDATOR_A, round: 6, pid: 1, uuid: 100 })];
+      });
+
+      const observer = makeObserverWithComet(publicClient, "http://172.192.41.96:26657");
+      const consumer = new Consumer({ network: "testnet", publicClient, walletClient, observer });
+
+      const partials = await consumer.collectPartials({
+        uuid: 100,
+        minPartials: 1,
+        fromBlock: 990_000n,
+        timeoutMs: 2_000,
+        pollIntervalMs: 10,
+      });
+
+      // ABCI was consulted exactly once per cache build.
+      expect(queryLatestActiveDKGNetwork).toHaveBeenCalledTimes(1);
+      expect(queryLatestActiveDKGNetwork).toHaveBeenCalledWith("http://172.192.41.96:26657");
+      // Partial from round 6 was accepted (signature mock returns true).
+      expect(partials).toHaveLength(1);
+      // verifyPartialSignature was called with the ROUND 6 key only.
+      const verifyCall = vi.mocked(verifyPartialSignature).mock.calls.find(
+        (c: any[]) => c[0].round === 6,
+      );
+      expect(verifyCall).toBeDefined();
+      // The commPubKey passed in must equal the round-6 key, not the round-5 one.
+      const passedKey = verifyCall![0].commPubKey;
+      const round6Bytes = toBytes(KEY_A_ROUND6);
+      expect(passedKey.length).toBe(round6Bytes.length);
+      expect([...passedKey]).toEqual([...round6Bytes]);
+    });
+
+    it("hybrid mode: when ABCI query fails, falls back to keeping all rounds (graceful degradation)", async () => {
+      const { publicClient, walletClient } = mockClients();
+      vi.mocked(verifyPartialSignature).mockReturnValue(true);
+      publicClient.getBlockNumber.mockResolvedValue(1_000_000n);
+
+      // ABCI rejects — hybrid path should swallow the error and scan without filtering.
+      vi.mocked(queryLatestActiveDKGNetwork).mockRejectedValue(new Error("ABCI unavailable"));
+
+      publicClient.getLogs.mockImplementation(async (params: any) => {
+        if (params.address === DKG_ADDR) {
+          return [
+            makeRegisteredLog({ validatorAddr: VALIDATOR_A, enclaveCommKey: KEY_A, round: 5 }),
+            makeRegisteredLog({ validatorAddr: VALIDATOR_A, enclaveCommKey: KEY_A_ROUND6, round: 6 }),
+          ];
+        }
+        return [makePartialDecryptionLog({ validator: VALIDATOR_A, round: 5, pid: 1, uuid: 101 })];
+      });
+
+      const observer = makeObserverWithComet(publicClient, "http://bad-host:26657");
+      const consumer = new Consumer({ network: "testnet", publicClient, walletClient, observer });
+
+      const partials = await consumer.collectPartials({
+        uuid: 101,
+        minPartials: 1,
+        fromBlock: 990_000n,
+        timeoutMs: 2_000,
+        pollIntervalMs: 10,
+      });
+
+      // Even though ABCI failed, the partial (round 5) still verifies because we kept
+      // both rounds' keys — the verify loop finds the round-5 match.
+      expect(partials).toHaveLength(1);
+    });
+
+    it("hybrid mode default: no observer → SDK still consults the default CometBFT URL", async () => {
+      const { publicClient, walletClient } = mockClients();
+      vi.mocked(verifyPartialSignature).mockReturnValue(true);
+      vi.mocked(queryLatestActiveDKGNetwork).mockClear();
+      // Default ABCI URL is reachable and reports active round = 6.
+      vi.mocked(queryLatestActiveDKGNetwork).mockResolvedValue({
+        round: 6,
+        globalPublicKey: new Uint8Array(),
+        threshold: 3,
+      } as any);
+      publicClient.getBlockNumber.mockResolvedValue(1_000_000n);
+
+      publicClient.getLogs.mockImplementation(async (params: any) => {
+        if (params.address === DKG_ADDR) {
+          return [
+            makeRegisteredLog({ validatorAddr: VALIDATOR_A, enclaveCommKey: KEY_A, round: 5 }),
+            makeRegisteredLog({ validatorAddr: VALIDATOR_A, enclaveCommKey: KEY_A_ROUND6, round: 6 }),
+          ];
+        }
+        return [makePartialDecryptionLog({ validator: VALIDATOR_A, round: 6, pid: 1, uuid: 102 })];
+      });
+
+      // No observer passed — SDK should fall back to the hardcoded default URL.
+      const consumer = new Consumer({ network: "testnet", publicClient, walletClient });
+
+      const partials = await consumer.collectPartials({
+        uuid: 102,
+        minPartials: 1,
+        fromBlock: 990_000n,
+        timeoutMs: 2_000,
+        pollIntervalMs: 10,
+      });
+
+      // ABCI was consulted once using the SDK's default URL (not user-supplied).
+      expect(queryLatestActiveDKGNetwork).toHaveBeenCalledTimes(1);
+      expect(queryLatestActiveDKGNetwork).toHaveBeenCalledWith(
+        "http://172.192.41.96:26657",
+      );
+      expect(partials).toHaveLength(1);
     });
 
     it("reuses the cached commPubKey map across back-to-back collectPartials calls", async () => {
@@ -670,12 +832,17 @@ describe("Consumer", () => {
       expect(onInvalidPartial.mock.calls.length).toBeGreaterThanOrEqual(3);
     });
 
-    it("scans DKG history in contiguous non-overlapping chunks covering [0, latestBlock]", async () => {
+    it("scans DKG history in contiguous non-overlapping chunks covering [latestBlock - lookback, latestBlock]", async () => {
+      // Must mirror Consumer.DKG_LOOKBACK_BLOCKS. Kept as a local const so the
+      // three assertions below read from one source of truth.
+      const LOOKBACK = 432_000n;
+      // Any value > LOOKBACK exercises the main path (no clamp-to-0).
+      const LATEST = 17_300_000n;
+      const EXPECTED_START = LATEST - LOOKBACK;
+
       const { publicClient, walletClient } = mockClients();
       vi.mocked(verifyPartialSignature).mockReturnValue(true);
-
-      // latestBlock = 1_250_000 → 3 chunks of size 500_000: [0,500000], [500001,1000001], [1000002,1250000]
-      publicClient.getBlockNumber.mockResolvedValue(1_250_000n);
+      publicClient.getBlockNumber.mockResolvedValue(LATEST);
 
       const chunks: { from: bigint; to: bigint }[] = [];
       publicClient.getLogs.mockImplementation(async (params: any) => {
@@ -693,25 +860,21 @@ describe("Consumer", () => {
         consumer.collectPartials({
           uuid: 9,
           minPartials: 1,
-          fromBlock: 1_250_000n,
+          fromBlock: LATEST,
           timeoutMs: 200,
           pollIntervalMs: 50,
         }),
       ).rejects.toThrow();
 
-      // Verify contiguity: each chunk starts exactly one past the previous end,
-      // and the final chunk reaches latestBlock. Count accounts for both the
-      // initial build and the one-shot refresh triggered by the unknown validator,
-      // so we expect 6 total chunk calls (3 per scan × 2 scans).
-      expect(chunks.length).toBe(6);
+      // LOOKBACK < DKG_LOGS_BLOCK_CHUNK (500_000n) → single chunk per scan.
+      // Initial build (1) + one-shot refresh on unknown validator (1) = 2 calls.
+      expect(chunks.length).toBe(2);
 
-      const firstBuild = chunks.slice(0, 3);
-      expect(firstBuild[0].from).toBe(0n);
-      expect(firstBuild[0].to).toBe(500_000n);
-      expect(firstBuild[1].from).toBe(500_001n);
-      expect(firstBuild[1].to).toBe(1_000_001n);
-      expect(firstBuild[2].from).toBe(1_000_002n);
-      expect(firstBuild[2].to).toBe(1_250_000n);
+      // Both calls must cover exactly [LATEST - LOOKBACK, LATEST].
+      for (const c of chunks) {
+        expect(c.from).toBe(EXPECTED_START);
+        expect(c.to).toBe(LATEST);
+      }
     });
 
     it("deduplicates concurrent cache builds — only one scan runs", async () => {

--- a/packages/sdk/__tests__/consumer.test.ts
+++ b/packages/sdk/__tests__/consumer.test.ts
@@ -480,4 +480,307 @@ describe("Consumer", () => {
     expect(partials).toHaveLength(1);
     expect(partials[0].pid).toBe(2);
   });
+
+  describe("commPubKey map caching and chunked scan", () => {
+    const DKG_ADDR = "0xcccccc0000000000000000000000000000000004";
+    const CDR_ADDR = "0xcccccc0000000000000000000000000000000005";
+    const VALIDATOR_A = "0x0000000000000000000000000000000000000001" as `0x${string}`;
+    const VALIDATOR_B = "0x0000000000000000000000000000000000000002" as `0x${string}`;
+    const KEY_A = ("0x" + "aa".repeat(64)) as `0x${string}`;
+    const KEY_B = ("0x" + "bb".repeat(64)) as `0x${string}`;
+
+    /** Count how many times publicClient.getLogs was called against the DKG contract. */
+    function dkgScanCount(publicClient: any): number {
+      return publicClient.getLogs.mock.calls.filter(
+        (c: any[]) => c[0].address === DKG_ADDR,
+      ).length;
+    }
+
+    it("reuses the cached commPubKey map across back-to-back collectPartials calls", async () => {
+      const { publicClient, walletClient } = mockClients();
+      vi.mocked(verifyPartialSignature).mockReturnValue(true);
+
+      // Chain head stays at 100 so DKG scan is a single chunk.
+      publicClient.getBlockNumber.mockResolvedValue(100n);
+
+      // DKG scan response (call 1, shared by both collectPartials invocations)
+      const dkgRegistered = [
+        makeRegisteredLog({ validatorAddr: VALIDATOR_A, enclaveCommKey: KEY_A, round: 1 }),
+      ];
+      // Each collectPartials call: 1 DKG scan (only on first) + CDR polls
+      publicClient.getLogs.mockImplementation(async (params: any) => {
+        if (params.address === DKG_ADDR) return dkgRegistered;
+        // CDR: return one matching partial per uuid
+        const uuidFromCall = (publicClient.getLogs as any).mock.calls.length;
+        return [
+          makePartialDecryptionLog({
+            validator: VALIDATOR_A,
+            round: 1,
+            pid: 1,
+            uuid: uuidFromCall < 3 ? 10 : 11,
+          }),
+        ];
+      });
+
+      const consumer = new Consumer({ network: "testnet", publicClient, walletClient });
+
+      await consumer.collectPartials({
+        uuid: 10,
+        minPartials: 1,
+        fromBlock: 90n,
+        timeoutMs: 5_000,
+        pollIntervalMs: 10,
+      });
+      expect(dkgScanCount(publicClient)).toBe(1);
+
+      await consumer.collectPartials({
+        uuid: 11,
+        minPartials: 1,
+        fromBlock: 90n,
+        timeoutMs: 5_000,
+        pollIntervalMs: 10,
+      });
+      // Still 1 — cache hit on second call.
+      expect(dkgScanCount(publicClient)).toBe(1);
+    });
+
+    it("refreshes the cache once when a partial from an unknown validator appears", async () => {
+      const { publicClient, walletClient } = mockClients();
+      vi.mocked(verifyPartialSignature).mockReturnValue(true);
+      publicClient.getBlockNumber.mockResolvedValue(100n);
+
+      let dkgCallCount = 0;
+      publicClient.getLogs.mockImplementation(async (params: any) => {
+        if (params.address === DKG_ADDR) {
+          dkgCallCount++;
+          // First scan: only validator A. Second scan (refresh): also validator B.
+          return dkgCallCount === 1
+            ? [makeRegisteredLog({ validatorAddr: VALIDATOR_A, enclaveCommKey: KEY_A, round: 1 })]
+            : [
+                makeRegisteredLog({ validatorAddr: VALIDATOR_A, enclaveCommKey: KEY_A, round: 1 }),
+                makeRegisteredLog({ validatorAddr: VALIDATOR_B, enclaveCommKey: KEY_B, round: 1 }),
+              ];
+        }
+        // CDR scan: partial from validator B (unknown on first DKG scan).
+        return [makePartialDecryptionLog({ validator: VALIDATOR_B, round: 1, pid: 1, uuid: 7 })];
+      });
+
+      const consumer = new Consumer({ network: "testnet", publicClient, walletClient });
+      const partials = await consumer.collectPartials({
+        uuid: 7,
+        minPartials: 1,
+        fromBlock: 90n,
+        timeoutMs: 5_000,
+        pollIntervalMs: 10,
+      });
+
+      // Refresh happened exactly once.
+      expect(dkgCallCount).toBe(2);
+      // Validator B's partial was accepted after refresh.
+      expect(partials).toHaveLength(1);
+      expect(partials[0].validator.toLowerCase()).toBe(VALIDATOR_B.toLowerCase());
+    });
+
+    it("does not re-refresh for the same unknown validator within one call", async () => {
+      const { publicClient, walletClient } = mockClients();
+      vi.mocked(verifyPartialSignature).mockReturnValue(true);
+      publicClient.getBlockNumber.mockResolvedValue(100n);
+
+      let dkgCallCount = 0;
+      const onInvalidPartial = vi.fn();
+
+      publicClient.getLogs.mockImplementation(async (params: any) => {
+        if (params.address === DKG_ADDR) {
+          dkgCallCount++;
+          // Validator B never appears — refresh cannot add it.
+          return [makeRegisteredLog({ validatorAddr: VALIDATOR_A, enclaveCommKey: KEY_A, round: 1 })];
+        }
+        // Three partials from the same unknown validator B.
+        return [
+          makePartialDecryptionLog({ validator: VALIDATOR_B, round: 1, pid: 1, uuid: 8 }),
+          makePartialDecryptionLog({ validator: VALIDATOR_B, round: 1, pid: 2, uuid: 8 }),
+          makePartialDecryptionLog({ validator: VALIDATOR_B, round: 1, pid: 3, uuid: 8 }),
+        ];
+      });
+
+      const consumer = new Consumer({ network: "testnet", publicClient, walletClient });
+      await expect(
+        consumer.collectPartials({
+          uuid: 8,
+          minPartials: 1,
+          fromBlock: 90n,
+          timeoutMs: 300,
+          pollIntervalMs: 50,
+          onInvalidPartial,
+        }),
+      ).rejects.toThrow();
+
+      // Exactly one refresh attempted (initial + 1), not three.
+      expect(dkgCallCount).toBe(2);
+      // All three partials reported as unknown validator.
+      expect(onInvalidPartial.mock.calls.length).toBeGreaterThanOrEqual(3);
+    });
+
+    it("scans DKG history in contiguous non-overlapping chunks covering [0, latestBlock]", async () => {
+      const { publicClient, walletClient } = mockClients();
+      vi.mocked(verifyPartialSignature).mockReturnValue(true);
+
+      // latestBlock = 1_250_000 → 3 chunks of size 500_000: [0,500000], [500001,1000001], [1000002,1250000]
+      publicClient.getBlockNumber.mockResolvedValue(1_250_000n);
+
+      const chunks: { from: bigint; to: bigint }[] = [];
+      publicClient.getLogs.mockImplementation(async (params: any) => {
+        if (params.address === DKG_ADDR) {
+          chunks.push({ from: params.fromBlock, to: params.toBlock });
+          return [];
+        }
+        return [makePartialDecryptionLog({ validator: VALIDATOR_A, round: 1, pid: 1, uuid: 9 })];
+      });
+
+      const consumer = new Consumer({ network: "testnet", publicClient, walletClient });
+      // Force cache build by invoking the flow; collectPartials will throw since
+      // validator A isn't registered, but we only care about chunk coverage.
+      await expect(
+        consumer.collectPartials({
+          uuid: 9,
+          minPartials: 1,
+          fromBlock: 1_250_000n,
+          timeoutMs: 200,
+          pollIntervalMs: 50,
+        }),
+      ).rejects.toThrow();
+
+      // Verify contiguity: each chunk starts exactly one past the previous end,
+      // and the final chunk reaches latestBlock. Count accounts for both the
+      // initial build and the one-shot refresh triggered by the unknown validator,
+      // so we expect 6 total chunk calls (3 per scan × 2 scans).
+      expect(chunks.length).toBe(6);
+
+      const firstBuild = chunks.slice(0, 3);
+      expect(firstBuild[0].from).toBe(0n);
+      expect(firstBuild[0].to).toBe(500_000n);
+      expect(firstBuild[1].from).toBe(500_001n);
+      expect(firstBuild[1].to).toBe(1_000_001n);
+      expect(firstBuild[2].from).toBe(1_000_002n);
+      expect(firstBuild[2].to).toBe(1_250_000n);
+    });
+
+    it("deduplicates concurrent cache builds — only one scan runs", async () => {
+      const { publicClient, walletClient } = mockClients();
+      vi.mocked(verifyPartialSignature).mockReturnValue(true);
+      publicClient.getBlockNumber.mockResolvedValue(100n);
+
+      let dkgCallCount = 0;
+      publicClient.getLogs.mockImplementation(async (params: any) => {
+        if (params.address === DKG_ADDR) {
+          dkgCallCount++;
+          // Simulate a slow scan so a concurrent caller arrives during the in-flight build.
+          await new Promise((r) => setTimeout(r, 50));
+          return [makeRegisteredLog({ validatorAddr: VALIDATOR_A, enclaveCommKey: KEY_A, round: 1 })];
+        }
+        return [makePartialDecryptionLog({ validator: VALIDATOR_A, round: 1, pid: 1, uuid: 20 })];
+      });
+
+      const consumer = new Consumer({ network: "testnet", publicClient, walletClient });
+      // Fire two collectPartials concurrently — both should observe one build.
+      await Promise.all([
+        consumer.collectPartials({ uuid: 20, minPartials: 1, fromBlock: 90n, timeoutMs: 5_000, pollIntervalMs: 10 }),
+        consumer.collectPartials({ uuid: 20, minPartials: 1, fromBlock: 90n, timeoutMs: 5_000, pollIntervalMs: 10 }),
+      ]);
+
+      expect(dkgCallCount).toBe(1);
+    });
+
+    it("retries a failing chunk with exponential backoff and succeeds on second attempt", async () => {
+      const { publicClient, walletClient } = mockClients();
+      vi.mocked(verifyPartialSignature).mockReturnValue(true);
+      publicClient.getBlockNumber.mockResolvedValue(100n);
+
+      let dkgAttempt = 0;
+      publicClient.getLogs.mockImplementation(async (params: any) => {
+        if (params.address === DKG_ADDR) {
+          dkgAttempt++;
+          if (dkgAttempt === 1) {
+            throw new Error("invalid block range params");
+          }
+          return [makeRegisteredLog({ validatorAddr: VALIDATOR_A, enclaveCommKey: KEY_A, round: 1 })];
+        }
+        return [makePartialDecryptionLog({ validator: VALIDATOR_A, round: 1, pid: 1, uuid: 30 })];
+      });
+
+      const consumer = new Consumer({ network: "testnet", publicClient, walletClient });
+      const partials = await consumer.collectPartials({
+        uuid: 30,
+        minPartials: 1,
+        fromBlock: 90n,
+        timeoutMs: 5_000,
+        pollIntervalMs: 10,
+      });
+
+      expect(dkgAttempt).toBe(2);
+      expect(partials).toHaveLength(1);
+    });
+
+    it("propagates the error after exhausting getLogs retries", async () => {
+      const { publicClient, walletClient } = mockClients();
+      publicClient.getBlockNumber.mockResolvedValue(100n);
+
+      publicClient.getLogs.mockRejectedValue(new Error("persistent RPC failure"));
+
+      const consumer = new Consumer({ network: "testnet", publicClient, walletClient });
+      await expect(
+        consumer.collectPartials({
+          uuid: 40,
+          minPartials: 1,
+          fromBlock: 90n,
+          timeoutMs: 5_000,
+          pollIntervalMs: 10,
+        }),
+      ).rejects.toThrow("persistent RPC failure");
+
+      // 3 attempts (MAX_ATTEMPTS) for the first chunk, then give up.
+      expect(publicClient.getLogs.mock.calls.length).toBe(3);
+    });
+
+    it("clears the cached promise on build failure so the next call retries from scratch", async () => {
+      const { publicClient, walletClient } = mockClients();
+      vi.mocked(verifyPartialSignature).mockReturnValue(true);
+      publicClient.getBlockNumber.mockResolvedValue(100n);
+
+      let callCount = 0;
+      publicClient.getLogs.mockImplementation(async (params: any) => {
+        if (params.address === DKG_ADDR) {
+          callCount++;
+          // First build: fail every retry. Second build: succeed immediately.
+          if (callCount <= 3) throw new Error("transient failure");
+          return [makeRegisteredLog({ validatorAddr: VALIDATOR_A, enclaveCommKey: KEY_A, round: 1 })];
+        }
+        return [makePartialDecryptionLog({ validator: VALIDATOR_A, round: 1, pid: 1, uuid: 50 })];
+      });
+
+      const consumer = new Consumer({ network: "testnet", publicClient, walletClient });
+
+      await expect(
+        consumer.collectPartials({
+          uuid: 50,
+          minPartials: 1,
+          fromBlock: 90n,
+          timeoutMs: 5_000,
+          pollIntervalMs: 10,
+        }),
+      ).rejects.toThrow();
+
+      // Second call must trigger a fresh build (not return the cached rejection).
+      const partials = await consumer.collectPartials({
+        uuid: 50,
+        minPartials: 1,
+        fromBlock: 90n,
+        timeoutMs: 5_000,
+        pollIntervalMs: 10,
+      });
+      expect(partials).toHaveLength(1);
+      // First build attempted 3 retries; second build succeeded on attempt 1. Total DKG calls = 4.
+      expect(callCount).toBe(4);
+    });
+  });
 });

--- a/packages/sdk/src/consumer.ts
+++ b/packages/sdk/src/consumer.ts
@@ -16,6 +16,15 @@ export class Consumer {
   private network: Network;
   private observer: Observer | null;
 
+  /**
+   * Cached validator → commPubKey[] map. Built on first use and kept for the
+   * Consumer instance's lifetime. Registered events are immutable, so the
+   * only staleness risk is a new validator registering after the cache was
+   * built; that surfaces as "unknown validator" during verify, which triggers
+   * an automatic one-shot refresh (see collectPartialsFromEvents).
+   */
+  private commPubKeyMapCache: Map<string, Uint8Array[]> | null = null;
+
   /** Alias for {@link accessCDR} */
   readVault: Consumer["accessCDR"];
   /** Alias for {@link downloadFile} */
@@ -90,9 +99,17 @@ export class Consumer {
   /** Chunk size for historical getLogs scans. Kept well below typical RPC block-range limits. */
   private static readonly DKG_LOGS_BLOCK_CHUNK = 500_000n;
 
-  private async getCommPubKeyMap(): Promise<Map<string, Uint8Array[]>> {
+  /**
+   * Return the cached commPubKey map, building it on first call or when
+   * {@link forceRefresh} is true. Safe to call repeatedly.
+   */
+  private async getCommPubKeyMap(forceRefresh = false): Promise<Map<string, Uint8Array[]>> {
+    if (!forceRefresh && this.commPubKeyMapCache) {
+      return this.commPubKeyMapCache;
+    }
     const dkgAddress = contractAddresses[this.network].dkg;
-    return this.fetchRegisteredValidators(dkgAddress);
+    this.commPubKeyMapCache = await this.fetchRegisteredValidators(dkgAddress);
+    return this.commPubKeyMapCache;
   }
 
   private async fetchRegisteredValidators(
@@ -185,8 +202,11 @@ export class Consumer {
     const cdrAddress = contractAddresses[this.network].cdr;
     const deadline = Date.now() + timeoutMs;
 
-    // Build commPubKey map from DKG Registered events
-    const commPubKeyMap = await this.getCommPubKeyMap();
+    // Build commPubKey map from DKG Registered events (cached across calls).
+    let commPubKeyMap = await this.getCommPubKeyMap();
+    // Track which validators have already triggered a cache refresh this call,
+    // so a genuinely unknown validator can't force repeated re-scans.
+    const refreshedFor = new Set<string>();
 
     let lastScannedBlock = fromBlock;
     const collected = new Map<string, PartialDecryptionEvent>();
@@ -226,7 +246,15 @@ export class Consumer {
               // Verify signature — try all known commPubKeys for this validator
               // (DKG round rotation may cause the signing key to differ from the latest registration)
               const validatorAddr = log.args.validator.toLowerCase();
-              const commPubKeys = commPubKeyMap.get(validatorAddr);
+              let commPubKeys = commPubKeyMap.get(validatorAddr);
+
+              // Cache may be stale if a new validator registered after we
+              // built the map. Refresh once per unknown validator per call.
+              if ((!commPubKeys || commPubKeys.length === 0) && !refreshedFor.has(validatorAddr)) {
+                refreshedFor.add(validatorAddr);
+                commPubKeyMap = await this.getCommPubKeyMap(true);
+                commPubKeys = commPubKeyMap.get(validatorAddr);
+              }
 
               if (!commPubKeys || commPubKeys.length === 0) {
                 onInvalidPartial?.(event, new Error(`unknown validator: ${log.args.validator}`));

--- a/packages/sdk/src/consumer.ts
+++ b/packages/sdk/src/consumer.ts
@@ -347,40 +347,49 @@ export class Consumer {
                 signature: log.args.signature,
               };
 
-              // Verify signature — try all known commPubKeys for this validator
-              // (DKG round rotation may cause the signing key to differ from the latest registration)
+              // Verify signature — try all known commPubKeys for this validator.
+              // In hybrid mode the cached map holds only the active-round keys,
+              // so a DKG rotation that happens after the cache is built leaves
+              // every validator with stale (old-round) keys. Refreshing on any
+              // verification failure — not just on an absent validator — lets
+              // the next round's partials recover without a process restart.
               const validatorAddr = log.args.validator.toLowerCase();
               let commPubKeys = commPubKeyMap.get(validatorAddr);
 
-              // Cache may be stale if a new validator registered after we
-              // built the map. Refresh once per unknown validator per call.
-              if ((!commPubKeys || commPubKeys.length === 0) && !refreshedFor.has(validatorAddr)) {
+              const tryVerifyWith = (keys: Uint8Array[] | undefined): boolean => {
+                if (!keys || keys.length === 0) return false;
+                for (let ki = keys.length - 1; ki >= 0; ki--) {
+                  if (verifyPartialSignature({
+                    round: event.round,
+                    ciphertext: toBytes(log.args.ciphertext),
+                    encryptedPartial: toBytes(event.encryptedPartial),
+                    ephemeralPubKey: toBytes(event.ephemeralPubKey),
+                    pubShare: toBytes(event.pubShare),
+                    signature: toBytes(log.args.signature),
+                    commPubKey: keys[ki],
+                  })) return true;
+                }
+                return false;
+              };
+
+              let valid = tryVerifyWith(commPubKeys);
+
+              // Refresh the cache once per validator per call on any verification
+              // failure (unknown validator OR all cached keys fail). Deduped by
+              // validator address so a genuinely bad signer can't force repeated
+              // full-history rescans within a single collectPartials invocation.
+              if (!valid && !refreshedFor.has(validatorAddr)) {
                 refreshedFor.add(validatorAddr);
                 commPubKeyMap = await this.getCommPubKeyMap(true);
                 commPubKeys = commPubKeyMap.get(validatorAddr);
-              }
-
-              if (!commPubKeys || commPubKeys.length === 0) {
-                onInvalidPartial?.(event, new Error(`unknown validator: ${log.args.validator}`));
-                continue;
-              }
-
-              let valid = false;
-              for (let ki = commPubKeys.length - 1; ki >= 0; ki--) {
-                valid = verifyPartialSignature({
-                  round: event.round,
-                  ciphertext: toBytes(log.args.ciphertext),
-                  encryptedPartial: toBytes(event.encryptedPartial),
-                  ephemeralPubKey: toBytes(event.ephemeralPubKey),
-                  pubShare: toBytes(event.pubShare),
-                  signature: toBytes(log.args.signature),
-                  commPubKey: commPubKeys[ki],
-                });
-                if (valid) break;
+                valid = tryVerifyWith(commPubKeys);
               }
 
               if (!valid) {
-                onInvalidPartial?.(event, new Error(`invalid signature from validator ${log.args.validator}`));
+                const reason = (!commPubKeys || commPubKeys.length === 0)
+                  ? `unknown validator: ${log.args.validator}`
+                  : `invalid signature from validator ${log.args.validator}`;
+                onInvalidPartial?.(event, new Error(reason));
                 continue;
               }
 

--- a/packages/sdk/src/consumer.ts
+++ b/packages/sdk/src/consumer.ts
@@ -351,11 +351,12 @@ export class Consumer {
     while (Date.now() < deadline) {
       const currentBlock = await this.publicClient.getBlockNumber();
       if (currentBlock >= lastScannedBlock) {
-        const rawLogs = await this.publicClient.getLogs({
-          address: cdrAddress,
-          fromBlock: lastScannedBlock,
-          toBlock: currentBlock,
-        });
+        // Same retry wrapper used for the DKG scan: public RPCs (notably
+        // aeneid.storyrpc.io) occasionally return "invalid block range params"
+        // for tiny ranges — a transient error we should not let surface as an
+        // accessCDR failure in the middle of the poll loop. See PERF-05 flake
+        // observed in https://github.com/piplabs/story-cdr-e2e/actions/runs/24884251274.
+        const rawLogs = await this.getLogsWithRetry(cdrAddress, lastScannedBlock, currentBlock);
         lastScannedBlock = currentBlock + BigInt(1);
 
         const parsed = parseEventLogs({

--- a/packages/sdk/src/consumer.ts
+++ b/packages/sdk/src/consumer.ts
@@ -75,52 +75,54 @@ export class Consumer {
 
   /**
    * Fetch validator address → commPubKey[] map from DKG Registered events.
-   * Each validator may re-register with a new commPubKey in each DKG round,
-   * so we keep all keys (most recent first) to handle round mismatch during
-   * signature verification.
+   *
+   * Each validator may re-register with a new commPubKey in each DKG round.
+   * Partials are signed with the commPubKey active in the round that serviced
+   * the read request, which is not necessarily the most recent round. The
+   * signature-verify loop in collectPartialsFromEvents tries every key in the
+   * returned array, so we must supply keys from every historical round — a
+   * rolling lookback window can exclude the round a partial was signed under
+   * and cause every verification to fail.
+   *
+   * We therefore scan the full history from genesis using chunked getLogs
+   * calls to stay within RPC range limits.
    */
-  /** Default lookback window: ~7 days at ~2 s/block. Matches Observer.DEFAULT_LOOKBACK_BLOCKS. */
-  private static readonly DEFAULT_LOOKBACK_BLOCKS = 302_400n;
+  /** Chunk size for historical getLogs scans. Kept well below typical RPC block-range limits. */
+  private static readonly DKG_LOGS_BLOCK_CHUNK = 500_000n;
 
   private async getCommPubKeyMap(): Promise<Map<string, Uint8Array[]>> {
     const dkgAddress = contractAddresses[this.network].dkg;
-    const latestBlock = await this.publicClient.getBlockNumber();
-    const fromBlock = latestBlock > Consumer.DEFAULT_LOOKBACK_BLOCKS
-      ? latestBlock - Consumer.DEFAULT_LOOKBACK_BLOCKS
-      : 0n;
-
-    const validators = await this.fetchRegisteredValidators(dkgAddress, fromBlock);
-
-    // Fallback: if lookback window found no validators, scan from block 0
-    if (validators.size === 0 && fromBlock > 0n) {
-      return this.fetchRegisteredValidators(dkgAddress, 0n);
-    }
-
-    return validators;
+    return this.fetchRegisteredValidators(dkgAddress);
   }
 
   private async fetchRegisteredValidators(
     dkgAddress: `0x${string}`,
-    fromBlock: bigint,
   ): Promise<Map<string, Uint8Array[]>> {
-    const rawLogs = await this.publicClient.getLogs({
-      address: dkgAddress,
-      fromBlock,
-      toBlock: "latest",
-    });
-
-    const parsed = parseEventLogs({
-      abi: dkgAbi,
-      logs: rawLogs,
-      eventName: "Registered",
-    });
-
+    const latestBlock = await this.publicClient.getBlockNumber();
+    const chunk = Consumer.DKG_LOGS_BLOCK_CHUNK;
     const validators = new Map<string, Uint8Array[]>();
-    for (const log of parsed) {
-      const addr = log.args.validatorAddr.toLowerCase() as `0x${string}`;
-      const keys = validators.get(addr) ?? [];
-      keys.push(toBytes(log.args.enclaveCommKey));
-      validators.set(addr, keys);
+
+    for (let from = 0n; from <= latestBlock; from = from + chunk + 1n) {
+      const to = from + chunk > latestBlock ? latestBlock : from + chunk;
+
+      const rawLogs = await this.publicClient.getLogs({
+        address: dkgAddress,
+        fromBlock: from,
+        toBlock: to,
+      });
+
+      const parsed = parseEventLogs({
+        abi: dkgAbi,
+        logs: rawLogs,
+        eventName: "Registered",
+      });
+
+      for (const log of parsed) {
+        const addr = log.args.validatorAddr.toLowerCase() as `0x${string}`;
+        const keys = validators.get(addr) ?? [];
+        keys.push(toBytes(log.args.enclaveCommKey));
+        validators.set(addr, keys);
+      }
     }
 
     return validators;

--- a/packages/sdk/src/consumer.ts
+++ b/packages/sdk/src/consumer.ts
@@ -17,13 +17,16 @@ export class Consumer {
   private observer: Observer | null;
 
   /**
-   * Cached validator → commPubKey[] map. Built on first use and kept for the
-   * Consumer instance's lifetime. Registered events are immutable, so the
-   * only staleness risk is a new validator registering after the cache was
-   * built; that surfaces as "unknown validator" during verify, which triggers
-   * an automatic one-shot refresh (see collectPartialsFromEvents).
+   * In-flight (or settled) promise for the cached commPubKey map. Promise-
+   * level caching deduplicates concurrent calls: if two accessCDR invocations
+   * both trigger a build at the same time, only one scan runs.
+   *
+   * Registered events are immutable, so the only staleness risk is a new
+   * validator registering after the cache was built; that surfaces as
+   * "unknown validator" during verify, which triggers an automatic one-shot
+   * refresh (see collectPartialsFromEvents).
    */
-  private commPubKeyMapCache: Map<string, Uint8Array[]> | null = null;
+  private commPubKeyMapPromise: Promise<Map<string, Uint8Array[]>> | null = null;
 
   /** Alias for {@link accessCDR} */
   readVault: Consumer["accessCDR"];
@@ -98,18 +101,31 @@ export class Consumer {
    */
   /** Chunk size for historical getLogs scans. Kept well below typical RPC block-range limits. */
   private static readonly DKG_LOGS_BLOCK_CHUNK = 500_000n;
+  /** Max attempts per chunk getLogs call before propagating the error. */
+  private static readonly GETLOGS_MAX_ATTEMPTS = 3;
+  /** Base delay (ms) for exponential backoff between getLogs retries. */
+  private static readonly GETLOGS_BACKOFF_MS = 500;
 
   /**
    * Return the cached commPubKey map, building it on first call or when
-   * {@link forceRefresh} is true. Safe to call repeatedly.
+   * {@link forceRefresh} is true. Concurrent callers share the same in-flight
+   * build promise so we never scan the full history twice in parallel. If a
+   * build fails, the rejected promise is cleared so a subsequent call can
+   * retry from scratch instead of inheriting the failure.
    */
   private async getCommPubKeyMap(forceRefresh = false): Promise<Map<string, Uint8Array[]>> {
-    if (!forceRefresh && this.commPubKeyMapCache) {
-      return this.commPubKeyMapCache;
+    if (!forceRefresh && this.commPubKeyMapPromise) {
+      return this.commPubKeyMapPromise;
     }
     const dkgAddress = contractAddresses[this.network].dkg;
-    this.commPubKeyMapCache = await this.fetchRegisteredValidators(dkgAddress);
-    return this.commPubKeyMapCache;
+    const p = this.fetchRegisteredValidators(dkgAddress).catch((err) => {
+      if (this.commPubKeyMapPromise === p) {
+        this.commPubKeyMapPromise = null;
+      }
+      throw err;
+    });
+    this.commPubKeyMapPromise = p;
+    return p;
   }
 
   private async fetchRegisteredValidators(
@@ -122,11 +138,7 @@ export class Consumer {
     for (let from = 0n; from <= latestBlock; from = from + chunk + 1n) {
       const to = from + chunk > latestBlock ? latestBlock : from + chunk;
 
-      const rawLogs = await this.publicClient.getLogs({
-        address: dkgAddress,
-        fromBlock: from,
-        toBlock: to,
-      });
+      const rawLogs = await this.getLogsWithRetry(dkgAddress, from, to);
 
       const parsed = parseEventLogs({
         abi: dkgAbi,
@@ -143,6 +155,31 @@ export class Consumer {
     }
 
     return validators;
+  }
+
+  /**
+   * getLogs wrapper with exponential-backoff retry. Public RPCs can return
+   * transient errors for individual chunk ranges (observed as
+   * "invalid block range params" on Aeneid); a narrow retry loop keeps the
+   * full-history scan robust without swallowing persistent failures.
+   */
+  private async getLogsWithRetry(
+    address: `0x${string}`,
+    fromBlock: bigint,
+    toBlock: bigint,
+  ): Promise<Awaited<ReturnType<PublicClient["getLogs"]>>> {
+    let lastError: unknown;
+    for (let attempt = 0; attempt < Consumer.GETLOGS_MAX_ATTEMPTS; attempt++) {
+      try {
+        return await this.publicClient.getLogs({ address, fromBlock, toBlock });
+      } catch (err) {
+        lastError = err;
+        if (attempt === Consumer.GETLOGS_MAX_ATTEMPTS - 1) break;
+        const delay = Consumer.GETLOGS_BACKOFF_MS * 2 ** attempt;
+        await new Promise((resolve) => setTimeout(resolve, delay));
+      }
+    }
+    throw lastError;
   }
 
   /**

--- a/packages/sdk/src/consumer.ts
+++ b/packages/sdk/src/consumer.ts
@@ -28,6 +28,14 @@ export class Consumer {
    */
   private commPubKeyMapPromise: Promise<Map<string, Uint8Array[]>> | null = null;
 
+  /**
+   * Flag tracking whether we've already warned about using the default
+   * (hardcoded, plaintext HTTP) CometBFT RPC URL on this Consumer instance.
+   * Keeps the warning to once per instance instead of spamming on every
+   * cache build / refresh.
+   */
+  private defaultCometUrlWarned = false;
+
   /** Alias for {@link accessCDR} */
   readVault: Consumer["accessCDR"];
   /** Alias for {@link downloadFile} */
@@ -142,8 +150,23 @@ export class Consumer {
    * Default CometBFT RPC URL for the hybrid active-round filter. Used when
    * the caller has not explicitly configured `cometRpcUrl` on the Observer.
    * Pinned to the Aeneid / mainnet CometBFT endpoint so the SDK is usable
-   * out of the box without any manual RPC configuration. Override by
-   * passing `cometRpcUrl` when constructing `CDRClient`.
+   * out of the box without any manual RPC configuration.
+   *
+   * ⚠️ SECURITY WARNING — The default is a raw IP over plaintext HTTP. A
+   * network-level attacker able to intercept traffic between the SDK and
+   * this endpoint can forge the `activeRound` response, causing the hybrid
+   * filter to keep only the attacker's chosen round's keys. All legitimate
+   * partials will then fail verification and be dropped — a denial-of-
+   * service on `accessCDR`. Fallback-to-unfiltered-scan does not apply
+   * here because the MITM returns a valid-looking response.
+   *
+   * For production deployments, override this by passing `cometRpcUrl`
+   * when constructing `CDRClient`, pointing either at your own CometBFT
+   * node or at an HTTPS endpoint you control. This default exists only as
+   * a zero-config convenience for development and demos.
+   *
+   * When the SDK falls back to this default at runtime, it emits a
+   * one-time `console.warn` to surface the risk.
    */
   private static readonly DEFAULT_COMET_RPC_URL = "http://172.192.41.96:26657";
   /** Max attempts per chunk getLogs call before propagating the error. */
@@ -190,6 +213,16 @@ export class Consumer {
     // undefined and keep every round in the window as a fallback.
     let activeRound: number | undefined;
     const cometRpcUrl = this.observer?.cometRpcUrl ?? Consumer.DEFAULT_COMET_RPC_URL;
+    if (!this.observer?.cometRpcUrl && !this.defaultCometUrlWarned) {
+      this.defaultCometUrlWarned = true;
+      // eslint-disable-next-line no-console
+      console.warn(
+        "[cdr-sdk] Using the default CometBFT RPC URL over plaintext HTTP " +
+          `(${Consumer.DEFAULT_COMET_RPC_URL}). A network-level attacker can forge the active DKG round ` +
+          "and cause every accessCDR call to fail. For production, pass `cometRpcUrl` to CDRClient " +
+          "pointing to your own CometBFT node or an HTTPS endpoint.",
+      );
+    }
     try {
       const network = await queryLatestActiveDKGNetwork(cometRpcUrl);
       activeRound = network.round;

--- a/packages/sdk/src/consumer.ts
+++ b/packages/sdk/src/consumer.ts
@@ -7,7 +7,7 @@ import { uuidToLabel } from "./label.js";
 import type { StorageProvider } from "./storage/types.js";
 import { Observer } from "./observer.js";
 import type { AttestationConfig } from "./attestation.js";
-import { queryCDRPartials } from "./cosmos/abci-query.js";
+import { queryCDRPartials, queryLatestActiveDKGNetwork } from "./cosmos/abci-query.js";
 import { bytesToHex as cosmosBytesToHex } from "./cosmos/protobuf.js";
 
 export class Consumer {
@@ -117,19 +117,35 @@ export class Consumer {
   /**
    * Fetch validator address → commPubKey[] map from DKG Registered events.
    *
-   * Each validator may re-register with a new commPubKey in each DKG round.
-   * Partials are signed with the commPubKey active in the round that serviced
-   * the read request, which is not necessarily the most recent round. The
-   * signature-verify loop in collectPartialsFromEvents tries every key in the
-   * returned array, so we must supply keys from every historical round — a
-   * rolling lookback window can exclude the round a partial was signed under
-   * and cause every verification to fail.
+   * Hybrid mode (default): query `GetLatestActiveDKGNetwork` via CometBFT
+   * ABCI to identify the currently active DKG round, then scan EVM
+   * `Registered` events within a bounded window and keep only registrations
+   * for that round. The CometBFT RPC URL defaults to the SDK's
+   * network-specific `DEFAULT_COMET_RPC_URL`; callers can override it by
+   * passing `cometRpcUrl` when constructing `CDRClient`. If the ABCI query
+   * fails (network unreachable, URL misconfigured, etc.), we fall back to
+   * keeping every key in the window and letting the verify loop try each.
    *
-   * We therefore scan the full history from genesis using chunked getLogs
-   * calls to stay within RPC range limits.
+   * The bounded window (`DKG_LOOKBACK_BLOCKS`) is sized for Aeneid / mainnet
+   * where blocks are ~2 s and DKG rotates roughly weekly — 10 days covers
+   * the current active round plus one rotation of buffer.
    */
   /** Chunk size for historical getLogs scans. Kept well below typical RPC block-range limits. */
   private static readonly DKG_LOGS_BLOCK_CHUNK = 500_000n;
+  /**
+   * DKG Registered-event lookback window, in blocks. Sized for Aeneid /
+   * mainnet (≈2 s/block, ~weekly DKG rotation): 10 days = 432_000 blocks.
+   * Covers the currently active DKG round plus one rotation of buffer.
+   */
+  private static readonly DKG_LOOKBACK_BLOCKS = 432_000n;
+  /**
+   * Default CometBFT RPC URL for the hybrid active-round filter. Used when
+   * the caller has not explicitly configured `cometRpcUrl` on the Observer.
+   * Pinned to the Aeneid / mainnet CometBFT endpoint so the SDK is usable
+   * out of the box without any manual RPC configuration. Override by
+   * passing `cometRpcUrl` when constructing `CDRClient`.
+   */
+  private static readonly DEFAULT_COMET_RPC_URL = "http://172.192.41.96:26657";
   /** Max attempts per chunk getLogs call before propagating the error. */
   private static readonly GETLOGS_MAX_ATTEMPTS = 3;
   /** Base delay (ms) for exponential backoff between getLogs retries. */
@@ -162,9 +178,28 @@ export class Consumer {
   ): Promise<Map<string, Uint8Array[]>> {
     const latestBlock = await this.publicClient.getBlockNumber();
     const chunk = Consumer.DKG_LOGS_BLOCK_CHUNK;
+    const startBlock = latestBlock > Consumer.DKG_LOOKBACK_BLOCKS
+      ? latestBlock - Consumer.DKG_LOOKBACK_BLOCKS
+      : 0n;
+
+    // Hybrid mode (default): query CometBFT ABCI for the currently active DKG
+    // round so we can filter EVM Registered events to just that round's
+    // commPubKeys. Uses the Observer's cometRpcUrl if the caller set one,
+    // otherwise falls back to the SDK's network-specific default URL. If
+    // both are unreachable or the query fails, we leave activeRound
+    // undefined and keep every round in the window as a fallback.
+    let activeRound: number | undefined;
+    const cometRpcUrl = this.observer?.cometRpcUrl ?? Consumer.DEFAULT_COMET_RPC_URL;
+    try {
+      const network = await queryLatestActiveDKGNetwork(cometRpcUrl);
+      activeRound = network.round;
+    } catch {
+      // ABCI unreachable or query failed — fall back to unfiltered scan.
+    }
+
     const validators = new Map<string, Uint8Array[]>();
 
-    for (let from = 0n; from <= latestBlock; from = from + chunk + 1n) {
+    for (let from = startBlock; from <= latestBlock; from = from + chunk + 1n) {
       const to = from + chunk > latestBlock ? latestBlock : from + chunk;
 
       const rawLogs = await this.getLogsWithRetry(dkgAddress, from, to);
@@ -176,6 +211,9 @@ export class Consumer {
       });
 
       for (const log of parsed) {
+        if (activeRound !== undefined && log.args.round !== activeRound) {
+          continue; // Hybrid mode: skip non-active rounds.
+        }
         const addr = log.args.validatorAddr.toLowerCase() as `0x${string}`;
         const keys = validators.get(addr) ?? [];
         keys.push(toBytes(log.args.enclaveCommKey));

--- a/packages/sdk/src/consumer.ts
+++ b/packages/sdk/src/consumer.ts
@@ -48,6 +48,35 @@ export class Consumer {
   }
 
   /**
+   * Warm the validator commPubKey cache in the background.
+   *
+   * The cache is normally built lazily on the first accessCDR / downloadFile
+   * call, which requires a full-history scan of DKG Registered events and
+   * can take tens of seconds on mature chains — long enough that a request
+   * triggered by a user click can appear to hang. Frontends that know a
+   * read is imminent (e.g. right after user login / wallet connection) can
+   * call prefetchRegistry() to start the scan early, so the subsequent
+   * accessCDR call hits a warm cache and returns immediately.
+   *
+   * Safe to call multiple times — concurrent callers share the same
+   * in-flight build via Promise-level dedupe, so repeated prefetches cost
+   * nothing. Errors propagate; callers doing best-effort warming should
+   * attach their own `.catch(() => {})` and let the real accessCDR call
+   * surface the failure later if it still occurs.
+   *
+   * @example
+   * ```ts
+   * // Right after user login / wallet connection, in a useEffect:
+   * cdrClient.consumer.prefetchRegistry().catch(() => {
+   *   // best-effort warm-up; real accessCDR call will retry if needed
+   * });
+   * ```
+   */
+  async prefetchRegistry(): Promise<void> {
+    await this.getCommPubKeyMap();
+  }
+
+  /**
    * Request a vault read. Auto-queries read fee. Emits VaultRead event for validators.
    * @example
    * ```ts


### PR DESCRIPTION
## Summary

Implements **hybrid mode as the default** for DKG commPubKey resolution in `Consumer`. The SDK now queries CometBFT ABCI for the currently active DKG round, then scans a bounded EVM `Registered` event window and keeps only that round's commPubKeys — no configuration required from the caller.

Fixes #53. Supersedes the full-history scan approach from PR #54 with a much cheaper bounded + filtered approach.

This branch is tuned for **Aeneid / mainnet** (2 s/block, ~weekly DKG rotation). A sibling branch `fix/53-hybrid-devnet` ships the same code with DevNet-sized constants.

## What changed

1. **Bounded EVM lookback** — `fetchRegisteredValidators()` scans `[latestBlock - 432_000n, latestBlock]` instead of scanning from block 0. 432_000 blocks ≈ 10 days at 2 s/block, covering the currently active DKG round plus ~one rotation of buffer.

2. **ABCI active-round filter (new)** — before scanning EVM events, the SDK calls `queryLatestActiveDKGNetwork(cometRpcUrl)` to learn the active round. EVM `Registered` events are then filtered to that round only, so the resulting commPubKey map holds exactly the keys validators are signing with right now — no multi-round accumulation.

3. **Zero-config default** — the SDK ships a baked-in `DEFAULT_COMET_RPC_URL = "http://172.192.41.96:26657"` (Aeneid CometBFT). Callers using `new CDRClient({ network: "testnet", publicClient, walletClient })` with no extra params get the hybrid behavior out of the box.

4. **Explicit override** — callers can still pass `cometRpcUrl` on `CDRClient`; it takes precedence over the default.

5. **Graceful fallback** — if the ABCI query fails (URL misconfigured, network unreachable, etc.), `activeRound` is left undefined and the SDK keeps every key in the window. No regression for environments without ABCI.

## Config surface

```ts
// Default — hybrid mode on, uses SDK-bundled Aeneid ABCI:
new CDRClient({ network: "testnet", publicClient, walletClient });

// Override the ABCI endpoint if you run a different CometBFT node:
new CDRClient({ network: "testnet", publicClient, walletClient, cometRpcUrl: "http://my-node:26657" });
```

## Verified against live Aeneid

With **no** `cometRpcUrl` passed (SDK uses the baked-in default):

| Step | Duration |
|------|---------:|
| ABCI `GetLatestActiveDKGNetwork` | ~300 ms |
| EVM scan (10-day window, 1 chunk of 500k) | ~900 ms |
| **Total `prefetchRegistry()` cold start** | **~1.3 s** |

- ABCI returned `activeRound = 6`
- EVM scan surfaced 10 `Registered` events (5 × round 5, 5 × round 6)
- Hybrid filter narrowed to 5 active validators (round 6 only)
- Freshly-signed partials verify end-to-end

## Preserved hardening from #54

- Promise-level dedupe (concurrent `accessCDR` share one cache build)
- Per-chunk retry with exponential backoff (3 attempts, 500 ms base)
- One-shot `refreshedFor` refresh on unknown validator
- Failed-build promise reset so subsequent callers retry cleanly
- `Consumer.prefetchRegistry()` public method for frontend warm-up on login

## Tests

23/23 passing (20 pre-existing + 3 new covering hybrid paths):

- `hybrid mode: queries ABCI for active round and filters Registered events to that round`
- `hybrid mode: when ABCI query fails, falls back to keeping all rounds (graceful degradation)`
- `hybrid mode default: no observer → SDK still consults the default CometBFT URL`

Test refactor: the chunk-coverage test extracts `LOOKBACK` / `LATEST` / `EXPECTED_START` into local constants so the three assertions read from one source of truth.

## Test plan

- [x] `pnpm --filter @piplabs/cdr-sdk build` — clean
- [x] `pnpm vitest run __tests__/consumer.test.ts` — 23/23 pass
- [x] Live Aeneid end-to-end — cold start 1.3 s, active-round filter correctly narrows to 5 validators
- [x] Re-run [story-cdr-e2e CDR SDK Integration Test](https://github.com/piplabs/story-cdr-e2e/actions/workflows/cdr-sdk-integration-test.yml) on `aeneid-testnet` with `sdk_ref: fix/53-hybrid-aeneid` — expect `access.test.ts` 6/6 pass (was 1/6 on main)

## Relation to DevNet branch

`fix/53-hybrid-devnet` ships the identical code with two hardcoded constants swapped for DevNet:

| Constant | Aeneid (this PR) | DevNet |
|----------|-----------------:|-------:|
| `DKG_LOOKBACK_BLOCKS` | `432_000n` (~10 d) | `620n` (~1.5 rounds at DevNet cadence) |
| `DEFAULT_COMET_RPC_URL` | `http://172.192.41.96:26657` | `http://172.207.250.203:26657` |

Zero behavioral divergence between the two branches.