### PR TITLE
fix(codeowners): correct Barry's GitHub handle

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @wo-o @lucas2brh @yingyangxu2026 @chao-peng-story @ShenWang-PiP
+* @wo-o @lucas2brh @yingyangxu2026 @barry-peng-story @ShenWang-PiP


### PR DESCRIPTION
## Summary

GitHub CODEOWNERS validation reported `Unknown owner on line 1: make sure @chao-peng-story exists and has write access to the repository`. Barry's actual handle is [`@barry-peng-story`](https://github.com/barry-peng-story).

## Test plan

- [x] Single-line edit, validated against the username shown on the user's GitHub profile
- [ ] After merge: confirm GitHub no longer shows the CODEOWNERS error banner