### PR TITLE
fix: accessCDR returns 0 partials after DKG rotation

### DIFF
--- a/packages/sdk/__tests__/consumer.test.ts
+++ b/packages/sdk/__tests__/consumer.test.ts
@@ -9,16 +9,22 @@ vi.mock("@piplabs/cdr-crypto", () => ({
 }));
 
 // Mock the cosmos ABCI query so the hybrid path is exercised without a live RPC.
+// queryDKGParams must be in the factory too: Observer.getLookbackBlocks()
+// invokes it to derive the EVM event-scan window. If it is absent, the import
+// resolves to undefined at runtime, the catch in getLookbackBlocks silently
+// swallows the error, and every test transparently falls back to
+// Observer.DEFAULT_LOOKBACK_BLOCKS instead of exercising the dynamic formula.
 vi.mock("../src/cosmos/abci-query.js", () => ({
   queryCDRPartials: vi.fn(),
   queryLatestActiveDKGNetwork: vi.fn(),
   queryVerifiedRegistrations: vi.fn(),
+  queryDKGParams: vi.fn(),
 }));
 
 import { Consumer } from "../src/consumer.js";
 import { Observer } from "../src/observer.js";
 import { verifyPartialSignature } from "@piplabs/cdr-crypto";
-import { queryLatestActiveDKGNetwork } from "../src/cosmos/abci-query.js";
+import { queryLatestActiveDKGNetwork, queryDKGParams } from "../src/cosmos/abci-query.js";
 
 function makePartialDecryptionLog(opts: {
   validator: `0x${string}`;
@@ -1208,6 +1214,137 @@ describe("Consumer", () => {
       expect(partials).toHaveLength(1);
       // First build attempted 3 retries; second build succeeded on attempt 1. Total DKG calls = 4.
       expect(callCount).toBe(4);
+    });
+
+    it("derives the event-scan lookback from queryDKGParams (dynamic formula)", async () => {
+      // Direct test of the dynamic-lookback formula (separate from the
+      // chunk-coverage test which intentionally exercises the fallback).
+      // Mock queryDKGParams with concrete values and assert the chunked DKG
+      // scan starts at exactly latestBlock - lookback, where:
+      //   lookback = 2 × (registration + dealing + finalization) + active
+      const REG = 100n, DEAL = 200n, FIN = 200n, ACTIVE = 1000n;
+      const EXPECTED_LOOKBACK = 2n * (REG + DEAL + FIN) + ACTIVE; // = 2000n
+      const LATEST = 1_000_000n;
+      const EXPECTED_START = LATEST - EXPECTED_LOOKBACK;
+
+      const { publicClient, walletClient } = mockClients();
+      vi.mocked(verifyPartialSignature).mockReturnValue(true);
+      vi.mocked(queryDKGParams).mockResolvedValue({
+        registrationPeriod: REG,
+        dealingPeriod: DEAL,
+        finalizationPeriod: FIN,
+        activePeriod: ACTIVE,
+      });
+      publicClient.getBlockNumber.mockResolvedValue(LATEST);
+
+      const chunks: { from: bigint; to: bigint }[] = [];
+      publicClient.getLogs.mockImplementation(async (params: any) => {
+        if (params.address === DKG_ADDR) {
+          chunks.push({ from: params.fromBlock, to: params.toBlock });
+          return [makeRegisteredLog({ validatorAddr: VALIDATOR_A, enclaveCommKey: KEY_A, round: 1 })];
+        }
+        return [makePartialDecryptionLog({ validator: VALIDATOR_A, round: 1, pid: 1, uuid: 200 })];
+      });
+
+      const consumer = new Consumer({ network: "testnet", publicClient, walletClient });
+      await consumer.collectPartials({ uuid: 200, minPartials: 1, fromBlock: 990_000n, timeoutMs: 5_000, pollIntervalMs: 10 });
+
+      // Lookback (2000) ≪ DKG_LOGS_BLOCK_CHUNK (500_000) → exactly one DKG-scan call.
+      expect(chunks.length).toBe(1);
+      expect(chunks[0].from).toBe(EXPECTED_START);
+      expect(chunks[0].to).toBe(LATEST);
+      expect(queryDKGParams).toHaveBeenCalled();
+    });
+
+    it("dedups concurrent force-refresh requests into a single rescan", async () => {
+      // Two collectPartials calls both hit a verification failure for the
+      // same validator at the same time. Without the buildInFlight guard,
+      // both would call getCommPubKeyMap(true) and fan out into two parallel
+      // full-history scans. With the guard, the second caller joins the
+      // first refresh's in-flight promise.
+      const { publicClient, walletClient } = mockClients();
+      publicClient.getBlockNumber.mockResolvedValue(100n);
+      // First verify call fails (forces refresh on both concurrent paths);
+      // post-refresh verifies all succeed.
+      let verifyCount = 0;
+      vi.mocked(verifyPartialSignature).mockImplementation(() => {
+        verifyCount++;
+        return verifyCount > 2; // first 2 calls (one per concurrent caller) fail
+      });
+
+      let dkgScanCount = 0;
+      publicClient.getLogs.mockImplementation(async (params: any) => {
+        if (params.address === DKG_ADDR) {
+          dkgScanCount++;
+          // Slow scan so concurrent callers definitely overlap.
+          await new Promise((r) => setTimeout(r, 80));
+          return [makeRegisteredLog({ validatorAddr: VALIDATOR_A, enclaveCommKey: KEY_A, round: 1 })];
+        }
+        return [makePartialDecryptionLog({ validator: VALIDATOR_A, round: 1, pid: 1, uuid: 201 })];
+      });
+
+      const consumer = new Consumer({ network: "testnet", publicClient, walletClient });
+      // Pre-warm cache so both concurrent callers go straight to verify (then both fail-then-refresh in parallel).
+      await consumer.prefetchRegistry();
+      const dkgScansAfterPrewarm = dkgScanCount;
+
+      await Promise.all([
+        consumer.collectPartials({ uuid: 201, minPartials: 1, fromBlock: 90n, timeoutMs: 5_000, pollIntervalMs: 10 }),
+        consumer.collectPartials({ uuid: 201, minPartials: 1, fromBlock: 90n, timeoutMs: 5_000, pollIntervalMs: 10 }),
+      ]);
+
+      // Exactly one refresh scan in addition to the prefetch.
+      expect(dkgScanCount - dkgScansAfterPrewarm).toBe(1);
+    });
+
+    it("emits the default-CometBFT-URL warning exactly once even after a force-refresh", async () => {
+      // When no Observer is wired into the Consumer, getEventLookback used
+      // to construct a fresh Observer on every call. Each new Observer had
+      // its own defaultCometUrlWarned=false, so a force-refresh would re-fire
+      // the plaintext-HTTP warning. The fix caches the fallback Observer on
+      // the Consumer instance, so the flag persists across refreshes.
+      const { publicClient, walletClient } = mockClients();
+      vi.mocked(verifyPartialSignature).mockReturnValue(true);
+      // Force the params query to fail so getLookbackBlocks falls back AND
+      // the warning path runs (the warning fires regardless of whether the
+      // params query succeeds or fails — it's about *consulting* the URL).
+      vi.mocked(queryDKGParams).mockRejectedValue(new Error("ABCI unreachable"));
+      publicClient.getBlockNumber.mockResolvedValue(100n);
+
+      let dkgScanCount = 0;
+      publicClient.getLogs.mockImplementation(async (params: any) => {
+        if (params.address === DKG_ADDR) {
+          dkgScanCount++;
+          // First scan: only validator A. Refresh: validator B also.
+          return dkgScanCount === 1
+            ? [makeRegisteredLog({ validatorAddr: VALIDATOR_A, enclaveCommKey: KEY_A, round: 1 })]
+            : [
+                makeRegisteredLog({ validatorAddr: VALIDATOR_A, enclaveCommKey: KEY_A, round: 1 }),
+                makeRegisteredLog({ validatorAddr: VALIDATOR_B, enclaveCommKey: KEY_B, round: 1 }),
+              ];
+        }
+        // Partial from validator B forces a refresh on the first call.
+        return [makePartialDecryptionLog({ validator: VALIDATOR_B, round: 1, pid: 1, uuid: 202 })];
+      });
+
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      try {
+        // No observer wired → fallback Observer path exercised.
+        const consumer = new Consumer({ network: "testnet", publicClient, walletClient });
+        await consumer.collectPartials({ uuid: 202, minPartials: 1, fromBlock: 90n, timeoutMs: 5_000, pollIntervalMs: 10 });
+
+        // Exactly one default-URL warning, even though the cache was built
+        // (initial scan) and refreshed (after the unknown-validator failure).
+        const defaultUrlWarnings = warnSpy.mock.calls.filter(
+          (c) => typeof c[0] === "string" && c[0].includes("default CometBFT RPC URL"),
+        );
+        expect(defaultUrlWarnings).toHaveLength(1);
+        // Sanity: the refresh actually happened — otherwise we wouldn't be
+        // testing the post-refresh case at all.
+        expect(dkgScanCount).toBeGreaterThanOrEqual(2);
+      } finally {
+        warnSpy.mockRestore();
+      }
     });
   });
 });

--- a/packages/sdk/__tests__/consumer.test.ts
+++ b/packages/sdk/__tests__/consumer.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { encodeAbiParameters, keccak256, toBytes, padHex } from "viem";
 
 // Mock @piplabs/cdr-crypto before importing Consumer so the WASM loader is never executed.
@@ -8,8 +8,17 @@ vi.mock("@piplabs/cdr-crypto", () => ({
   verifyPartialSignature: vi.fn(),
 }));
 
+// Mock the cosmos ABCI query so the hybrid path is exercised without a live RPC.
+vi.mock("../src/cosmos/abci-query.js", () => ({
+  queryCDRPartials: vi.fn(),
+  queryLatestActiveDKGNetwork: vi.fn(),
+  queryVerifiedRegistrations: vi.fn(),
+}));
+
 import { Consumer } from "../src/consumer.js";
+import { Observer } from "../src/observer.js";
 import { verifyPartialSignature } from "@piplabs/cdr-crypto";
+import { queryLatestActiveDKGNetwork } from "../src/cosmos/abci-query.js";
 
 function makePartialDecryptionLog(opts: {
   validator: `0x${string}`;
@@ -365,30 +374,42 @@ describe("Consumer", () => {
 
   it("collectPartials rejects invalid signatures and invokes callback", async () => {
     const { publicClient, walletClient } = mockClients();
+    const KEY_A = ("0x" + "aa".repeat(64)) as `0x${string}`;
+    const KEY_B = ("0x" + "bb".repeat(64)) as `0x${string}`;
     const mockVerify = vi.mocked(verifyPartialSignature);
     mockVerify.mockReset();
-    mockVerify.mockReturnValueOnce(false).mockReturnValue(true);
+    // Deterministically accept only KEY_B; accept/reject follows the key, not call
+    // order, so the one-shot refresh on verification failure (for validator A)
+    // sees the same stable map and still rejects.
+    mockVerify.mockImplementation((args: any) => {
+      const kB = toBytes(KEY_B);
+      return args.commPubKey.length === kB.length && [...args.commPubKey].every((b, i) => b === kB[i]);
+    });
 
     publicClient.getBlockNumber.mockResolvedValueOnce(100n).mockResolvedValue(101n);
 
-    publicClient.getLogs
-      .mockResolvedValueOnce([
-        makeRegisteredLog({
-          validatorAddr: "0x0000000000000000000000000000000000000001",
-          enclaveCommKey: ("0x" + "aa".repeat(64)) as `0x${string}`,
-          round: 1,
-        }),
-        makeRegisteredLog({
-          validatorAddr: "0x0000000000000000000000000000000000000002",
-          enclaveCommKey: ("0x" + "bb".repeat(64)) as `0x${string}`,
-          round: 1,
-        }),
-      ])
-      .mockResolvedValueOnce([
-        makePartialDecryptionLog({ validator: "0x0000000000000000000000000000000000000001", round: 1, pid: 1, uuid: 1 }),
-        makePartialDecryptionLog({ validator: "0x0000000000000000000000000000000000000002", round: 1, pid: 2, uuid: 1 }),
-      ])
-      .mockResolvedValue([]);
+    const dkgLogs = [
+      makeRegisteredLog({
+        validatorAddr: "0x0000000000000000000000000000000000000001",
+        enclaveCommKey: KEY_A,
+        round: 1,
+      }),
+      makeRegisteredLog({
+        validatorAddr: "0x0000000000000000000000000000000000000002",
+        enclaveCommKey: KEY_B,
+        round: 1,
+      }),
+    ];
+    let cdrPoll = 0;
+    publicClient.getLogs.mockImplementation(async (params: any) => {
+      if (params.address === "0xcccccc0000000000000000000000000000000004") return dkgLogs;
+      return cdrPoll++ === 0
+        ? [
+            makePartialDecryptionLog({ validator: "0x0000000000000000000000000000000000000001", round: 1, pid: 1, uuid: 1 }),
+            makePartialDecryptionLog({ validator: "0x0000000000000000000000000000000000000002", round: 1, pid: 2, uuid: 1 }),
+          ]
+        : [];
+    });
 
     const onInvalidPartial = vi.fn();
     const consumer = new Consumer({ network: "testnet", publicClient, walletClient });
@@ -443,30 +464,39 @@ describe("Consumer", () => {
 
   it("collectPartials silently skips invalid partials when no callback provided", async () => {
     const { publicClient, walletClient } = mockClients();
+    const KEY_A = ("0x" + "aa".repeat(64)) as `0x${string}`;
+    const KEY_B = ("0x" + "bb".repeat(64)) as `0x${string}`;
     const mockVerify = vi.mocked(verifyPartialSignature);
     mockVerify.mockReset();
-    mockVerify.mockReturnValueOnce(false).mockReturnValue(true);
+    mockVerify.mockImplementation((args: any) => {
+      const kB = toBytes(KEY_B);
+      return args.commPubKey.length === kB.length && [...args.commPubKey].every((b, i) => b === kB[i]);
+    });
 
     publicClient.getBlockNumber.mockResolvedValueOnce(100n).mockResolvedValue(101n);
 
-    publicClient.getLogs
-      .mockResolvedValueOnce([
-        makeRegisteredLog({
-          validatorAddr: "0x0000000000000000000000000000000000000001",
-          enclaveCommKey: ("0x" + "aa".repeat(64)) as `0x${string}`,
-          round: 1,
-        }),
-        makeRegisteredLog({
-          validatorAddr: "0x0000000000000000000000000000000000000002",
-          enclaveCommKey: ("0x" + "bb".repeat(64)) as `0x${string}`,
-          round: 1,
-        }),
-      ])
-      .mockResolvedValueOnce([
-        makePartialDecryptionLog({ validator: "0x0000000000000000000000000000000000000001", round: 1, pid: 1, uuid: 1 }),
-        makePartialDecryptionLog({ validator: "0x0000000000000000000000000000000000000002", round: 1, pid: 2, uuid: 1 }),
-      ])
-      .mockResolvedValue([]);
+    const dkgLogs = [
+      makeRegisteredLog({
+        validatorAddr: "0x0000000000000000000000000000000000000001",
+        enclaveCommKey: KEY_A,
+        round: 1,
+      }),
+      makeRegisteredLog({
+        validatorAddr: "0x0000000000000000000000000000000000000002",
+        enclaveCommKey: KEY_B,
+        round: 1,
+      }),
+    ];
+    let cdrPoll = 0;
+    publicClient.getLogs.mockImplementation(async (params: any) => {
+      if (params.address === "0xcccccc0000000000000000000000000000000004") return dkgLogs;
+      return cdrPoll++ === 0
+        ? [
+            makePartialDecryptionLog({ validator: "0x0000000000000000000000000000000000000001", round: 1, pid: 1, uuid: 1 }),
+            makePartialDecryptionLog({ validator: "0x0000000000000000000000000000000000000002", round: 1, pid: 2, uuid: 1 }),
+          ]
+        : [];
+    });
 
     const consumer = new Consumer({ network: "testnet", publicClient, walletClient });
     const partials = await consumer.collectPartials({
@@ -479,5 +509,705 @@ describe("Consumer", () => {
 
     expect(partials).toHaveLength(1);
     expect(partials[0].pid).toBe(2);
+  });
+
+  describe("commPubKey map caching and chunked scan", () => {
+    // Reset the ABCI mock between tests so state from one hybrid-mode test
+    // (e.g. mockRejectedValue) doesn't leak into the next and hang it.
+    // Default behavior: reject so non-hybrid tests don't accidentally hit a
+    // live mock — they should continue working via the ABCI-failure fallback.
+    beforeEach(() => {
+      vi.mocked(queryLatestActiveDKGNetwork).mockReset();
+      vi.mocked(queryLatestActiveDKGNetwork).mockRejectedValue(
+        new Error("ABCI not mocked for this test — fallback expected"),
+      );
+    });
+
+    const DKG_ADDR = "0xcccccc0000000000000000000000000000000004";
+    const CDR_ADDR = "0xcccccc0000000000000000000000000000000005";
+    const VALIDATOR_A = "0x0000000000000000000000000000000000000001" as `0x${string}`;
+    const VALIDATOR_B = "0x0000000000000000000000000000000000000002" as `0x${string}`;
+    const KEY_A = ("0x" + "aa".repeat(64)) as `0x${string}`;
+    const KEY_B = ("0x" + "bb".repeat(64)) as `0x${string}`;
+    const KEY_A_ROUND6 = ("0x" + "a6".repeat(64)) as `0x${string}`;
+
+    function makeObserverWithComet(publicClient: any, cometRpcUrl: string): Observer {
+      // Observer constructor requires cometRpcUrl only when dkgSource === "cosmos-abci".
+      // We pass "evm-events" here so the Observer itself stays on EVM but still carries
+      // a non-empty cometRpcUrl that the Consumer's hybrid path can pick up.
+      return new Observer({
+        network: "testnet",
+        publicClient: publicClient as any,
+        dkgSource: "evm-events",
+        cometRpcUrl,
+      });
+    }
+
+    /** Count how many times publicClient.getLogs was called against the DKG contract. */
+    function dkgScanCount(publicClient: any): number {
+      return publicClient.getLogs.mock.calls.filter(
+        (c: any[]) => c[0].address === DKG_ADDR,
+      ).length;
+    }
+
+    it("prefetchRegistry warms the cache so subsequent collectPartials does not scan DKG again", async () => {
+      const { publicClient, walletClient } = mockClients();
+      vi.mocked(verifyPartialSignature).mockReturnValue(true);
+      publicClient.getBlockNumber.mockResolvedValue(100n);
+
+      publicClient.getLogs.mockImplementation(async (params: any) => {
+        if (params.address === DKG_ADDR) {
+          return [makeRegisteredLog({ validatorAddr: VALIDATOR_A, enclaveCommKey: KEY_A, round: 1 })];
+        }
+        return [makePartialDecryptionLog({ validator: VALIDATOR_A, round: 1, pid: 1, uuid: 60 })];
+      });
+
+      const consumer = new Consumer({ network: "testnet", publicClient, walletClient });
+
+      await consumer.prefetchRegistry();
+      expect(dkgScanCount(publicClient)).toBe(1);
+
+      await consumer.collectPartials({
+        uuid: 60,
+        minPartials: 1,
+        fromBlock: 90n,
+        timeoutMs: 5_000,
+        pollIntervalMs: 10,
+      });
+      // Still 1 — prefetch primed the cache, collectPartials reused it.
+      expect(dkgScanCount(publicClient)).toBe(1);
+    });
+
+    it("prefetchRegistry is idempotent — concurrent calls share one scan", async () => {
+      const { publicClient, walletClient } = mockClients();
+      publicClient.getBlockNumber.mockResolvedValue(100n);
+
+      let dkgCallCount = 0;
+      publicClient.getLogs.mockImplementation(async () => {
+        dkgCallCount++;
+        await new Promise((r) => setTimeout(r, 30));
+        return [makeRegisteredLog({ validatorAddr: VALIDATOR_A, enclaveCommKey: KEY_A, round: 1 })];
+      });
+
+      const consumer = new Consumer({ network: "testnet", publicClient, walletClient });
+      await Promise.all([
+        consumer.prefetchRegistry(),
+        consumer.prefetchRegistry(),
+        consumer.prefetchRegistry(),
+      ]);
+
+      expect(dkgCallCount).toBe(1);
+    });
+
+    it("hybrid mode: queries ABCI for active round and filters Registered events to that round", async () => {
+      const { publicClient, walletClient } = mockClients();
+      vi.mocked(verifyPartialSignature).mockReturnValue(true);
+      vi.mocked(queryLatestActiveDKGNetwork).mockClear();
+      publicClient.getBlockNumber.mockResolvedValue(1_000_000n);
+
+      // ABCI says active round is 6.
+      vi.mocked(queryLatestActiveDKGNetwork).mockResolvedValue({
+        round: 6,
+        globalPublicKey: new Uint8Array(),
+        threshold: 3,
+      } as any);
+
+      const dkgRegistered = [
+        // Round 5 registrations (should be filtered out in hybrid mode).
+        makeRegisteredLog({ validatorAddr: VALIDATOR_A, enclaveCommKey: KEY_A, round: 5 }),
+        makeRegisteredLog({ validatorAddr: VALIDATOR_B, enclaveCommKey: KEY_B, round: 5 }),
+        // Round 6 registrations (active — these should be kept).
+        makeRegisteredLog({ validatorAddr: VALIDATOR_A, enclaveCommKey: KEY_A_ROUND6, round: 6 }),
+      ];
+      publicClient.getLogs.mockImplementation(async (params: any) => {
+        if (params.address === DKG_ADDR) return dkgRegistered;
+        // Partial signed under round 6 (matches active) — verify path runs through the map.
+        return [makePartialDecryptionLog({ validator: VALIDATOR_A, round: 6, pid: 1, uuid: 100 })];
+      });
+
+      const observer = makeObserverWithComet(publicClient, "http://172.192.41.96:26657");
+      const consumer = new Consumer({ network: "testnet", publicClient, walletClient, observer });
+
+      const partials = await consumer.collectPartials({
+        uuid: 100,
+        minPartials: 1,
+        fromBlock: 990_000n,
+        timeoutMs: 2_000,
+        pollIntervalMs: 10,
+      });
+
+      // ABCI was consulted exactly once per cache build.
+      expect(queryLatestActiveDKGNetwork).toHaveBeenCalledTimes(1);
+      expect(queryLatestActiveDKGNetwork).toHaveBeenCalledWith("http://172.192.41.96:26657");
+      // Partial from round 6 was accepted (signature mock returns true).
+      expect(partials).toHaveLength(1);
+      // verifyPartialSignature was called with the ROUND 6 key only.
+      const verifyCall = vi.mocked(verifyPartialSignature).mock.calls.find(
+        (c: any[]) => c[0].round === 6,
+      );
+      expect(verifyCall).toBeDefined();
+      // The commPubKey passed in must equal the round-6 key, not the round-5 one.
+      const passedKey = verifyCall![0].commPubKey;
+      const round6Bytes = toBytes(KEY_A_ROUND6);
+      expect(passedKey.length).toBe(round6Bytes.length);
+      expect([...passedKey]).toEqual([...round6Bytes]);
+    });
+
+    it("hybrid mode: when ABCI query fails, falls back to keeping all rounds (graceful degradation)", async () => {
+      const { publicClient, walletClient } = mockClients();
+      vi.mocked(verifyPartialSignature).mockReturnValue(true);
+      publicClient.getBlockNumber.mockResolvedValue(1_000_000n);
+
+      // ABCI rejects — hybrid path should swallow the error and scan without filtering.
+      vi.mocked(queryLatestActiveDKGNetwork).mockRejectedValue(new Error("ABCI unavailable"));
+
+      publicClient.getLogs.mockImplementation(async (params: any) => {
+        if (params.address === DKG_ADDR) {
+          return [
+            makeRegisteredLog({ validatorAddr: VALIDATOR_A, enclaveCommKey: KEY_A, round: 5 }),
+            makeRegisteredLog({ validatorAddr: VALIDATOR_A, enclaveCommKey: KEY_A_ROUND6, round: 6 }),
+          ];
+        }
+        return [makePartialDecryptionLog({ validator: VALIDATOR_A, round: 5, pid: 1, uuid: 101 })];
+      });
+
+      const observer = makeObserverWithComet(publicClient, "http://bad-host:26657");
+      const consumer = new Consumer({ network: "testnet", publicClient, walletClient, observer });
+
+      const partials = await consumer.collectPartials({
+        uuid: 101,
+        minPartials: 1,
+        fromBlock: 990_000n,
+        timeoutMs: 2_000,
+        pollIntervalMs: 10,
+      });
+
+      // Even though ABCI failed, the partial (round 5) still verifies because we kept
+      // both rounds' keys — the verify loop finds the round-5 match.
+      expect(partials).toHaveLength(1);
+    });
+
+    it("warns exactly once per Consumer when falling back to the default CometBFT URL", async () => {
+      const { publicClient, walletClient } = mockClients();
+      vi.mocked(verifyPartialSignature).mockReturnValue(true);
+      vi.mocked(queryLatestActiveDKGNetwork).mockResolvedValue({
+        round: 1, globalPublicKey: new Uint8Array(), threshold: 3,
+      } as any);
+      publicClient.getBlockNumber.mockResolvedValue(100n);
+      publicClient.getLogs.mockImplementation(async (params: any) => {
+        if (params.address === DKG_ADDR) {
+          return [makeRegisteredLog({ validatorAddr: VALIDATOR_A, enclaveCommKey: KEY_A, round: 1 })];
+        }
+        return [makePartialDecryptionLog({ validator: VALIDATOR_A, round: 1, pid: 1, uuid: 70 })];
+      });
+
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      try {
+        // No observer → hybrid path uses the hardcoded default URL.
+        const consumer = new Consumer({ network: "testnet", publicClient, walletClient });
+        // First accessCDR: warning fires.
+        await consumer.collectPartials({ uuid: 70, minPartials: 1, fromBlock: 90n, timeoutMs: 5_000, pollIntervalMs: 10 });
+        // Trigger an explicit refresh to force another default-URL consultation.
+        await consumer.prefetchRegistry();
+
+        const defaultWarnings = warnSpy.mock.calls.filter(
+          (c) => typeof c[0] === "string" && c[0].includes("default CometBFT RPC URL"),
+        );
+        expect(defaultWarnings).toHaveLength(1);
+        expect(defaultWarnings[0][0]).toContain("http://172.192.41.96:26657");
+      } finally {
+        warnSpy.mockRestore();
+      }
+    });
+
+    it("does not warn when the caller supplies an explicit cometRpcUrl", async () => {
+      const { publicClient, walletClient } = mockClients();
+      vi.mocked(verifyPartialSignature).mockReturnValue(true);
+      vi.mocked(queryLatestActiveDKGNetwork).mockResolvedValue({
+        round: 1, globalPublicKey: new Uint8Array(), threshold: 3,
+      } as any);
+      publicClient.getBlockNumber.mockResolvedValue(100n);
+      publicClient.getLogs.mockImplementation(async (params: any) => {
+        if (params.address === DKG_ADDR) {
+          return [makeRegisteredLog({ validatorAddr: VALIDATOR_A, enclaveCommKey: KEY_A, round: 1 })];
+        }
+        return [makePartialDecryptionLog({ validator: VALIDATOR_A, round: 1, pid: 1, uuid: 71 })];
+      });
+
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      try {
+        const observer = makeObserverWithComet(publicClient, "https://my-own-cometbft.example:26657");
+        const consumer = new Consumer({ network: "testnet", publicClient, walletClient, observer });
+        await consumer.collectPartials({ uuid: 71, minPartials: 1, fromBlock: 90n, timeoutMs: 5_000, pollIntervalMs: 10 });
+
+        const defaultWarnings = warnSpy.mock.calls.filter(
+          (c) => typeof c[0] === "string" && c[0].includes("default CometBFT RPC URL"),
+        );
+        expect(defaultWarnings).toHaveLength(0);
+      } finally {
+        warnSpy.mockRestore();
+      }
+    });
+
+    it("hybrid mode default: no observer → SDK still consults the default CometBFT URL", async () => {
+      const { publicClient, walletClient } = mockClients();
+      vi.mocked(verifyPartialSignature).mockReturnValue(true);
+      vi.mocked(queryLatestActiveDKGNetwork).mockClear();
+      // Default ABCI URL is reachable and reports active round = 6.
+      vi.mocked(queryLatestActiveDKGNetwork).mockResolvedValue({
+        round: 6,
+        globalPublicKey: new Uint8Array(),
+        threshold: 3,
+      } as any);
+      publicClient.getBlockNumber.mockResolvedValue(1_000_000n);
+
+      publicClient.getLogs.mockImplementation(async (params: any) => {
+        if (params.address === DKG_ADDR) {
+          return [
+            makeRegisteredLog({ validatorAddr: VALIDATOR_A, enclaveCommKey: KEY_A, round: 5 }),
+            makeRegisteredLog({ validatorAddr: VALIDATOR_A, enclaveCommKey: KEY_A_ROUND6, round: 6 }),
+          ];
+        }
+        return [makePartialDecryptionLog({ validator: VALIDATOR_A, round: 6, pid: 1, uuid: 102 })];
+      });
+
+      // No observer passed — SDK should fall back to the hardcoded default URL.
+      const consumer = new Consumer({ network: "testnet", publicClient, walletClient });
+
+      const partials = await consumer.collectPartials({
+        uuid: 102,
+        minPartials: 1,
+        fromBlock: 990_000n,
+        timeoutMs: 2_000,
+        pollIntervalMs: 10,
+      });
+
+      // ABCI was consulted once using the SDK's default URL (not user-supplied).
+      expect(queryLatestActiveDKGNetwork).toHaveBeenCalledTimes(1);
+      expect(queryLatestActiveDKGNetwork).toHaveBeenCalledWith(
+        "http://172.192.41.96:26657",
+      );
+      expect(partials).toHaveLength(1);
+    });
+
+    it("reuses the cached commPubKey map across back-to-back collectPartials calls", async () => {
+      const { publicClient, walletClient } = mockClients();
+      vi.mocked(verifyPartialSignature).mockReturnValue(true);
+
+      // Chain head stays at 100 so DKG scan is a single chunk.
+      publicClient.getBlockNumber.mockResolvedValue(100n);
+
+      // DKG scan response (call 1, shared by both collectPartials invocations)
+      const dkgRegistered = [
+        makeRegisteredLog({ validatorAddr: VALIDATOR_A, enclaveCommKey: KEY_A, round: 1 }),
+      ];
+      // Each collectPartials call: 1 DKG scan (only on first) + CDR polls
+      publicClient.getLogs.mockImplementation(async (params: any) => {
+        if (params.address === DKG_ADDR) return dkgRegistered;
+        // CDR: return one matching partial per uuid
+        const uuidFromCall = (publicClient.getLogs as any).mock.calls.length;
+        return [
+          makePartialDecryptionLog({
+            validator: VALIDATOR_A,
+            round: 1,
+            pid: 1,
+            uuid: uuidFromCall < 3 ? 10 : 11,
+          }),
+        ];
+      });
+
+      const consumer = new Consumer({ network: "testnet", publicClient, walletClient });
+
+      await consumer.collectPartials({
+        uuid: 10,
+        minPartials: 1,
+        fromBlock: 90n,
+        timeoutMs: 5_000,
+        pollIntervalMs: 10,
+      });
+      expect(dkgScanCount(publicClient)).toBe(1);
+
+      await consumer.collectPartials({
+        uuid: 11,
+        minPartials: 1,
+        fromBlock: 90n,
+        timeoutMs: 5_000,
+        pollIntervalMs: 10,
+      });
+      // Still 1 — cache hit on second call.
+      expect(dkgScanCount(publicClient)).toBe(1);
+    });
+
+    it("refreshes the cache once when a partial from an unknown validator appears", async () => {
+      const { publicClient, walletClient } = mockClients();
+      vi.mocked(verifyPartialSignature).mockReturnValue(true);
+      publicClient.getBlockNumber.mockResolvedValue(100n);
+
+      let dkgCallCount = 0;
+      publicClient.getLogs.mockImplementation(async (params: any) => {
+        if (params.address === DKG_ADDR) {
+          dkgCallCount++;
+          // First scan: only validator A. Second scan (refresh): also validator B.
+          return dkgCallCount === 1
+            ? [makeRegisteredLog({ validatorAddr: VALIDATOR_A, enclaveCommKey: KEY_A, round: 1 })]
+            : [
+                makeRegisteredLog({ validatorAddr: VALIDATOR_A, enclaveCommKey: KEY_A, round: 1 }),
+                makeRegisteredLog({ validatorAddr: VALIDATOR_B, enclaveCommKey: KEY_B, round: 1 }),
+              ];
+        }
+        // CDR scan: partial from validator B (unknown on first DKG scan).
+        return [makePartialDecryptionLog({ validator: VALIDATOR_B, round: 1, pid: 1, uuid: 7 })];
+      });
+
+      const consumer = new Consumer({ network: "testnet", publicClient, walletClient });
+      const partials = await consumer.collectPartials({
+        uuid: 7,
+        minPartials: 1,
+        fromBlock: 90n,
+        timeoutMs: 5_000,
+        pollIntervalMs: 10,
+      });
+
+      // Refresh happened exactly once.
+      expect(dkgCallCount).toBe(2);
+      // Validator B's partial was accepted after refresh.
+      expect(partials).toHaveLength(1);
+      expect(partials[0].validator.toLowerCase()).toBe(VALIDATOR_B.toLowerCase());
+    });
+
+    it("refreshes once when a DKG rotation leaves every cached key stale", async () => {
+      // Scenario: cache built under round 5 (KEY_A), then rotation → active round 6
+      // (KEY_A_ROUND6). Partial comes in signed under round 6. The pre-fix code only
+      // refreshed when a validator was absent from the map, so stale-but-present keys
+      // silently dropped every partial. With the fix, verification failure against
+      // cached keys triggers a one-shot refresh, after which the round-6 key matches.
+      const { publicClient, walletClient } = mockClients();
+      publicClient.getBlockNumber.mockResolvedValue(100n);
+
+      // ABCI reports round 5 on first build, round 6 on refresh.
+      vi.mocked(queryLatestActiveDKGNetwork)
+        .mockResolvedValueOnce({ round: 5, globalPublicKey: new Uint8Array(), threshold: 3 } as any)
+        .mockResolvedValue({ round: 6, globalPublicKey: new Uint8Array(), threshold: 3 } as any);
+
+      let dkgScanNo = 0;
+      publicClient.getLogs.mockImplementation(async (params: any) => {
+        if (params.address === DKG_ADDR) {
+          dkgScanNo++;
+          // First scan: only the round-5 registration is returned (hybrid filter keeps it).
+          // Second scan (refresh): chain now shows both rounds; hybrid filter keeps only round-6.
+          return dkgScanNo === 1
+            ? [makeRegisteredLog({ validatorAddr: VALIDATOR_A, enclaveCommKey: KEY_A, round: 5 })]
+            : [
+                makeRegisteredLog({ validatorAddr: VALIDATOR_A, enclaveCommKey: KEY_A, round: 5 }),
+                makeRegisteredLog({ validatorAddr: VALIDATOR_A, enclaveCommKey: KEY_A_ROUND6, round: 6 }),
+              ];
+        }
+        return [makePartialDecryptionLog({ validator: VALIDATOR_A, round: 6, pid: 1, uuid: 60 })];
+      });
+
+      // verifyPartialSignature returns true only for the round-6 key; false for anything else.
+      vi.mocked(verifyPartialSignature).mockImplementation((args: any) => {
+        const round6 = toBytes(KEY_A_ROUND6);
+        return args.commPubKey.length === round6.length &&
+          [...args.commPubKey].every((b, i) => b === round6[i]);
+      });
+
+      const observer = makeObserverWithComet(publicClient, "http://abci-mock:26657");
+      const consumer = new Consumer({ network: "testnet", publicClient, walletClient, observer });
+
+      const partials = await consumer.collectPartials({
+        uuid: 60,
+        minPartials: 1,
+        fromBlock: 90n,
+        timeoutMs: 5_000,
+        pollIntervalMs: 10,
+      });
+
+      // Refresh happened exactly once; partial accepted after refresh.
+      expect(dkgScanNo).toBe(2);
+      expect(partials).toHaveLength(1);
+    });
+
+    it("does not re-refresh for the same validator on repeated verification failure", async () => {
+      // Three partials from the same validator, all fail signature. The first failure
+      // triggers a refresh; the next two must reuse the refreshed cache without
+      // kicking off another full-history scan (refreshedFor deduplication).
+      const { publicClient, walletClient } = mockClients();
+      publicClient.getBlockNumber.mockResolvedValue(100n);
+      vi.mocked(verifyPartialSignature).mockReturnValue(false);
+
+      let dkgScanNo = 0;
+      const onInvalidPartial = vi.fn();
+      publicClient.getLogs.mockImplementation(async (params: any) => {
+        if (params.address === DKG_ADDR) {
+          dkgScanNo++;
+          return [makeRegisteredLog({ validatorAddr: VALIDATOR_A, enclaveCommKey: KEY_A, round: 1 })];
+        }
+        return [
+          makePartialDecryptionLog({ validator: VALIDATOR_A, round: 1, pid: 1, uuid: 61 }),
+          makePartialDecryptionLog({ validator: VALIDATOR_A, round: 1, pid: 2, uuid: 61 }),
+          makePartialDecryptionLog({ validator: VALIDATOR_A, round: 1, pid: 3, uuid: 61 }),
+        ];
+      });
+
+      const consumer = new Consumer({ network: "testnet", publicClient, walletClient });
+      await expect(
+        consumer.collectPartials({
+          uuid: 61,
+          minPartials: 1,
+          fromBlock: 90n,
+          timeoutMs: 300,
+          pollIntervalMs: 50,
+          onInvalidPartial,
+        }),
+      ).rejects.toThrow();
+
+      // Initial build + 1 refresh (triggered by first failed verify). Not 4.
+      expect(dkgScanNo).toBe(2);
+      expect(onInvalidPartial.mock.calls.length).toBeGreaterThanOrEqual(3);
+    });
+
+    it("does not re-refresh for the same unknown validator within one call", async () => {
+      const { publicClient, walletClient } = mockClients();
+      vi.mocked(verifyPartialSignature).mockReturnValue(true);
+      publicClient.getBlockNumber.mockResolvedValue(100n);
+
+      let dkgCallCount = 0;
+      const onInvalidPartial = vi.fn();
+
+      publicClient.getLogs.mockImplementation(async (params: any) => {
+        if (params.address === DKG_ADDR) {
+          dkgCallCount++;
+          // Validator B never appears — refresh cannot add it.
+          return [makeRegisteredLog({ validatorAddr: VALIDATOR_A, enclaveCommKey: KEY_A, round: 1 })];
+        }
+        // Three partials from the same unknown validator B.
+        return [
+          makePartialDecryptionLog({ validator: VALIDATOR_B, round: 1, pid: 1, uuid: 8 }),
+          makePartialDecryptionLog({ validator: VALIDATOR_B, round: 1, pid: 2, uuid: 8 }),
+          makePartialDecryptionLog({ validator: VALIDATOR_B, round: 1, pid: 3, uuid: 8 }),
+        ];
+      });
+
+      const consumer = new Consumer({ network: "testnet", publicClient, walletClient });
+      await expect(
+        consumer.collectPartials({
+          uuid: 8,
+          minPartials: 1,
+          fromBlock: 90n,
+          timeoutMs: 300,
+          pollIntervalMs: 50,
+          onInvalidPartial,
+        }),
+      ).rejects.toThrow();
+
+      // Exactly one refresh attempted (initial + 1), not three.
+      expect(dkgCallCount).toBe(2);
+      // All three partials reported as unknown validator.
+      expect(onInvalidPartial.mock.calls.length).toBeGreaterThanOrEqual(3);
+    });
+
+    it("scans DKG history in contiguous non-overlapping chunks covering [latestBlock - lookback, latestBlock]", async () => {
+      // The lookback now comes from Observer.getLookbackBlocks(), which
+      // computes 2×(reg+deal+fin) + active from on-chain DKG params and
+      // falls back to Observer.DEFAULT_LOOKBACK_BLOCKS (302_400n) when the
+      // params query fails. The mocked queryDKGParams throws here, so the
+      // fallback value applies.
+      const LOOKBACK = 302_400n;
+      // Any value > LOOKBACK exercises the main path (no clamp-to-0).
+      const LATEST = 17_300_000n;
+      const EXPECTED_START = LATEST - LOOKBACK;
+
+      const { publicClient, walletClient } = mockClients();
+      vi.mocked(verifyPartialSignature).mockReturnValue(true);
+      publicClient.getBlockNumber.mockResolvedValue(LATEST);
+
+      const chunks: { from: bigint; to: bigint }[] = [];
+      publicClient.getLogs.mockImplementation(async (params: any) => {
+        if (params.address === DKG_ADDR) {
+          chunks.push({ from: params.fromBlock, to: params.toBlock });
+          return [];
+        }
+        return [makePartialDecryptionLog({ validator: VALIDATOR_A, round: 1, pid: 1, uuid: 9 })];
+      });
+
+      const consumer = new Consumer({ network: "testnet", publicClient, walletClient });
+      // Force cache build by invoking the flow; collectPartials will throw since
+      // validator A isn't registered, but we only care about chunk coverage.
+      await expect(
+        consumer.collectPartials({
+          uuid: 9,
+          minPartials: 1,
+          fromBlock: LATEST,
+          timeoutMs: 200,
+          pollIntervalMs: 50,
+        }),
+      ).rejects.toThrow();
+
+      // LOOKBACK < DKG_LOGS_BLOCK_CHUNK (500_000n) → single chunk per scan.
+      // Initial build (1) + one-shot refresh on unknown validator (1) = 2 calls.
+      expect(chunks.length).toBe(2);
+
+      // Both calls must cover exactly [LATEST - LOOKBACK, LATEST].
+      for (const c of chunks) {
+        expect(c.from).toBe(EXPECTED_START);
+        expect(c.to).toBe(LATEST);
+      }
+    });
+
+    it("deduplicates concurrent cache builds — only one scan runs", async () => {
+      const { publicClient, walletClient } = mockClients();
+      vi.mocked(verifyPartialSignature).mockReturnValue(true);
+      publicClient.getBlockNumber.mockResolvedValue(100n);
+
+      let dkgCallCount = 0;
+      publicClient.getLogs.mockImplementation(async (params: any) => {
+        if (params.address === DKG_ADDR) {
+          dkgCallCount++;
+          // Simulate a slow scan so a concurrent caller arrives during the in-flight build.
+          await new Promise((r) => setTimeout(r, 50));
+          return [makeRegisteredLog({ validatorAddr: VALIDATOR_A, enclaveCommKey: KEY_A, round: 1 })];
+        }
+        return [makePartialDecryptionLog({ validator: VALIDATOR_A, round: 1, pid: 1, uuid: 20 })];
+      });
+
+      const consumer = new Consumer({ network: "testnet", publicClient, walletClient });
+      // Fire two collectPartials concurrently — both should observe one build.
+      await Promise.all([
+        consumer.collectPartials({ uuid: 20, minPartials: 1, fromBlock: 90n, timeoutMs: 5_000, pollIntervalMs: 10 }),
+        consumer.collectPartials({ uuid: 20, minPartials: 1, fromBlock: 90n, timeoutMs: 5_000, pollIntervalMs: 10 }),
+      ]);
+
+      expect(dkgCallCount).toBe(1);
+    });
+
+    it("retries a transient CDR-poll getLogs failure and still collects partials", async () => {
+      // Regression for PERF-05 flake: the partial-polling getLogs call used to
+      // bypass the retry wrapper, so a single transient "invalid block range
+      // params" from the public RPC would propagate all the way up as an
+      // accessCDR failure. With the wrapper, one bad attempt is absorbed and
+      // the poll loop keeps going.
+      const { publicClient, walletClient } = mockClients();
+      vi.mocked(verifyPartialSignature).mockReturnValue(true);
+      publicClient.getBlockNumber.mockResolvedValue(100n);
+
+      let cdrAttempt = 0;
+      publicClient.getLogs.mockImplementation(async (params: any) => {
+        if (params.address === DKG_ADDR) {
+          return [makeRegisteredLog({ validatorAddr: VALIDATOR_A, enclaveCommKey: KEY_A, round: 1 })];
+        }
+        // CDR scan: first attempt fails with the exact error observed in e2e.
+        cdrAttempt++;
+        if (cdrAttempt === 1) {
+          throw new Error("invalid block range params");
+        }
+        return [makePartialDecryptionLog({ validator: VALIDATOR_A, round: 1, pid: 1, uuid: 80 })];
+      });
+
+      const consumer = new Consumer({ network: "testnet", publicClient, walletClient });
+      const partials = await consumer.collectPartials({
+        uuid: 80,
+        minPartials: 1,
+        fromBlock: 90n,
+        timeoutMs: 5_000,
+        pollIntervalMs: 10,
+      });
+
+      // 1 transient failure + 1 successful retry.
+      expect(cdrAttempt).toBe(2);
+      expect(partials).toHaveLength(1);
+    });
+
+    it("retries a failing chunk with exponential backoff and succeeds on second attempt", async () => {
+      const { publicClient, walletClient } = mockClients();
+      vi.mocked(verifyPartialSignature).mockReturnValue(true);
+      publicClient.getBlockNumber.mockResolvedValue(100n);
+
+      let dkgAttempt = 0;
+      publicClient.getLogs.mockImplementation(async (params: any) => {
+        if (params.address === DKG_ADDR) {
+          dkgAttempt++;
+          if (dkgAttempt === 1) {
+            throw new Error("invalid block range params");
+          }
+          return [makeRegisteredLog({ validatorAddr: VALIDATOR_A, enclaveCommKey: KEY_A, round: 1 })];
+        }
+        return [makePartialDecryptionLog({ validator: VALIDATOR_A, round: 1, pid: 1, uuid: 30 })];
+      });
+
+      const consumer = new Consumer({ network: "testnet", publicClient, walletClient });
+      const partials = await consumer.collectPartials({
+        uuid: 30,
+        minPartials: 1,
+        fromBlock: 90n,
+        timeoutMs: 5_000,
+        pollIntervalMs: 10,
+      });
+
+      expect(dkgAttempt).toBe(2);
+      expect(partials).toHaveLength(1);
+    });
+
+    it("propagates the error after exhausting getLogs retries", async () => {
+      const { publicClient, walletClient } = mockClients();
+      publicClient.getBlockNumber.mockResolvedValue(100n);
+
+      publicClient.getLogs.mockRejectedValue(new Error("persistent RPC failure"));
+
+      const consumer = new Consumer({ network: "testnet", publicClient, walletClient });
+      await expect(
+        consumer.collectPartials({
+          uuid: 40,
+          minPartials: 1,
+          fromBlock: 90n,
+          timeoutMs: 5_000,
+          pollIntervalMs: 10,
+        }),
+      ).rejects.toThrow("persistent RPC failure");
+
+      // 3 attempts (MAX_ATTEMPTS) for the first chunk, then give up.
+      expect(publicClient.getLogs.mock.calls.length).toBe(3);
+    });
+
+    it("clears the cached promise on build failure so the next call retries from scratch", async () => {
+      const { publicClient, walletClient } = mockClients();
+      vi.mocked(verifyPartialSignature).mockReturnValue(true);
+      publicClient.getBlockNumber.mockResolvedValue(100n);
+
+      let callCount = 0;
+      publicClient.getLogs.mockImplementation(async (params: any) => {
+        if (params.address === DKG_ADDR) {
+          callCount++;
+          // First build: fail every retry. Second build: succeed immediately.
+          if (callCount <= 3) throw new Error("transient failure");
+          return [makeRegisteredLog({ validatorAddr: VALIDATOR_A, enclaveCommKey: KEY_A, round: 1 })];
+        }
+        return [makePartialDecryptionLog({ validator: VALIDATOR_A, round: 1, pid: 1, uuid: 50 })];
+      });
+
+      const consumer = new Consumer({ network: "testnet", publicClient, walletClient });
+
+      await expect(
+        consumer.collectPartials({
+          uuid: 50,
+          minPartials: 1,
+          fromBlock: 90n,
+          timeoutMs: 5_000,
+          pollIntervalMs: 10,
+        }),
+      ).rejects.toThrow();
+
+      // Second call must trigger a fresh build (not return the cached rejection).
+      const partials = await consumer.collectPartials({
+        uuid: 50,
+        minPartials: 1,
+        fromBlock: 90n,
+        timeoutMs: 5_000,
+        pollIntervalMs: 10,
+      });
+      expect(partials).toHaveLength(1);
+      // First build attempted 3 retries; second build succeeded on attempt 1. Total DKG calls = 4.
+      expect(callCount).toBe(4);
+    });
   });
 });

--- a/packages/sdk/src/consumer.ts
+++ b/packages/sdk/src/consumer.ts
@@ -28,6 +28,24 @@ export class Consumer {
    */
   private commPubKeyMapPromise: Promise<Map<string, Uint8Array[]>> | null = null;
 
+  /**
+   * Whether a scan is currently in progress. Used to deduplicate concurrent
+   * force-refresh requests: without this flag, two collectPartials calls that
+   * both encounter a verification failure at the same time would each call
+   * getCommPubKeyMap(true) and fan out into two parallel full-history scans.
+   * With it, the second caller joins the first refresh's in-flight promise.
+   */
+  private commPubKeyMapBuildInFlight = false;
+
+  /**
+   * Cached "fallback" Observer used by getEventLookback when the Consumer
+   * was constructed without one. Reusing the same instance preserves its
+   * `defaultCometUrlWarned` flag, so the plaintext-HTTP warning fires
+   * exactly once per Consumer instead of once per getEventLookback call
+   * (which would re-fire after every cache refresh).
+   */
+  private fallbackObserver: Observer | null = null;
+
   /** Alias for {@link accessCDR} */
   readVault: Consumer["accessCDR"];
   /** Alias for {@link downloadFile} */
@@ -140,22 +158,36 @@ export class Consumer {
 
   /**
    * Return the cached commPubKey map, building it on first call or when
-   * {@link forceRefresh} is true. Concurrent callers share the same in-flight
-   * build promise so we never scan the full history twice in parallel. If a
-   * build fails, the rejected promise is cleared so a subsequent call can
-   * retry from scratch instead of inheriting the failure.
+   * {@link forceRefresh} is true.
+   *
+   * Concurrent callers share the same in-flight build promise so we never
+   * scan the full history twice in parallel — this dedup applies to the
+   * force-refresh path as well, so two collectPartials calls that both
+   * hit a verification failure at the same time only trigger one rescan.
+   * On build failure the rejected promise is cleared so a subsequent
+   * call can retry from scratch instead of inheriting the rejection.
    */
   private async getCommPubKeyMap(forceRefresh = false): Promise<Map<string, Uint8Array[]>> {
+    // Any build currently in flight is shared with all callers, refresh or not.
+    if (this.commPubKeyMapBuildInFlight && this.commPubKeyMapPromise) {
+      return this.commPubKeyMapPromise;
+    }
+    // No build in flight: a non-refresh caller can reuse a settled cache.
     if (!forceRefresh && this.commPubKeyMapPromise) {
       return this.commPubKeyMapPromise;
     }
+    this.commPubKeyMapBuildInFlight = true;
     const dkgAddress = contractAddresses[this.network].dkg;
-    const p = this.fetchRegisteredValidators(dkgAddress).catch((err) => {
-      if (this.commPubKeyMapPromise === p) {
-        this.commPubKeyMapPromise = null;
-      }
-      throw err;
-    });
+    const p = this.fetchRegisteredValidators(dkgAddress)
+      .catch((err) => {
+        if (this.commPubKeyMapPromise === p) {
+          this.commPubKeyMapPromise = null;
+        }
+        throw err;
+      })
+      .finally(() => {
+        this.commPubKeyMapBuildInFlight = false;
+      });
     this.commPubKeyMapPromise = p;
     return p;
   }
@@ -165,16 +197,20 @@ export class Consumer {
    *   2 × (registrationPeriod + dealingPeriod + finalizationPeriod) + activePeriod
    *
    * Delegates to the configured Observer (which caches DKG params). When no
-   * Observer is wired, builds a temporary one bound to this Consumer's
-   * cometRpcUrl resolution so the same fallback URL + warning apply.
+   * Observer is wired, lazily builds a single temporary one bound to this
+   * Consumer's cometRpcUrl resolution and reuses it across calls — reusing
+   * preserves the Observer's `defaultCometUrlWarned` flag so the plaintext-
+   * HTTP warning fires once per Consumer rather than once per refresh.
    */
   private async getEventLookback(): Promise<bigint> {
     if (this.observer) return this.observer.getLookbackBlocks();
-    const tmp = new Observer({
-      network: this.network,
-      publicClient: this.publicClient,
-    });
-    return tmp.getLookbackBlocks();
+    if (!this.fallbackObserver) {
+      this.fallbackObserver = new Observer({
+        network: this.network,
+        publicClient: this.publicClient,
+      });
+    }
+    return this.fallbackObserver.getLookbackBlocks();
   }
 
   private async fetchRegisteredValidators(

--- a/packages/sdk/src/consumer.ts
+++ b/packages/sdk/src/consumer.ts
@@ -7,7 +7,7 @@ import { uuidToLabel } from "./label.js";
 import type { StorageProvider } from "./storage/types.js";
 import { Observer } from "./observer.js";
 import type { AttestationConfig } from "./attestation.js";
-import { queryCDRPartials } from "./cosmos/abci-query.js";
+import { queryCDRPartials, queryLatestActiveDKGNetwork } from "./cosmos/abci-query.js";
 import { bytesToHex as cosmosBytesToHex } from "./cosmos/protobuf.js";
 
 export class Consumer {
@@ -15,6 +15,18 @@ export class Consumer {
   private walletClient: WalletClient;
   private network: Network;
   private observer: Observer | null;
+
+  /**
+   * In-flight (or settled) promise for the cached commPubKey map. Promise-
+   * level caching deduplicates concurrent calls: if two accessCDR invocations
+   * both trigger a build at the same time, only one scan runs.
+   *
+   * Registered events are immutable, so the only staleness risk is a new
+   * validator registering after the cache was built; that surfaces as
+   * "unknown validator" during verify, which triggers an automatic one-shot
+   * refresh (see collectPartialsFromEvents).
+   */
+  private commPubKeyMapPromise: Promise<Map<string, Uint8Array[]>> | null = null;
 
   /** Alias for {@link accessCDR} */
   readVault: Consumer["accessCDR"];
@@ -33,6 +45,35 @@ export class Consumer {
     this.observer = params.observer ?? null;
     this.readVault = this.accessCDR.bind(this);
     this.readFileVault = this.downloadFile.bind(this);
+  }
+
+  /**
+   * Warm the validator commPubKey cache in the background.
+   *
+   * The cache is normally built lazily on the first accessCDR / downloadFile
+   * call, which requires a full-history scan of DKG Registered events and
+   * can take tens of seconds on mature chains — long enough that a request
+   * triggered by a user click can appear to hang. Frontends that know a
+   * read is imminent (e.g. right after user login / wallet connection) can
+   * call prefetchRegistry() to start the scan early, so the subsequent
+   * accessCDR call hits a warm cache and returns immediately.
+   *
+   * Safe to call multiple times — concurrent callers share the same
+   * in-flight build via Promise-level dedupe, so repeated prefetches cost
+   * nothing. Errors propagate; callers doing best-effort warming should
+   * attach their own `.catch(() => {})` and let the real accessCDR call
+   * surface the failure later if it still occurs.
+   *
+   * @example
+   * ```ts
+   * // Right after user login / wallet connection, in a useEffect:
+   * cdrClient.consumer.prefetchRegistry().catch(() => {
+   *   // best-effort warm-up; real accessCDR call will retry if needed
+   * });
+   * ```
+   */
+  async prefetchRegistry(): Promise<void> {
+    await this.getCommPubKeyMap();
   }
 
   /**
@@ -75,55 +116,140 @@ export class Consumer {
 
   /**
    * Fetch validator address → commPubKey[] map from DKG Registered events.
-   * Each validator may re-register with a new commPubKey in each DKG round,
-   * so we keep all keys (most recent first) to handle round mismatch during
-   * signature verification.
+   *
+   * Hybrid mode (default): query `GetLatestActiveDKGNetwork` via CometBFT
+   * ABCI to identify the currently active DKG round, then scan EVM
+   * `Registered` events within a bounded window and keep only registrations
+   * for that round. The CometBFT RPC URL defaults to
+   * {@link Observer.DEFAULT_COMET_RPC_URL}; callers can override it by
+   * passing `cometRpcUrl` when constructing `CDRClient`. If the ABCI query
+   * fails (network unreachable, URL misconfigured, etc.), we fall back to
+   * keeping every key in the window and letting the verify loop try each.
+   *
+   * The scan window is computed from on-chain DKG params via
+   * {@link Observer.getLookbackBlocks} — `2 × (registrationPeriod +
+   * dealingPeriod + finalizationPeriod) + activePeriod` — covering the
+   * current epoch plus one prior protocol pass for buffer.
    */
-  /** Default lookback window: ~7 days at ~2 s/block. Matches Observer.DEFAULT_LOOKBACK_BLOCKS. */
-  private static readonly DEFAULT_LOOKBACK_BLOCKS = 302_400n;
+  /** Chunk size for historical getLogs scans. Kept well below typical RPC block-range limits. */
+  private static readonly DKG_LOGS_BLOCK_CHUNK = 500_000n;
+  /** Max attempts per chunk getLogs call before propagating the error. */
+  private static readonly GETLOGS_MAX_ATTEMPTS = 3;
+  /** Base delay (ms) for exponential backoff between getLogs retries. */
+  private static readonly GETLOGS_BACKOFF_MS = 500;
 
-  private async getCommPubKeyMap(): Promise<Map<string, Uint8Array[]>> {
+  /**
+   * Return the cached commPubKey map, building it on first call or when
+   * {@link forceRefresh} is true. Concurrent callers share the same in-flight
+   * build promise so we never scan the full history twice in parallel. If a
+   * build fails, the rejected promise is cleared so a subsequent call can
+   * retry from scratch instead of inheriting the failure.
+   */
+  private async getCommPubKeyMap(forceRefresh = false): Promise<Map<string, Uint8Array[]>> {
+    if (!forceRefresh && this.commPubKeyMapPromise) {
+      return this.commPubKeyMapPromise;
+    }
     const dkgAddress = contractAddresses[this.network].dkg;
+    const p = this.fetchRegisteredValidators(dkgAddress).catch((err) => {
+      if (this.commPubKeyMapPromise === p) {
+        this.commPubKeyMapPromise = null;
+      }
+      throw err;
+    });
+    this.commPubKeyMapPromise = p;
+    return p;
+  }
+
+  /**
+   * Resolve the event-scan lookback window in blocks:
+   *   2 × (registrationPeriod + dealingPeriod + finalizationPeriod) + activePeriod
+   *
+   * Delegates to the configured Observer (which caches DKG params). When no
+   * Observer is wired, builds a temporary one bound to this Consumer's
+   * cometRpcUrl resolution so the same fallback URL + warning apply.
+   */
+  private async getEventLookback(): Promise<bigint> {
+    if (this.observer) return this.observer.getLookbackBlocks();
+    const tmp = new Observer({
+      network: this.network,
+      publicClient: this.publicClient,
+    });
+    return tmp.getLookbackBlocks();
+  }
+
+  private async fetchRegisteredValidators(
+    dkgAddress: `0x${string}`,
+  ): Promise<Map<string, Uint8Array[]>> {
     const latestBlock = await this.publicClient.getBlockNumber();
-    const fromBlock = latestBlock > Consumer.DEFAULT_LOOKBACK_BLOCKS
-      ? latestBlock - Consumer.DEFAULT_LOOKBACK_BLOCKS
-      : 0n;
+    const chunk = Consumer.DKG_LOGS_BLOCK_CHUNK;
+    const lookback = await this.getEventLookback();
+    const startBlock = latestBlock > lookback ? latestBlock - lookback : 0n;
 
-    const validators = await this.fetchRegisteredValidators(dkgAddress, fromBlock);
+    // Hybrid mode (default): query CometBFT ABCI for the currently active DKG
+    // round so we can filter EVM Registered events to just that round's
+    // commPubKeys. Uses the Observer's cometRpcUrl if the caller set one,
+    // otherwise falls back to the SDK's network-specific default URL (the
+    // one-time plaintext-HTTP warning is emitted by Observer.getDKGParams,
+    // which getEventLookback() already invoked above).
+    let activeRound: number | undefined;
+    const cometRpcUrl = this.observer?.cometRpcUrl ?? Observer.DEFAULT_COMET_RPC_URL;
+    try {
+      const network = await queryLatestActiveDKGNetwork(cometRpcUrl);
+      activeRound = network.round;
+    } catch {
+      // ABCI unreachable or query failed — fall back to unfiltered scan.
+    }
 
-    // Fallback: if lookback window found no validators, scan from block 0
-    if (validators.size === 0 && fromBlock > 0n) {
-      return this.fetchRegisteredValidators(dkgAddress, 0n);
+    const validators = new Map<string, Uint8Array[]>();
+
+    for (let from = startBlock; from <= latestBlock; from = from + chunk + 1n) {
+      const to = from + chunk > latestBlock ? latestBlock : from + chunk;
+
+      const rawLogs = await this.getLogsWithRetry(dkgAddress, from, to);
+
+      const parsed = parseEventLogs({
+        abi: dkgAbi,
+        logs: rawLogs,
+        eventName: "Registered",
+      });
+
+      for (const log of parsed) {
+        if (activeRound !== undefined && log.args.round !== activeRound) {
+          continue; // Hybrid mode: skip non-active rounds.
+        }
+        const addr = log.args.validatorAddr.toLowerCase() as `0x${string}`;
+        const keys = validators.get(addr) ?? [];
+        keys.push(toBytes(log.args.enclaveCommKey));
+        validators.set(addr, keys);
+      }
     }
 
     return validators;
   }
 
-  private async fetchRegisteredValidators(
-    dkgAddress: `0x${string}`,
+  /**
+   * getLogs wrapper with exponential-backoff retry. Public RPCs can return
+   * transient errors for individual chunk ranges (observed as
+   * "invalid block range params" on Aeneid); a narrow retry loop keeps the
+   * full-history scan robust without swallowing persistent failures.
+   */
+  private async getLogsWithRetry(
+    address: `0x${string}`,
     fromBlock: bigint,
-  ): Promise<Map<string, Uint8Array[]>> {
-    const rawLogs = await this.publicClient.getLogs({
-      address: dkgAddress,
-      fromBlock,
-      toBlock: "latest",
-    });
-
-    const parsed = parseEventLogs({
-      abi: dkgAbi,
-      logs: rawLogs,
-      eventName: "Registered",
-    });
-
-    const validators = new Map<string, Uint8Array[]>();
-    for (const log of parsed) {
-      const addr = log.args.validatorAddr.toLowerCase() as `0x${string}`;
-      const keys = validators.get(addr) ?? [];
-      keys.push(toBytes(log.args.enclaveCommKey));
-      validators.set(addr, keys);
+    toBlock: bigint,
+  ): Promise<Awaited<ReturnType<PublicClient["getLogs"]>>> {
+    let lastError: unknown;
+    for (let attempt = 0; attempt < Consumer.GETLOGS_MAX_ATTEMPTS; attempt++) {
+      try {
+        return await this.publicClient.getLogs({ address, fromBlock, toBlock });
+      } catch (err) {
+        lastError = err;
+        if (attempt === Consumer.GETLOGS_MAX_ATTEMPTS - 1) break;
+        const delay = Consumer.GETLOGS_BACKOFF_MS * 2 ** attempt;
+        await new Promise((resolve) => setTimeout(resolve, delay));
+      }
     }
-
-    return validators;
+    throw lastError;
   }
 
   /**
@@ -183,8 +309,11 @@ export class Consumer {
     const cdrAddress = contractAddresses[this.network].cdr;
     const deadline = Date.now() + timeoutMs;
 
-    // Build commPubKey map from DKG Registered events
-    const commPubKeyMap = await this.getCommPubKeyMap();
+    // Build commPubKey map from DKG Registered events (cached across calls).
+    let commPubKeyMap = await this.getCommPubKeyMap();
+    // Track which validators have already triggered a cache refresh this call,
+    // so a genuinely unknown validator can't force repeated re-scans.
+    const refreshedFor = new Set<string>();
 
     let lastScannedBlock = fromBlock;
     const collected = new Map<string, PartialDecryptionEvent>();
@@ -192,11 +321,12 @@ export class Consumer {
     while (Date.now() < deadline) {
       const currentBlock = await this.publicClient.getBlockNumber();
       if (currentBlock >= lastScannedBlock) {
-        const rawLogs = await this.publicClient.getLogs({
-          address: cdrAddress,
-          fromBlock: lastScannedBlock,
-          toBlock: currentBlock,
-        });
+        // Same retry wrapper used for the DKG scan: public RPCs (notably
+        // aeneid.storyrpc.io) occasionally return "invalid block range params"
+        // for tiny ranges — a transient error we should not let surface as an
+        // accessCDR failure in the middle of the poll loop. See PERF-05 flake
+        // observed in https://github.com/piplabs/story-cdr-e2e/actions/runs/24884251274.
+        const rawLogs = await this.getLogsWithRetry(cdrAddress, lastScannedBlock, currentBlock);
         lastScannedBlock = currentBlock + BigInt(1);
 
         const parsed = parseEventLogs({
@@ -221,32 +351,49 @@ export class Consumer {
                 signature: log.args.signature,
               };
 
-              // Verify signature — try all known commPubKeys for this validator
-              // (DKG round rotation may cause the signing key to differ from the latest registration)
+              // Verify signature — try all known commPubKeys for this validator.
+              // In hybrid mode the cached map holds only the active-round keys,
+              // so a DKG rotation that happens after the cache is built leaves
+              // every validator with stale (old-round) keys. Refreshing on any
+              // verification failure — not just on an absent validator — lets
+              // the next round's partials recover without a process restart.
               const validatorAddr = log.args.validator.toLowerCase();
-              const commPubKeys = commPubKeyMap.get(validatorAddr);
+              let commPubKeys = commPubKeyMap.get(validatorAddr);
 
-              if (!commPubKeys || commPubKeys.length === 0) {
-                onInvalidPartial?.(event, new Error(`unknown validator: ${log.args.validator}`));
-                continue;
-              }
+              const tryVerifyWith = (keys: Uint8Array[] | undefined): boolean => {
+                if (!keys || keys.length === 0) return false;
+                for (let ki = keys.length - 1; ki >= 0; ki--) {
+                  if (verifyPartialSignature({
+                    round: event.round,
+                    ciphertext: toBytes(log.args.ciphertext),
+                    encryptedPartial: toBytes(event.encryptedPartial),
+                    ephemeralPubKey: toBytes(event.ephemeralPubKey),
+                    pubShare: toBytes(event.pubShare),
+                    signature: toBytes(log.args.signature),
+                    commPubKey: keys[ki],
+                  })) return true;
+                }
+                return false;
+              };
 
-              let valid = false;
-              for (let ki = commPubKeys.length - 1; ki >= 0; ki--) {
-                valid = verifyPartialSignature({
-                  round: event.round,
-                  ciphertext: toBytes(log.args.ciphertext),
-                  encryptedPartial: toBytes(event.encryptedPartial),
-                  ephemeralPubKey: toBytes(event.ephemeralPubKey),
-                  pubShare: toBytes(event.pubShare),
-                  signature: toBytes(log.args.signature),
-                  commPubKey: commPubKeys[ki],
-                });
-                if (valid) break;
+              let valid = tryVerifyWith(commPubKeys);
+
+              // Refresh the cache once per validator per call on any verification
+              // failure (unknown validator OR all cached keys fail). Deduped by
+              // validator address so a genuinely bad signer can't force repeated
+              // full-history rescans within a single collectPartials invocation.
+              if (!valid && !refreshedFor.has(validatorAddr)) {
+                refreshedFor.add(validatorAddr);
+                commPubKeyMap = await this.getCommPubKeyMap(true);
+                commPubKeys = commPubKeyMap.get(validatorAddr);
+                valid = tryVerifyWith(commPubKeys);
               }
 
               if (!valid) {
-                onInvalidPartial?.(event, new Error(`invalid signature from validator ${log.args.validator}`));
+                const reason = (!commPubKeys || commPubKeys.length === 0)
+                  ? `unknown validator: ${log.args.validator}`
+                  : `invalid signature from validator ${log.args.validator}`;
+                onInvalidPartial?.(event, new Error(reason));
                 continue;
               }
 

--- a/packages/sdk/src/cosmos/abci-query.ts
+++ b/packages/sdk/src/cosmos/abci-query.ts
@@ -10,13 +10,16 @@
 import { base64ToBytes } from "./protobuf.js";
 import {
   type DKGNetwork,
+  type DKGParams,
   type DKGRegistration,
   type DKGPartialDecryptionSubmissionsByRound,
   decodeCDRPartialsResponse,
   decodeLatestActiveResponse,
+  decodeParamsResponse,
   decodeVerifiedRegistrationsResponse,
   encodeCDRPartialsRequest,
   encodeLatestActiveRequest,
+  encodeParamsRequest,
   encodeVerifiedRegistrationsRequest,
 } from "./dkg-proto.js";
 
@@ -83,6 +86,20 @@ export async function queryLatestActiveDKGNetwork(
     encodeLatestActiveRequest(),
   );
   return decodeLatestActiveResponse(bytes);
+}
+
+/**
+ * Query x/dkg module parameters. All `*Period` fields are durations in BLOCKS
+ * (not seconds). One full DKG epoch =
+ *   registrationPeriod + dealingPeriod + finalizationPeriod + activePeriod.
+ */
+export async function queryDKGParams(rpcUrl: string): Promise<DKGParams> {
+  const bytes = await abciQuery(
+    rpcUrl,
+    `${SERVICE}/Params`,
+    encodeParamsRequest(),
+  );
+  return decodeParamsResponse(bytes);
 }
 
 export async function queryVerifiedRegistrations(

--- a/packages/sdk/src/cosmos/dkg-proto.ts
+++ b/packages/sdk/src/cosmos/dkg-proto.ts
@@ -63,6 +63,17 @@ export interface DKGPartialDecryptionSubmissionsByRound {
   thresholdMet: boolean;
 }
 
+/**
+ * x/dkg module parameters. All `*Period` fields are durations in BLOCKS.
+ * One full DKG epoch = registrationPeriod + dealingPeriod + finalizationPeriod + activePeriod.
+ */
+export interface DKGParams {
+  registrationPeriod: bigint;
+  dealingPeriod: bigint;
+  finalizationPeriod: bigint;
+  activePeriod: bigint;
+}
+
 // ---------------------------------------------------------------------------
 // Decoders
 // ---------------------------------------------------------------------------
@@ -228,6 +239,43 @@ export function decodeVerifiedRegistrationsResponse(
   return out;
 }
 
+/** QueryParamsResponse { Params params = 1; } */
+export function decodeParamsResponse(bytes: Uint8Array): DKGParams {
+  const r = new Reader(bytes);
+  let inner: Uint8Array | null = null;
+  while (!r.eof) {
+    const { field, wireType } = r.readTag();
+    if (field === 1 && wireType === 2) {
+      inner = r.readLenDelim();
+    } else {
+      r.skipField(wireType);
+    }
+  }
+  if (!inner) throw new Error("params: missing params field");
+  return decodeDKGParams(inner);
+}
+
+export function decodeDKGParams(bytes: Uint8Array): DKGParams {
+  const r = new Reader(bytes);
+  const out: DKGParams = {
+    registrationPeriod: 0n,
+    dealingPeriod: 0n,
+    finalizationPeriod: 0n,
+    activePeriod: 0n,
+  };
+  while (!r.eof) {
+    const { field, wireType } = r.readTag();
+    switch (field) {
+      case 1: out.registrationPeriod = r.readVarint(); break;
+      case 2: out.dealingPeriod = r.readVarint(); break;
+      case 3: out.finalizationPeriod = r.readVarint(); break;
+      case 4: out.activePeriod = r.readVarint(); break;
+      default: r.skipField(wireType);
+    }
+  }
+  return out;
+}
+
 /** QueryGetCDRPartialsResponse { repeated DKGPartialDecryptionSubmissionsByRound submissions = 1; } */
 export function decodeCDRPartialsResponse(
   bytes: Uint8Array,
@@ -251,6 +299,11 @@ export function decodeCDRPartialsResponse(
 
 /** QueryGetLatestActiveDKGNetworkRequest (empty) */
 export function encodeLatestActiveRequest(): Uint8Array {
+  return new Uint8Array();
+}
+
+/** QueryParamsRequest (empty) */
+export function encodeParamsRequest(): Uint8Array {
   return new Uint8Array();
 }
 
@@ -344,6 +397,19 @@ export function encodePartialsByRound(
 
 export function encodeLatestActiveResponse(n: DKGNetwork): Uint8Array {
   return new Writer().writeMessage(1, encodeDKGNetwork(n)).finish();
+}
+
+export function encodeDKGParams(p: DKGParams): Uint8Array {
+  const w = new Writer();
+  if (p.registrationPeriod !== 0n) w.writeTag(1, 0).writeVarint(p.registrationPeriod);
+  if (p.dealingPeriod !== 0n) w.writeTag(2, 0).writeVarint(p.dealingPeriod);
+  if (p.finalizationPeriod !== 0n) w.writeTag(3, 0).writeVarint(p.finalizationPeriod);
+  if (p.activePeriod !== 0n) w.writeTag(4, 0).writeVarint(p.activePeriod);
+  return w.finish();
+}
+
+export function encodeParamsResponse(p: DKGParams): Uint8Array {
+  return new Writer().writeMessage(1, encodeDKGParams(p)).finish();
 }
 
 export function encodeVerifiedRegistrationsResponse(

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -8,6 +8,7 @@ export * from "./label.js";
 export * from "./conditions.js";
 export * from "./attestation.js";
 export * from "./storage/index.js";
+export type { DKGParams } from "./cosmos/dkg-proto.js";
 
 // Re-export from sub-packages for convenience
 export * from "@piplabs/cdr-contracts";

--- a/packages/sdk/src/observer.ts
+++ b/packages/sdk/src/observer.ts
@@ -11,10 +11,11 @@ import { CURVE_ED25519 } from "@piplabs/cdr-crypto";
 import type { Vault } from "./types.js";
 import { RpcConsensusError } from "./errors.js";
 import {
+  queryDKGParams,
   queryLatestActiveDKGNetwork,
   queryVerifiedRegistrations,
 } from "./cosmos/abci-query.js";
-import type { DKGNetwork } from "./cosmos/dkg-proto.js";
+import type { DKGNetwork, DKGParams } from "./cosmos/dkg-proto.js";
 
 /**
  * Which backend to use for DKG queries.
@@ -43,8 +44,24 @@ export class Observer {
   /** Many RPCs reject or time out on wide eth_getLogs ranges; chunk to stay under typical caps. */
   private static readonly DKG_LOGS_BLOCK_CHUNK = 8192n;
 
-  /** Default lookback window: ~7 days at ~2 s/block. Avoids scanning from block 0 on long chains. */
+  /**
+   * Fallback lookback window when DKG params can't be fetched from any
+   * CometBFT RPC. When params are reachable, the window is computed as
+   * `2 × (registrationPeriod + dealingPeriod + finalizationPeriod) + activePeriod`,
+   * which spans the current epoch plus a buffer of one prior DKG protocol pass.
+   */
   private static readonly DEFAULT_LOOKBACK_BLOCKS = 302_400n;
+
+  /**
+   * Default CometBFT RPC URL used to fetch DKG params when the caller has not
+   * configured `cometRpcUrl`. Pinned to the Aeneid / mainnet endpoint so the
+   * SDK works zero-config for development and demos.
+   *
+   * ⚠️ Plaintext HTTP — a network-level attacker could forge params /
+   * activeRound responses. Production deployments should always pass an
+   * explicit `cometRpcUrl` (own node, or HTTPS).
+   */
+  static readonly DEFAULT_COMET_RPC_URL = "http://172.192.41.96:26657";
 
   private publicClient: PublicClient;
   private network: Network;
@@ -52,6 +69,8 @@ export class Observer {
   readonly cometRpcUrl: string | undefined;
   private minThresholdRatio?: number;
   private validationClients?: PublicClient[];
+  private dkgParamsPromise: Promise<DKGParams> | null = null;
+  private defaultCometUrlWarned = false;
 
   constructor(params: {
     network: Network;
@@ -269,10 +288,9 @@ export class Observer {
     round?: number;
   }): Promise<Map<string, Uint8Array>> {
     const toBlock = await this.publicClient.getBlockNumber();
+    const lookback = await this.getLookbackBlocks();
     const fromBlock = params?.fromBlock ??
-      (toBlock > Observer.DEFAULT_LOOKBACK_BLOCKS
-        ? toBlock - Observer.DEFAULT_LOOKBACK_BLOCKS
-        : 0n);
+      (toBlock > lookback ? toBlock - lookback : 0n);
 
     const rawLogs = await this.fetchDkgEventLogs(
       this.publicClient,
@@ -342,10 +360,9 @@ export class Observer {
   private async getFinalizedEvents(params?: { fromBlock?: bigint; toBlock?: bigint }): Promise<Array<{ args: { round: number; globalPubKey: `0x${string}`; validatorAddr: `0x${string}` } }>> {
     const toBlock =
       params?.toBlock ?? (await this.publicClient.getBlockNumber());
+    const lookback = await this.getLookbackBlocks();
     const fromBlock = params?.fromBlock ??
-      (toBlock > Observer.DEFAULT_LOOKBACK_BLOCKS
-        ? toBlock - Observer.DEFAULT_LOOKBACK_BLOCKS
-        : 0n);
+      (toBlock > lookback ? toBlock - lookback : 0n);
 
     const rawLogs = await this.fetchDkgEventLogs(
       this.publicClient,
@@ -428,10 +445,9 @@ export class Observer {
     // Cross-validate against additional RPCs if configured
     if (this.validationClients?.length) {
       const primaryHex = toHex(rawPoint);
+      const lookback = await this.getLookbackBlocks();
       const fromBlock = params?.fromBlock ??
-        (toBlock > Observer.DEFAULT_LOOKBACK_BLOCKS
-          ? toBlock - Observer.DEFAULT_LOOKBACK_BLOCKS
-          : 0n);
+        (toBlock > lookback ? toBlock - lookback : 0n);
 
       const settled = await Promise.allSettled(
         this.validationClients.map(async (client) => {
@@ -463,10 +479,9 @@ export class Observer {
     round?: number;
   }): Promise<Map<string, Uint8Array>> {
     const toBlock = await this.publicClient.getBlockNumber();
+    const lookback = await this.getLookbackBlocks();
     const fromBlock = params?.fromBlock ??
-      (toBlock > Observer.DEFAULT_LOOKBACK_BLOCKS
-        ? toBlock - Observer.DEFAULT_LOOKBACK_BLOCKS
-        : 0n);
+      (toBlock > lookback ? toBlock - lookback : 0n);
 
     const rawLogs = await this.fetchDkgEventLogs(
       this.publicClient,
@@ -507,6 +522,51 @@ export class Observer {
 
   private async getLatestActiveNetwork(): Promise<DKGNetwork> {
     return queryLatestActiveDKGNetwork(this.requireCometRpcUrl());
+  }
+
+  /**
+   * Fetch x/dkg module Params, cached for the lifetime of this Observer.
+   * Uses the configured `cometRpcUrl`; falls back to
+   * {@link Observer.DEFAULT_COMET_RPC_URL} with a one-time warning when none
+   * is set.
+   */
+  async getDKGParams(): Promise<DKGParams> {
+    if (!this.dkgParamsPromise) {
+      const url = this.cometRpcUrl ?? Observer.DEFAULT_COMET_RPC_URL;
+      if (!this.cometRpcUrl && !this.defaultCometUrlWarned) {
+        this.defaultCometUrlWarned = true;
+        // eslint-disable-next-line no-console
+        console.warn(
+          "[cdr-sdk] Using the default CometBFT RPC URL over plaintext HTTP " +
+            `(${Observer.DEFAULT_COMET_RPC_URL}) to fetch DKG params for the event-scan lookback. ` +
+            "A network-level attacker can forge params and shrink/expand the scan window. " +
+            "For production, pass `cometRpcUrl` to CDRClient pointing to your own CometBFT node " +
+            "or an HTTPS endpoint.",
+        );
+      }
+      this.dkgParamsPromise = queryDKGParams(url).catch((e) => {
+        this.dkgParamsPromise = null;
+        throw e;
+      });
+    }
+    return this.dkgParamsPromise;
+  }
+
+  /**
+   * Lookback window for EVM event scans, in blocks:
+   *   2 × (registrationPeriod + dealingPeriod + finalizationPeriod) + activePeriod
+   *
+   * Falls back to {@link Observer.DEFAULT_LOOKBACK_BLOCKS} when DKG params
+   * are unreachable on every CometBFT URL.
+   */
+  async getLookbackBlocks(): Promise<bigint> {
+    try {
+      const p = await this.getDKGParams();
+      return 2n * (p.registrationPeriod + p.dealingPeriod + p.finalizationPeriod)
+        + p.activePeriod;
+    } catch {
+      return Observer.DEFAULT_LOOKBACK_BLOCKS;
+    }
   }
 
   private async getGlobalPubKeyFromCosmos(): Promise<Uint8Array> {


### PR DESCRIPTION
## The bug

`accessCDR` and `downloadFile` consistently return `got 0/N partials` and time out on chains where the active DKG round is older than the configured lookback window. Reproduced on Aeneid in [story-cdr-e2e run 24841032260](https://github.com/piplabs/story-cdr-e2e/actions/runs/24841032260).

## Root cause

`Consumer.fetchRegisteredValidators` walks back a fixed 302 400-block (~7 day) window of `Registered` events to build the commPubKey map used to verify partials. Two failure modes:

1. **History older than the window.** A partial signed under round N is verified against keys from `Registered` events. Once a validator's round-N registration falls outside the 7-day window, every partial it signs is dropped — even though the event is still on chain.
2. **Cache cannot self-heal.** No instance-level cache and no refresh on verification failure. Each `accessCDR` re-scans the window from scratch, and a stale view persists for the life of the `Consumer`.

Both surface to the user as the same `got 0/N` timeout.

## How this PR fixes it

- **Per-instance commPubKey map cache** with Promise-level dedupe, so concurrent `accessCDR` callers share one in-flight build instead of fanning out into parallel scans. Public `prefetchRegistry()` lets frontends warm the cache at login so the first user-triggered read returns from a hot cache.
- **Chunked, retry-protected `getLogs`** for the DKG history scan — a transient public-RPC error on a single chunk no longer aborts the whole build.
- **Hybrid active-round filter.** Query CometBFT `GetLatestActiveDKGNetwork` for the currently active round, then keep only that round's keys from a bounded EVM event window. If ABCI is unreachable the code falls back to the unfiltered scan, so this is a performance/scope tightening with no functional regression.
- **Refresh on any verification failure.** In hybrid mode the cache holds only the active round's keys, so a rotation invalidates every entry — but validators are still in the map, so the absent-validator refresh trigger never fires. The refresh now triggers on any verify-fail (deduped per validator per call), and the loop re-runs against the fresh map.
- **Lookback derived from on-chain params.** New `queryDKGParams()` ABCI call + `2 × (registration + dealing + finalization) + active` formula, so the same SDK works on networks with different DKG cadence without hardcoded per-network constants. 302 400-block static fallback when params are unreachable.
- **Default-URL safety surface.** The bundled CometBFT default is plain HTTP and MITM-able; JSDoc spells out the threat model and a one-time `console.warn` per `Consumer` instance fires when the default is consulted at runtime, so production deployments visibly know to override `cometRpcUrl`.

## Public API

No breaking changes. `prefetchRegistry()` is the only addition — opt-in, backwards compatible. `accessCDR` / `downloadFile` / `Observer.dkgSource` signatures unchanged.

## Performance (live Aeneid, before vs after)

| Metric | Before | After |
|---|---|---|
| Partials verified | 0 / 30 | 30 / 30 |
| `getLogs` calls per cold cache build | 34 | 1 |
| Cold-start latency | ~14 s | ~1.3 s |
| Concurrent cache builds | N parallel scans | 1 (Promise dedupe) |
| Transient RPC error during poll | hard fail | retry up to 3× |

## Test plan

- [x] `pnpm --filter @piplabs/cdr-sdk test` — unit suite passes
- [x] story-cdr-e2e Aeneid full suite — only pre-existing fails remain (cosmos-abci issue #46)
- [x] story-cdr-e2e DevNet `E2E-01` — full upload + access roundtrip green

## Related

- Issue #53 — original bug report
- Issue #46 — separate cosmos-abci mode gap (not addressed here)