### PR TITLE
refactor(sdk): per-network lookback default + constructor override

### DIFF
--- a/packages/sdk/src/consumer.ts
+++ b/packages/sdk/src/consumer.ts
@@ -7,6 +7,7 @@ import { uuidToLabel } from "./label.js";
 import type { StorageProvider } from "./storage/types.js";
 import { Observer } from "./observer.js";
 import type { AttestationConfig } from "./attestation.js";
+import { resolveLookbackBlocks } from "./defaults.js";
 import { queryCDRPartials } from "./cosmos/abci-query.js";
 import { bytesToHex as cosmosBytesToHex } from "./cosmos/protobuf.js";
 
@@ -15,6 +16,7 @@ export class Consumer {
   private walletClient: WalletClient;
   private network: Network;
   private observer: Observer | null;
+  private lookbackBlocks: bigint;
 
   /** Alias for {@link accessCDR} */
   readVault: Consumer["accessCDR"];
@@ -26,11 +28,19 @@ export class Consumer {
     publicClient: PublicClient;
     walletClient: WalletClient;
     observer?: Observer;
+    /**
+     * Block range to scan back from `latest` when looking up DKG
+     * `Registered` events. Defaults to the per-network value in
+     * `defaults.ts` (~7 days at 2 s/block on Story). Override for chains
+     * with different block time or DKG cadence.
+     */
+    lookbackBlocks?: bigint;
   }) {
     this.publicClient = params.publicClient;
     this.walletClient = params.walletClient;
     this.network = params.network;
     this.observer = params.observer ?? null;
+    this.lookbackBlocks = resolveLookbackBlocks(params.network, params.lookbackBlocks);
     this.readVault = this.accessCDR.bind(this);
     this.readFileVault = this.downloadFile.bind(this);
   }
@@ -79,14 +89,11 @@ export class Consumer {
    * so we keep all keys (most recent first) to handle round mismatch during
    * signature verification.
    */
-  /** Default lookback window: ~7 days at ~2 s/block. Matches Observer.DEFAULT_LOOKBACK_BLOCKS. */
-  private static readonly DEFAULT_LOOKBACK_BLOCKS = 302_400n;
-
   private async getCommPubKeyMap(): Promise<Map<string, Uint8Array[]>> {
     const dkgAddress = contractAddresses[this.network].dkg;
     const latestBlock = await this.publicClient.getBlockNumber();
-    const fromBlock = latestBlock > Consumer.DEFAULT_LOOKBACK_BLOCKS
-      ? latestBlock - Consumer.DEFAULT_LOOKBACK_BLOCKS
+    const fromBlock = latestBlock > this.lookbackBlocks
+      ? latestBlock - this.lookbackBlocks
       : 0n;
 
     const validators = await this.fetchRegisteredValidators(dkgAddress, fromBlock);

--- a/packages/sdk/src/defaults.ts
+++ b/packages/sdk/src/defaults.ts
@@ -1,0 +1,35 @@
+import type { Network } from "@piplabs/cdr-contracts";
+
+/**
+ * Per-network defaults for SDK constructor options.
+ *
+ * Constants live here so Consumer and Observer share a single source of
+ * truth and SDK consumers can override per-instance via constructor
+ * options. Resolution order: explicit constructor arg > network default
+ * (from these tables).
+ */
+
+/**
+ * Default lookback window when scanning DKG `Registered` / `Finalized`
+ * events on long-running chains. Tuned to ~7 days of block production
+ * at ~2 s/block (302_400 blocks). One full DKG cycle on Story is
+ * 241_920 blocks (4 phases × 34_560 / 34_560 / 34_560 / 138_240); a
+ * 7-day window safely covers >1 full active phase plus buffer.
+ *
+ * Both networks currently share the same value because both target
+ * Story chains running the same x/dkg cadence. Forks or private
+ * deployments with different block time / DKG params should override
+ * via the `lookbackBlocks` constructor option rather than editing
+ * this table.
+ */
+export const DEFAULT_LOOKBACK_BLOCKS_BY_NETWORK: Record<Network, bigint> = {
+  mainnet: 302_400n,
+  testnet: 302_400n,
+};
+
+export function resolveLookbackBlocks(
+  network: Network,
+  override?: bigint,
+): bigint {
+  return override ?? DEFAULT_LOOKBACK_BLOCKS_BY_NETWORK[network];
+}

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -8,6 +8,7 @@ export * from "./label.js";
 export * from "./conditions.js";
 export * from "./attestation.js";
 export * from "./storage/index.js";
+export * from "./defaults.js";
 
 // Re-export from sub-packages for convenience
 export * from "@piplabs/cdr-contracts";

--- a/packages/sdk/src/observer.ts
+++ b/packages/sdk/src/observer.ts
@@ -15,6 +15,7 @@ import {
   queryVerifiedRegistrations,
 } from "./cosmos/abci-query.js";
 import type { DKGNetwork } from "./cosmos/dkg-proto.js";
+import { resolveLookbackBlocks } from "./defaults.js";
 
 /**
  * Which backend to use for DKG queries.
@@ -43,15 +44,13 @@ export class Observer {
   /** Many RPCs reject or time out on wide eth_getLogs ranges; chunk to stay under typical caps. */
   private static readonly DKG_LOGS_BLOCK_CHUNK = 8192n;
 
-  /** Default lookback window: ~7 days at ~2 s/block. Avoids scanning from block 0 on long chains. */
-  private static readonly DEFAULT_LOOKBACK_BLOCKS = 302_400n;
-
   private publicClient: PublicClient;
   private network: Network;
   readonly dkgSource: DkgSource;
   readonly cometRpcUrl: string | undefined;
   private minThresholdRatio?: number;
   private validationClients?: PublicClient[];
+  private lookbackBlocks: bigint;
 
   constructor(params: {
     network: Network;
@@ -67,6 +66,13 @@ export class Observer {
     minThresholdRatio?: number;
     /** Additional RPC clients for cross-validating critical on-chain reads (evm-events mode only). */
     validationClients?: PublicClient[];
+    /**
+     * Block range to scan back from `latest` when looking up DKG events
+     * (`Registered` / `Finalized`) in `evm-events` mode. Defaults to the
+     * per-network value in `defaults.ts` (~7 days at 2 s/block on Story).
+     * Override for chains with different block time or DKG cadence.
+     */
+    lookbackBlocks?: bigint;
   }) {
     this.publicClient = params.publicClient;
     this.network = params.network;
@@ -74,6 +80,7 @@ export class Observer {
     this.cometRpcUrl = params.cometRpcUrl;
     this.minThresholdRatio = params.minThresholdRatio;
     this.validationClients = params.validationClients;
+    this.lookbackBlocks = resolveLookbackBlocks(params.network, params.lookbackBlocks);
 
     if (this.dkgSource === "cosmos-abci" && !this.cometRpcUrl) {
       throw new Error(
@@ -270,8 +277,8 @@ export class Observer {
   }): Promise<Map<string, Uint8Array>> {
     const toBlock = await this.publicClient.getBlockNumber();
     const fromBlock = params?.fromBlock ??
-      (toBlock > Observer.DEFAULT_LOOKBACK_BLOCKS
-        ? toBlock - Observer.DEFAULT_LOOKBACK_BLOCKS
+      (toBlock > this.lookbackBlocks
+        ? toBlock - this.lookbackBlocks
         : 0n);
 
     const rawLogs = await this.fetchDkgEventLogs(
@@ -343,8 +350,8 @@ export class Observer {
     const toBlock =
       params?.toBlock ?? (await this.publicClient.getBlockNumber());
     const fromBlock = params?.fromBlock ??
-      (toBlock > Observer.DEFAULT_LOOKBACK_BLOCKS
-        ? toBlock - Observer.DEFAULT_LOOKBACK_BLOCKS
+      (toBlock > this.lookbackBlocks
+        ? toBlock - this.lookbackBlocks
         : 0n);
 
     const rawLogs = await this.fetchDkgEventLogs(
@@ -429,8 +436,8 @@ export class Observer {
     if (this.validationClients?.length) {
       const primaryHex = toHex(rawPoint);
       const fromBlock = params?.fromBlock ??
-        (toBlock > Observer.DEFAULT_LOOKBACK_BLOCKS
-          ? toBlock - Observer.DEFAULT_LOOKBACK_BLOCKS
+        (toBlock > this.lookbackBlocks
+          ? toBlock - this.lookbackBlocks
           : 0n);
 
       const settled = await Promise.allSettled(
@@ -464,8 +471,8 @@ export class Observer {
   }): Promise<Map<string, Uint8Array>> {
     const toBlock = await this.publicClient.getBlockNumber();
     const fromBlock = params?.fromBlock ??
-      (toBlock > Observer.DEFAULT_LOOKBACK_BLOCKS
-        ? toBlock - Observer.DEFAULT_LOOKBACK_BLOCKS
+      (toBlock > this.lookbackBlocks
+        ? toBlock - this.lookbackBlocks
         : 0n);
 
     const rawLogs = await this.fetchDkgEventLogs(


### PR DESCRIPTION
## Summary

- Remove duplicated `private static readonly DEFAULT_LOOKBACK_BLOCKS = 302_400n` from `Consumer` and `Observer`.
- Add new file `packages/sdk/src/defaults.ts` with `DEFAULT_LOOKBACK_BLOCKS_BY_NETWORK: Record<Network, bigint>` and `resolveLookbackBlocks(network, override?)`.
- Expose both via the SDK barrel (`index.ts`) so external consumers can read or compute against the defaults.
- Add optional `lookbackBlocks?: bigint` constructor param to both `Consumer` and `Observer`. Resolution order: explicit param > per-network default.

## Why

The hardcoded `302_400n` (~7 days at 2 s/block) is reasonable for the two networks the SDK currently supports, but:

1. Two copies (`consumer.ts` + `observer.ts`) drift independently — one had a `// Matches Observer.DEFAULT_LOOKBACK_BLOCKS` comment to manually pin the duplication.
2. SDK consumers running against forks, private chains, or future networks with different block time or DKG cadence had to fork the SDK or work around it.
3. As an SDK, defaults should be opinionated but overridable. Tier 2 (per-network table) + tier 3 (constructor override) is the standard layered-config pattern (viem / ethers / alchemy SDK all do this).

## Behavior

- No behavior change for callers using the existing constructor signatures — same `302_400n` value resolves through `defaults.ts`.
- New override: `new Consumer({ ..., lookbackBlocks: 100_000n })` or `new Observer({ ..., lookbackBlocks: 100_000n })`.

## Test plan

- [x] `pnpm -r run build` — clean
- [x] `pnpm --filter @piplabs/cdr-sdk run test` — 81 passed, 23 skipped (integration suite, unchanged)
- [x] No production-code behavior change for default-configured callers (same constant value through the new path)