### PR TITLE
chore(cli): enable npm publish for @piplabs/cdr-cli

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -10,5 +10,5 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": ["@piplabs/cdr-cli"]
+  "ignore": []
 }

--- a/apps/cli/LICENSE
+++ b/apps/cli/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 PIP Labs Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -45,18 +45,20 @@ export CDR_PRIVATE_KEY=0x...
 # 1. See current fees (no key needed for read-only queries)
 cdr-cli --network testnet status fees
 
-# 2. Allocate a vault (open-access conditions for demo only)
-cdr-cli --network testnet allocate \
-  --write-condition 0x... --read-condition 0x...
+# 2. Allocate a vault and capture the assigned UUID from the JSON output.
+#    `allocate` returns { txHash, uuid }.
+UUID=$(cdr-cli --network testnet --json allocate \
+  --write-condition 0x... --read-condition 0x... | jq -r '.uuid')
 
-# 3. Encrypt a 32-byte data key against the DKG global pubkey
-cdr-cli encrypt --data-key 0x...32-bytes... --global-pub-key 0x... --uuid 42
+# 3. Encrypt a 32-byte data key against the DKG global pubkey, scoped to this
+#    vault's UUID (used to derive the TDH2 label).
+cdr-cli encrypt --data-key 0x...32-bytes... --global-pub-key 0x... --uuid "$UUID"
 
-# 4. Write the resulting ciphertext into the vault
-cdr-cli --network testnet write --uuid 42 --encrypted-data 0x...
+# 4. Write the resulting ciphertext into the vault.
+cdr-cli --network testnet write --uuid "$UUID" --encrypted-data 0x...
 
-# 5. Request a read; collect partials off-chain
-cdr-cli --network testnet read --uuid 42 --requester-pub-key 0x...
+# 5. Request a read; collect partials off-chain.
+cdr-cli --network testnet read --uuid "$UUID" --requester-pub-key 0x...
 ```
 
 For the full upload/read flow including `collectPartials` and `tdh2Combine`, use the SDK directly — the CLI exposes the contract-facing primitives but does not orchestrate validator-partial collection.

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -1,0 +1,64 @@
+# @piplabs/cdr-cli
+
+Command-line interface for the [CDR (Confidential Data Rails) protocol](https://github.com/piplabs/cdr-sdk) on Story L1. Wraps the `@piplabs/cdr-sdk` runtime in a `cdr-cli` binary you can pipe shell scripts into.
+
+## Install
+
+```sh
+npm install -g @piplabs/cdr-cli
+# or, project-local
+npm install --save-dev @piplabs/cdr-cli
+```
+
+## Global options
+
+Available on every subcommand:
+
+| Flag | Description | Default |
+|---|---|---|
+| `--network <name>` | `mainnet` or `testnet` | `testnet` |
+| `--rpc-url <url>` | Override the chain RPC URL | (network default) |
+| `--private-key <hex>` | Wallet private key. May also be set via `CDR_PRIVATE_KEY` environment variable. | — |
+| `--json` | Output structured JSON instead of human-readable text | off |
+
+## Subcommands
+
+| Command | Purpose |
+|---|---|
+| `cdr-cli status vault <uuid>` | Print vault details for a given UUID |
+| `cdr-cli status fees` | Print current `allocateFee`, `writeFee`, `readFee` |
+| `cdr-cli allocate --write-condition <addr> --read-condition <addr> [--updatable] [--write-condition-data <hex>] [--read-condition-data <hex>] [--fee <wei>]` | Allocate a new CDR vault |
+| `cdr-cli write --uuid <n> --encrypted-data <hex> [--access-aux-data <hex>] [--fee <wei>]` | Write encrypted data to a vault |
+| `cdr-cli read --uuid <n> --requester-pub-key <hex> [--access-aux-data <hex>] [--fee <wei>]` | Request a vault read (emits the `VaultRead` event for validators to act on) |
+| `cdr-cli encrypt --data-key <hex> --global-pub-key <hex> --uuid <n>` | TDH2-encrypt a data key against the DKG global public key, scoped to a vault label |
+| `cdr-cli decrypt-partial --encrypted-partial <hex> --ephemeral-pub-key <hex> --recipient-priv-key <hex>` | ECIES-decrypt one validator's partial decryption returned for a `read` request |
+
+Run `cdr-cli <subcommand> --help` for the live flag set.
+
+## Quick example
+
+```sh
+# 1. See current fees
+cdr-cli --network testnet status fees
+
+# 2. Allocate a vault (open-access conditions for demo only)
+cdr-cli --network testnet --private-key 0x... allocate \
+  --write-condition 0x... --read-condition 0x...
+
+# 3. Encrypt a 32-byte data key against the DKG global pubkey
+cdr-cli encrypt --data-key 0x...32-bytes... --global-pub-key 0x... --uuid 42
+
+# 4. Write the resulting ciphertext into the vault
+cdr-cli --network testnet --private-key 0x... write \
+  --uuid 42 --encrypted-data 0x...
+
+# 5. Request a read; collect partials off-chain
+cdr-cli --network testnet --private-key 0x... read \
+  --uuid 42 --requester-pub-key 0x...
+```
+
+For the full upload/read flow including `collectPartials` and `tdh2Combine`, use the SDK directly — the CLI exposes the contract-facing primitives but does not orchestrate validator-partial collection.
+
+## License
+
+MIT — see [LICENSE](./LICENSE).

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -18,7 +18,7 @@ Available on every subcommand:
 |---|---|---|
 | `--network <name>` | `mainnet` or `testnet` | `testnet` |
 | `--rpc-url <url>` | Override the chain RPC URL | (network default) |
-| `--private-key <hex>` | Wallet private key. May also be set via `CDR_PRIVATE_KEY` environment variable. | — |
+| `--private-key <hex>` | Wallet private key. **Prefer the `CDR_PRIVATE_KEY` environment variable** — passing secrets as CLI flags exposes them to `ps`, shell history, and CI logs. | — |
 | `--json` | Output structured JSON instead of human-readable text | off |
 
 ## Subcommands
@@ -38,23 +38,25 @@ Run `cdr-cli <subcommand> --help` for the live flag set.
 ## Quick example
 
 ```sh
-# 1. See current fees
+# Set the wallet key once via env var so it doesn't land in shell history
+# or `ps` output. Use a secret manager in production environments.
+export CDR_PRIVATE_KEY=0x...
+
+# 1. See current fees (no key needed for read-only queries)
 cdr-cli --network testnet status fees
 
 # 2. Allocate a vault (open-access conditions for demo only)
-cdr-cli --network testnet --private-key 0x... allocate \
+cdr-cli --network testnet allocate \
   --write-condition 0x... --read-condition 0x...
 
 # 3. Encrypt a 32-byte data key against the DKG global pubkey
 cdr-cli encrypt --data-key 0x...32-bytes... --global-pub-key 0x... --uuid 42
 
 # 4. Write the resulting ciphertext into the vault
-cdr-cli --network testnet --private-key 0x... write \
-  --uuid 42 --encrypted-data 0x...
+cdr-cli --network testnet write --uuid 42 --encrypted-data 0x...
 
 # 5. Request a read; collect partials off-chain
-cdr-cli --network testnet --private-key 0x... read \
-  --uuid 42 --requester-pub-key 0x...
+cdr-cli --network testnet read --uuid 42 --requester-pub-key 0x...
 ```
 
 For the full upload/read flow including `collectPartials` and `tdh2Combine`, use the SDK directly — the CLI exposes the contract-facing primitives but does not orchestrate validator-partial collection.

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -18,7 +18,8 @@
     "build": "tsc",
     "dev": "tsx src/index.ts",
     "clean": "rm -rf dist",
-    "lint": "tsc --noEmit"
+    "lint": "tsc --noEmit",
+    "prepublishOnly": "pnpm run build"
   },
   "dependencies": {
     "@piplabs/cdr-sdk": "workspace:*",

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -2,9 +2,18 @@
   "name": "@piplabs/cdr-cli",
   "version": "0.1.1",
   "type": "module",
+  "license": "MIT",
   "bin": {
     "cdr-cli": "dist/index.js"
   },
+  "publishConfig": {
+    "access": "public"
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE"
+  ],
   "scripts": {
     "build": "tsc",
     "dev": "tsx src/index.ts",


### PR DESCRIPTION
## Summary

Bring `apps/cli` (`@piplabs/cdr-cli`) into the release rotation alongside `contracts` / `crypto` / `sdk`. Mirrors the publish setup landed for the other three packages in #64.

## Why

`apps/cli` is a real SDK companion CLI, not an internal-only workspace tool:
- `package.json` declares `"bin": { "cdr-cli": "dist/index.js" }` — the npm pattern for installable CLI binaries
- `apps/cli/src/commands/` holds 7 functional commander.js subcommands (`status vault`, `status fees`, `allocate`, `write`, `read`, `encrypt`, `decrypt-partial`)
- The root README at line 140 already markets it: ``[`@piplabs/cdr-cli`](./apps/cli) | Command-line interface``
- npm registry shows the package never published (404 today), but the upstream maintainer's [`89bec7b5`](https://github.com/piplabs/cdr-sdk/commit/89bec7b5) bumped its version alongside the other packages — historical intent was "ship it"

Excluding it from the Changesets release rotation (the previous state, set in #65) was an unverified judgement on my part. This PR corrects that.

## Changes

- `apps/cli/package.json`: add `publishConfig.access=public`, `files: ["dist", "README.md", "LICENSE"]`, `license: "MIT"`
- `apps/cli/LICENSE`: copy of the root MIT LICENSE
- `apps/cli/README.md`: install + global options + subcommand reference. Every flag and command name was verified against the actual source under `apps/cli/src/commands/*.ts` before documenting; no claimed flags that don't exist.
- `.changeset/config.json`: remove `"@piplabs/cdr-cli"` from `ignore`. Next release will bump and publish all four packages together by default unless a changeset opts cli out.

## Verification

- `pnpm install` succeeds
- `pnpm -r run build` clean
- `pnpm publish --dry-run` on `apps/cli`:
  - `name: @piplabs/cdr-cli`
  - `version: 0.1.1`
  - `35 files, 7.4 kB`
  - Includes LICENSE + README + `dist/`, no `src/` or test leakage
  - `public access (dry-run)`

## Test plan

- [x] `pnpm install` works
- [x] `pnpm -r run build` clean
- [x] `pnpm publish --dry-run` on cli tarball is correct shape
- [ ] After merge: next release-cycle changeset can opt cli in/out per-PR via the standard interactive `pnpm changeset` flow
