### PR TITLE
chore(release): npm publish setup

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 PIP Labs Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/contracts/LICENSE
+++ b/packages/contracts/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 PIP Labs Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/contracts/README.md
+++ b/packages/contracts/README.md
@@ -15,7 +15,7 @@ npm install @piplabs/cdr-contracts viem
 - `cdrAbi`, `dkgAbi` — viem-compatible ABIs
 - `contractAddresses` — `{ mainnet: { dkg, cdr }, testnet: { dkg, cdr } }`
 - `type Network` — `"mainnet" | "testnet"`
-- `getCdrContract`, `getDkgContract` — viem contract helpers
+- `getCDRContract`, `getDKGContract` — viem `getContract` helpers
 
 ## Usage
 

--- a/packages/contracts/README.md
+++ b/packages/contracts/README.md
@@ -1,0 +1,36 @@
+# @piplabs/cdr-contracts
+
+ABIs, deployment addresses, and the `Network` type for the CDR (Confidential Data Rails) contracts on Story L1.
+
+This package is a building block for [`@piplabs/cdr-sdk`](https://www.npmjs.com/package/@piplabs/cdr-sdk). Most users should install the SDK instead — it re-exports everything from this package.
+
+## Install
+
+```sh
+npm install @piplabs/cdr-contracts viem
+```
+
+## Exports
+
+- `cdrAbi`, `dkgAbi` — viem-compatible ABIs
+- `contractAddresses` — `{ mainnet: { dkg, cdr }, testnet: { dkg, cdr } }`
+- `type Network` — `"mainnet" | "testnet"`
+- `getCdrContract`, `getDkgContract` — viem contract helpers
+
+## Usage
+
+```ts
+import { cdrAbi, contractAddresses } from "@piplabs/cdr-contracts";
+import { createPublicClient, http } from "viem";
+
+const client = createPublicClient({ transport: http("https://aeneid.storyrpc.io") });
+const fee = await client.readContract({
+  address: contractAddresses.testnet.cdr,
+  abi: cdrAbi,
+  functionName: "readFee",
+});
+```
+
+## License
+
+MIT — see [LICENSE](./LICENSE).

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -2,8 +2,17 @@
   "name": "@piplabs/cdr-contracts",
   "version": "0.1.1",
   "type": "module",
+  "license": "MIT",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "publishConfig": {
+    "access": "public"
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE"
+  ],
   "scripts": {
     "build": "tsc",
     "clean": "rm -rf dist",

--- a/packages/crypto/LICENSE
+++ b/packages/crypto/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 PIP Labs Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/crypto/README.md
+++ b/packages/crypto/README.md
@@ -1,0 +1,27 @@
+# @piplabs/cdr-crypto
+
+Cryptographic primitives for the CDR (Confidential Data Rails) protocol on Story L1: TDH2 threshold encryption, ECIES partial decryption, partial-signature verification, and AEAD file encryption.
+
+This package is a building block for [`@piplabs/cdr-sdk`](https://www.npmjs.com/package/@piplabs/cdr-sdk). Most users should install the SDK instead — it re-exports everything from this package.
+
+## Install
+
+```sh
+npm install @piplabs/cdr-crypto
+```
+
+## Exports
+
+- `tdh2Encrypt`, `tdh2Verify`, `tdh2Combine`, `tdh2ExtractLabel` — threshold ElGamal (TDH2)
+- `decryptPartial`, `generateEphemeralKeyPair` — ECIES helpers used to receive partial decryptions
+- `verifyPartialSignature` — Ed25519 signature check on a validator partial
+- `encryptFile`, `decryptFile` — AES-GCM streaming file encryption keyed by a TDH2-protected data key
+- `initWasm`, `resetWasm`, `getWasm`, `setWasmForTesting`, `CURVE_ED25519` — WASM module lifecycle (must call `initWasm()` once before any TDH2 op)
+
+## WASM bundle
+
+The TDH2 implementation is compiled to a `cb-mpc-tdh2.wasm` shipped in `dist/wasm/`. Bundlers must be able to copy or fetch this file at runtime. See the SDK README for environment-specific setup notes.
+
+## License
+
+MIT — see [LICENSE](./LICENSE).

--- a/packages/crypto/README.md
+++ b/packages/crypto/README.md
@@ -1,6 +1,6 @@
 # @piplabs/cdr-crypto
 
-Cryptographic primitives for the CDR (Confidential Data Rails) protocol on Story L1: TDH2 threshold encryption, ECIES partial decryption, partial-signature verification, and AEAD file encryption.
+Cryptographic primitives for the CDR (Confidential Data Rails) protocol on Story L1: TDH2 threshold encryption (via WASM), ECIES partial decryption, validator partial-signature verification, and file encryption.
 
 This package is a building block for [`@piplabs/cdr-sdk`](https://www.npmjs.com/package/@piplabs/cdr-sdk). Most users should install the SDK instead — it re-exports everything from this package.
 
@@ -12,15 +12,15 @@ npm install @piplabs/cdr-crypto
 
 ## Exports
 
-- `tdh2Encrypt`, `tdh2Verify`, `tdh2Combine`, `tdh2ExtractLabel` — threshold ElGamal (TDH2)
+- `tdh2Encrypt`, `tdh2Verify`, `tdh2Combine`, `tdh2ExtractLabel` — TDH2 threshold encryption (implementation in WASM)
 - `decryptPartial`, `generateEphemeralKeyPair` — ECIES helpers used to receive partial decryptions
-- `verifyPartialSignature` — Ed25519 signature check on a validator partial
-- `encryptFile`, `decryptFile` — AES-GCM streaming file encryption keyed by a TDH2-protected data key
+- `verifyPartialSignature` — secp256k1 ECDSA verification of a validator's partial-decryption signature (RLP encode the response fields, keccak256, recover, address compare against `commPubKey`)
+- `encryptFile`, `decryptFile` — AES-256-GCM single-pass file encryption (`Uint8Array` in / `Uint8Array` out, ciphertext format: `IV || encrypted || GCM tag`)
 - `initWasm`, `resetWasm`, `getWasm`, `setWasmForTesting`, `CURVE_ED25519` — WASM module lifecycle (must call `initWasm()` once before any TDH2 op)
 
 ## WASM bundle
 
-The TDH2 implementation is compiled to a `cb-mpc-tdh2.wasm` shipped in `dist/wasm/`. Bundlers must be able to copy or fetch this file at runtime. See the SDK README for environment-specific setup notes.
+The TDH2 implementation is compiled to `cb-mpc-tdh2.wasm` shipped in `dist/wasm/`. Bundlers must be able to copy or fetch this file at runtime.
 
 ## License
 

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -2,8 +2,17 @@
   "name": "@piplabs/cdr-crypto",
   "version": "0.1.1",
   "type": "module",
+  "license": "MIT",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "publishConfig": {
+    "access": "public"
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE"
+  ],
   "scripts": {
     "build": "tsc && cp src/wasm/cb-mpc-tdh2.js src/wasm/cb-mpc-tdh2.wasm dist/wasm/",
     "test": "vitest run",

--- a/packages/sdk/LICENSE
+++ b/packages/sdk/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 PIP Labs Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -1,0 +1,55 @@
+# @piplabs/cdr-sdk
+
+TypeScript SDK for **Confidential Data Rails (CDR)** on Story L1. Encrypt data to a threshold DKG public key, store it in on-chain vaults, and recover it when a quorum of validators provide partial decryptions.
+
+This is the main entry point. It re-exports everything you need from `@piplabs/cdr-contracts` (ABIs + addresses) and `@piplabs/cdr-crypto` (TDH2 / ECIES primitives).
+
+## Install
+
+```sh
+npm install @piplabs/cdr-sdk viem
+```
+
+Optional storage providers (peer dependencies, install only what you use):
+
+```sh
+npm install helia @helia/unixfs multiformats     # IPFS via Helia
+npm install @storacha/client                     # Storacha
+npm install @filoz/synapse-sdk                   # Filecoin via Synapse
+```
+
+## Quick start
+
+```ts
+import { CDRClient, initWasm } from "@piplabs/cdr-sdk";
+import { createPublicClient, createWalletClient, http } from "viem";
+import { privateKeyToAccount } from "viem/accounts";
+
+await initWasm(); // Required before any encryption
+
+const account = privateKeyToAccount(process.env.PRIVATE_KEY as `0x${string}`);
+const client = new CDRClient({
+  network: "testnet",
+  publicClient: createPublicClient({ transport: http("https://aeneid.storyrpc.io") }),
+  walletClient: createWalletClient({ account, transport: http("https://aeneid.storyrpc.io") }),
+});
+
+const globalPubKey = await client.observer.getGlobalPubKey();
+const threshold = await client.observer.getThreshold();
+```
+
+See the full [repository README](https://github.com/piplabs/cdr-sdk#readme) for end-to-end upload + read flows, condition contracts, and architecture docs.
+
+## Public API
+
+- `CDRClient` — top-level client with `.observer`, `.uploader`, `.consumer`
+- `Uploader` — write encrypted data to a CDR vault
+- `Consumer` — request a vault read and combine partial decryptions
+- `Observer` — query CDR contract state and DKG round info
+- `conditions` — helpers for write/read condition contracts (`open`, `ownerOnly`, `tokenGate`, `merkle`, `custom`)
+- Re-exported from `@piplabs/cdr-crypto`: `tdh2Encrypt`, `tdh2Combine`, `verifyPartialSignature`, `encryptFile`, `decryptFile`, `initWasm`, ...
+- Re-exported from `@piplabs/cdr-contracts`: `cdrAbi`, `dkgAbi`, `contractAddresses`, `Network`, ...
+
+## License
+
+MIT — see [LICENSE](./LICENSE).

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -2,8 +2,17 @@
   "name": "@piplabs/cdr-sdk",
   "version": "0.1.1",
   "type": "module",
+  "license": "MIT",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "publishConfig": {
+    "access": "public"
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE"
+  ],
   "scripts": {
     "build": "tsc",
     "test": "vitest run",


### PR DESCRIPTION
## Summary

Prepare the 3 packages for first npm publish.

- `publishConfig.access = "public"` on all 3 (scoped `@piplabs/*` defaults to private; without this, first publish 402s)
- `files: ["dist", "README.md", "LICENSE"]` whitelist on all 3 (no src / tests / configs leak into tarball)
- `license: "MIT"` field for npm registry UI
- MIT LICENSE at root + a copy in each package dir (npm tarballs only see the package dir)
- Per-package READMEs: sdk README is the primary npm landing page; contracts + crypto are terse pointers to the SDK

Version stays at **0.1.1** for this first publish (testing the full flow with the version that's been on main). Next release that ships merged code bumps to 0.1.2.

## Verified via `pnpm publish --dry-run`

| Package | Files | Contains LICENSE+README |
|---|---|---|
| `@piplabs/cdr-contracts` | 23 (dist/ only + meta) | yes |
| `@piplabs/cdr-crypto` | dist/ + wasm + meta | yes |
| `@piplabs/cdr-sdk` | dist/ + meta | yes |

No `src/`, `__tests__/`, or config files leaked.

## Known cosmetic issue (out of scope)

`packages/contracts/dist/contracts.d.ts` is 2.6 MB because viem's `getContract()` generic inlines the full ABI as a literal type. Runtime unaffected. Future cleanup: stop exporting the typed contract helper from the public surface, or split it behind a deeper import path.

## Test plan

- [x] `pnpm -r run build` — clean
- [x] `pnpm publish --dry-run` on each package — tarballs include only dist/ + LICENSE + README + package.json
- [ ] After merge: `npm login` + manual publish in dependency order (contracts → crypto → sdk)
- [ ] Smoke test: fresh install in /tmp, `import { CDRClient } from "@piplabs/cdr-sdk"`