### PR TITLE
fix(release): gate publish on Version Packages PR merge

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,23 +8,78 @@ on:
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:
-  release:
+  # ---------------------------------------------------------------------------
+  # Stage 1: Version Packages PR management. Runs on every main push, no
+  # environment gate, no npm contact. If unreleased `.changeset/*.md` files
+  # exist, opens or updates a "Version Packages" PR. Otherwise no-op. This
+  # stage never publishes — chore / docs / bug-fix-without-release commits
+  # land here and exit cleanly without requesting reviewer approval.
+  # ---------------------------------------------------------------------------
+  changesets:
     runs-on: ubuntu-latest
-    # Environment gate. Configure required reviewers + main-only deployment
-    # branch in repo Settings → Environments → npm-publish so that a human
-    # must click "Approve and deploy" in the GH Actions UI before either
-    # the Version Packages PR is opened or any npm publish is executed.
-    # See PR description for setup instructions.
-    environment: npm-publish
-    timeout-minutes: 20
+    timeout-minutes: 15
     permissions:
-      contents: write       # commit version bumps + create git tags
+      contents: write       # commit version bumps for the auto-PR
       pull-requests: write  # open / update the "Version Packages" PR
-      id-token: write       # mint OIDC token for npm provenance
+    outputs:
+      hasChangesets: ${{ steps.changesets.outputs.hasChangesets }}
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0    # full history needed for changelog generation
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - run: pnpm -r run build
+
+      # Vitest unit tests across all packages that declare a `test` script.
+      # Failure aborts the release pipeline before any publish.
+      - run: pnpm -r run test
+
+      - name: Open / update Version Packages PR
+        id: changesets
+        uses: changesets/action@v1
+        with:
+          # Intentionally NO `publish` input. This stage only opens PRs;
+          # publishing is gated by the separate `publish` job below.
+          version: pnpm changeset version
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # ---------------------------------------------------------------------------
+  # Stage 2: Publish to npm. Runs only when:
+  #   1. The previous stage saw no unreleased changesets (hasChangesets=false),
+  #      AND
+  #   2. The merge commit message contains "chore: release packages" — the
+  #      default title of the auto-generated Version Packages PR
+  #      (changesets/action input `title`, default value).
+  # Both conditions are required so that ordinary chore / docs / fix commits
+  # to main never trigger publish, only the merge of an actual release PR
+  # does. If a maintainer manually renames the auto-PR title, this guard
+  # fails closed — RELEASING.md documents this constraint.
+  # ---------------------------------------------------------------------------
+  publish:
+    needs: changesets
+    if: |
+      needs.changesets.outputs.hasChangesets == 'false' &&
+      contains(github.event.head_commit.message, 'chore: release packages')
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    environment: npm-publish
+    permissions:
+      contents: write   # push git tags
+      id-token: write   # mint OIDC token for npm provenance
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - uses: pnpm/action-setup@v4
 
@@ -38,25 +93,11 @@ jobs:
 
       - run: pnpm -r run build
 
-      # Run vitest unit tests across all packages that declare a `test`
-      # script. Currently: packages/crypto (17 tests) + packages/sdk
-      # (81 tests passed, 23 integration tests skipped — they require a
-      # live chain RPC and cannot run on a stock CI runner).
-      # Failure here aborts the release before any npm publish.
-      - run: pnpm -r run test
-
-      - name: Create Release Pull Request or Publish
-        uses: changesets/action@v1
-        with:
-          # When unreleased changesets exist on main: opens / updates a
-          # "Version Packages" PR that bumps versions + writes CHANGELOGs.
-          # When that PR merges: this job runs again, no changesets remain,
-          # so changesets/action runs the publish command below.
-          version: pnpm changeset version
-          publish: pnpm changeset publish
+      - name: Publish to npm
+        run: pnpm changeset publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          # Adds OIDC-signed provenance attestation to the published tarball
-          # so consumers can verify the build originated from this workflow.
+          # Emit OIDC-signed provenance so consumers can verify the tarball
+          # was produced by this workflow.
           NPM_CONFIG_PROVENANCE: "true"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,26 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
+      # Supply-chain gate. Audit production dependencies (the deps that ship
+      # to consumers) for high+ severity vulnerabilities. devDependencies are
+      # excluded — they don't make it into the published tarball.
+      #
+      # `pnpm audit` exits 0 even when vulnerabilities exist (the
+      # --audit-level flag is a print filter, not a failure threshold), so
+      # we parse JSON and explicitly fail on any high or critical advisory.
+      # Suppress specific transitive vulns by adding a pnpm.overrides entry
+      # in the root package.json once a fixed version is available.
+      - name: Audit production dependencies
+        run: |
+          pnpm audit --json --prod > /tmp/audit.json || true
+          COUNT=$(jq '[.advisories | to_entries[] | select(.value.severity == "high" or .value.severity == "critical")] | length' /tmp/audit.json)
+          if [ "${COUNT:-0}" -gt 0 ]; then
+            echo "::error::Found $COUNT high+ severity vulnerabilities in production deps"
+            jq '[.advisories | to_entries[] | select(.value.severity == "high" or .value.severity == "critical") | .value | {severity, title, module: .module_name, vulnerable: .vulnerable_versions, patched: .patched_versions}]' /tmp/audit.json
+            exit 1
+          fi
+          echo "No high+ severity vulnerabilities in production deps."
+
       - run: pnpm -r run build
 
       # Vitest unit tests across all packages that declare a `test` script.
@@ -92,6 +112,15 @@ jobs:
       - run: pnpm install --frozen-lockfile
 
       - run: pnpm -r run build
+
+      # Pre-publish dry-run. Validates tarball contents (file list, package.json
+      # shape, workspace:* substitution) without contacting the registry to
+      # write. Catches regressions in `files` whitelists or workspace dep
+      # resolution before any tarball is irrevocably uploaded.
+      - name: Verify publish tarballs (dry-run)
+        run: pnpm -r publish --dry-run --no-git-checks
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Publish to npm
         run: pnpm changeset publish

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -6,17 +6,24 @@ Maintainer-facing guide for cutting a new version of `@piplabs/cdr-contracts`, `
 
 ## Pipeline gates
 
-Every push to `main` triggers `.github/workflows/release.yml`. The job is gated by:
+Every push to `main` triggers `.github/workflows/release.yml`, which runs in two stages:
 
-| Gate | Where it lives | What it checks |
-|---|---|---|
-| 1. `pnpm install --frozen-lockfile` | release.yml step | `pnpm-lock.yaml` matches `package.json` deps; reproducible install |
-| 2. `pnpm -r run build` | release.yml step | TypeScript compiles for every package |
-| 3. `pnpm -r run test` | release.yml step | vitest unit suites pass for every package that declares a `test` script |
-| 4. `environment: npm-publish` | repo Settings → Environments | A required reviewer must click **Approve and deploy** in the Actions UI before any step runs. Reviewer list and main-only branch restriction live in the environment config. |
-| 5. Changesets two-stage flow | `.changeset/` files in repo | Action opens a "Version Packages" PR when `.changeset/*.md` files exist; only publishes when those files are absent (i.e. after the version PR merges). |
+**Stage 1 — `changesets` job** (always runs, no approval gate, no npm contact)
+- `pnpm install --frozen-lockfile` — reproducible install
+- `pnpm -r run build` — TypeScript compiles
+- `pnpm -r run test` — vitest unit suites pass
+- `changesets/action@v1` — opens / updates the "Version Packages" PR when unreleased changesets exist; otherwise no-op
 
-For exact action behaviour see the upstream [`changesets/action` README](https://github.com/changesets/action#readme). The combination of gates 4 and 5 ensures publishes only happen via merged Version Packages PRs that have passed both human review and the environment approval.
+**Stage 2 — `publish` job** (runs only on actual release commits)
+- Conditional `if`: `hasChangesets == 'false' && contains(commit message, 'chore: release packages')`
+- `environment: npm-publish` — required reviewer must click **Approve and deploy** before any step runs
+- `pnpm install --frozen-lockfile` + `pnpm -r run build` + `pnpm changeset publish` (with OIDC provenance)
+
+The two-stage split means ordinary chore / docs / fix commits never request reviewer approval — they finish in stage 1 and never reach the publish job. Approval is requested only when the merged commit is the auto-generated Version Packages PR (default title `chore: release packages`).
+
+> **Important constraint**: do not rename the Version Packages PR title before merging. The publish guard checks the merge commit message contains `"chore: release packages"`. A renamed title fails the guard closed → the publish job is skipped → no release.
+
+For exact action behaviour see the upstream [`changesets/action` README](https://github.com/changesets/action#readme).
 
 ## Day-to-day: shipping a code change
 
@@ -44,22 +51,19 @@ A PR with no `.changeset/*.md` is fine for pure docs / chore work that should no
 
 After your PR merges to `main`:
 
-1. release.yml triggers, pauses at the `npm-publish` environment gate.
-2. A reviewer (someone in the environment's required reviewers list, not yourself due to **Prevent self-review**) approves in the Actions UI.
-3. Job runs install / build / test.
-4. `changesets/action` sees your `.md` file, opens (or updates) a PR titled **"chore: release packages"** that:
+1. release.yml `changesets` job runs install / build / test, then `changesets/action` sees your `.md` file and opens (or updates) a PR titled **"chore: release packages"** that:
    - Bumps the affected packages' `version` fields in `package.json`
    - Appends a CHANGELOG entry per package using `@changesets/changelog-github` (auto-links your PR + handle)
    - Deletes the consumed `.changeset/*.md`
-   - Does **not** publish anything yet
-5. Maintainer reviews the "chore: release packages" PR (see [Reviewing the Version Packages PR](#reviewing-the-version-packages-pr) below) and merges it.
-6. release.yml triggers again, pauses at the `npm-publish` environment gate.
-7. Reviewer approves.
-8. `changesets/action` sees no remaining `.md` files, runs `pnpm changeset publish`, which:
+2. The `publish` job's `if` guard evaluates false on this commit (the merge commit message is your feature PR's title, not `chore: release packages`), so the job is skipped and no environment approval is requested.
+3. Maintainer reviews the "chore: release packages" PR (see [Reviewing the Version Packages PR](#reviewing-the-version-packages-pr) below) and merges it. **Do not rename the PR title** — the publish guard depends on it.
+4. release.yml runs again. `changesets` job no-ops (no `.md` files left). `publish` job's `if` guard evaluates true → reaches the `environment: npm-publish` gate.
+5. A reviewer (someone in the environment's required reviewers list, not yourself due to **Prevent self-review**) approves in the Actions UI.
+6. `pnpm changeset publish` runs, which:
    - Publishes each bumped package (whose `package.json.version > npm dist-tags.latest`)
-   - Adds OIDC-signed npm provenance attestation (configured via `NPM_CONFIG_PROVENANCE=true` in the workflow env)
+   - Adds OIDC-signed npm provenance attestation
    - Creates per-package git tags like `@piplabs/cdr-sdk@0.1.3`
-   - Creates a GitHub Release per tag (`createGithubReleases` defaults to true on the action)
+   - Creates a GitHub Release per tag (`createGithubReleases` defaults to true)
 
 ## First-time release of an unpublished package
 
@@ -77,18 +81,16 @@ pnpm changeset
 
 The Version Packages PR will bump all three to 0.1.2. After it merges + final approval, `pnpm changeset publish` publishes all three. From then on, packages can version independently — only mention the ones you changed in subsequent changesets.
 
-## Reviewing approvals (what each gate means)
+## Reviewing the approval
 
-The `npm-publish` environment gate fires on **every push to `main`**, including merges that don't trigger a release. Reviewer should check the Actions run page before approving:
+The `npm-publish` environment gate is reached **only when the publish job runs**, which happens only on the merge of an auto-generated Version Packages PR. Reviewer responsibility at approval time:
 
-| Workflow run is for | How to tell from the run page | What approval means |
-|---|---|---|
-| A merged feature PR with a changeset | The triggering commit message is the feature PR's title; `.changeset/` has new `.md` files (visible in commit diff) | Approve to let action open the Version Packages PR. No npm publish in this run. |
-| A merged "chore: release packages" PR | The triggering commit message is `Version Packages` or `chore: release packages`; `.changeset/` has only `README.md` + `config.json` | Approve to publish to npm. **This is the irreversible step.** |
-| A merged docs / chore PR (no changeset) | No `.md` files in `.changeset/`; `package.json.version` matches what's already on npm | `pnpm changeset publish` will be a no-op. Safe to approve, but you can also let it sit. |
-| A merged PR that bumped `package.json.version` manually | `package.json` diff shows version change; `.changeset/` has no related `.md` | **DO NOT APPROVE.** This bypasses Changesets and would publish an unintended version. Reject and investigate. |
+| The Actions run is for | What approval means |
+|---|---|
+| A merged "chore: release packages" PR (Version Packages PR) | Approve to publish to npm. **This is the irreversible step.** Confirm the package versions in the merge commit's `package.json` diffs match what you expect to ship. |
+| Anything else (chore / docs / fix / feature PR with changeset) | The publish job's `if` guard skips this run — no approval is requested in the first place. If you do see an unexpected approval request, **DO NOT APPROVE.** Investigate the merge commit; the only way the publish job runs is if its commit message contains `chore: release packages`, which should mean the Version Packages PR was merged.
 
-If unsure, click into the Actions run, scroll to the "Create Release Pull Request or Publish" step pre-execution, and check the commit diff that triggered it.
+Before clicking Approve, click into the run, expand the `publish` job, and verify the diff that triggered it actually bumps versions you intend to release.
 
 ## Reviewing the Version Packages PR
 

--- a/package.json
+++ b/package.json
@@ -17,10 +17,10 @@
   "packageManager": "pnpm@9.15.0",
   "pnpm": {
     "overrides": {
-      "protobufjs@<7.5.5": ">=7.5.5",
-      "brace-expansion@<1.1.13": ">=1.1.13",
-      "follow-redirects@<=1.15.11": ">=1.16.0",
-      "axios@<1.15.0": ">=1.15.0"
+      "protobufjs@<7.5.5": ">=7.5.5 <8",
+      "brace-expansion@<1.1.13": ">=1.1.13 <2",
+      "follow-redirects@<=1.15.11": ">=1.16.0 <2",
+      "axios@<1.15.0": ">=1.15.0 <2"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -14,5 +14,13 @@
     "turbo": "^2",
     "typescript": "^5.5"
   },
-  "packageManager": "pnpm@9.15.0"
+  "packageManager": "pnpm@9.15.0",
+  "pnpm": {
+    "overrides": {
+      "protobufjs@<7.5.5": ">=7.5.5",
+      "brace-expansion@<1.1.13": ">=1.1.13",
+      "follow-redirects@<=1.15.11": ">=1.16.0",
+      "axios@<1.15.0": ">=1.15.0"
+    }
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,12 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  protobufjs@<7.5.5: '>=7.5.5'
+  brace-expansion@<1.1.13: '>=1.1.13'
+  follow-redirects@<=1.15.11: '>=1.16.0'
+  axios@<1.15.0: '>=1.15.0'
+
 importers:
 
   .:
@@ -1533,8 +1539,8 @@ packages:
   atomically@2.1.1:
     resolution: {integrity: sha512-P4w9o2dqARji6P7MHprklbfiArZAWvo07yW7qs3pdljb3BWr12FIB7W+p0zJiuiVsUpRO0iZn1kFFcpPegg0tQ==}
 
-  axios@1.13.6:
-    resolution: {integrity: sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==}
+  axios@1.15.2:
+    resolution: {integrity: sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==}
 
   babel-jest@29.7.0:
     resolution: {integrity: sha512-BrvGY3xZSwEcCzKvKsCi2GgHqDqsYkOP4/by5xCgIwGXQxIEh+8ew3gmrE1y7XRR6LHZIj6yLYnUi/mm2KXKBg==}
@@ -1595,9 +1601,6 @@ packages:
 
   blockstore-core@6.1.2:
     resolution: {integrity: sha512-yWU38RM8DJ6C7Y2shIeTNVgGiJX/ko2RXqDyNlxMakOc+aVS7k1SCiakMlh6ix0juRNPtj0ySMTXU8UBDXXRCQ==}
-
-  brace-expansion@1.1.12:
-    resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
 
   brace-expansion@2.0.3:
     resolution: {integrity: sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==}
@@ -1721,9 +1724,6 @@ packages:
 
   commander@2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
-
-  concat-map@0.0.1:
-    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
   conf@11.0.2:
     resolution: {integrity: sha512-jjyhlQ0ew/iwmtwsS2RaB6s8DBifcE2GYBEaw2SJDUY/slJJbNfY4GlDVzOs/ff8cM/Wua5CikqXgbFl5eu85A==}
@@ -2049,8 +2049,8 @@ packages:
   flow-enums-runtime@0.0.6:
     resolution: {integrity: sha512-3PYnM29RFXwvAN6Pc/scUfkI7RwhQ/xqyLUyPNlXUp9S40zI8nup9tUSrTLSVnWGBN38FNiGWbwZOB6uR4OGdw==}
 
-  follow-redirects@1.15.11:
-    resolution: {integrity: sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==}
+  follow-redirects@1.16.0:
+    resolution: {integrity: sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==}
     engines: {node: '>=4.0'}
     peerDependencies:
       debug: '*'
@@ -3025,15 +3025,16 @@ packages:
   promise@8.3.0:
     resolution: {integrity: sha512-rZPNPKTOYVNEEKFaq1HqTgOwZD+4/YHS5ukLzQCypkj+OkYx7iv0mA91lJlpPPZ8vMau3IIGj5Qlwrx+8iiSmg==}
 
-  protobufjs@7.5.4:
-    resolution: {integrity: sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==}
+  protobufjs@8.0.1:
+    resolution: {integrity: sha512-NWWCCscLjs+cOKF/s/XVNFRW7Yih0fdH+9brffR5NZCy8k42yRdl5KlWKMVXuI1vfCoy4o1z80XR/W/QUb3V3w==}
     engines: {node: '>=12.0.0'}
 
   protons-runtime@5.6.0:
     resolution: {integrity: sha512-/Kde+sB9DsMFrddJT/UZWe6XqvL7SL5dbag/DBCElFKhkwDj7XKt53S+mzLyaDP5OqS0wXjV5SA572uWDaT0Hg==}
 
-  proxy-from-env@1.1.0:
-    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
+  proxy-from-env@2.1.0:
+    resolution: {integrity: sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==}
+    engines: {node: '>=10'}
 
   pump@3.0.4:
     resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
@@ -4505,7 +4506,7 @@ snapshots:
       '@perma/map': 1.0.3
       actor: 2.3.1
       multiformats: 13.4.2
-      protobufjs: 7.5.4
+      protobufjs: 8.0.1
       rabin-rs: 2.1.0
 
   '@ipshipyard/libp2p-auto-tls@2.0.1':
@@ -5732,7 +5733,7 @@ snapshots:
     dependencies:
       '@peculiar/x509': 1.14.3
       asn1js: 3.0.7
-      axios: 1.13.6(debug@4.4.3)
+      axios: 1.15.2(debug@4.4.3)
       debug: 4.4.3
       node-forge: 1.4.0
     transitivePeerDependencies:
@@ -5809,11 +5810,11 @@ snapshots:
       stubborn-fs: 2.0.0
       when-exit: 2.1.5
 
-  axios@1.13.6(debug@4.4.3):
+  axios@1.15.2(debug@4.4.3):
     dependencies:
-      follow-redirects: 1.15.11(debug@4.4.3)
+      follow-redirects: 1.16.0(debug@4.4.3)
       form-data: 4.0.5
-      proxy-from-env: 1.1.0
+      proxy-from-env: 2.1.0
     transitivePeerDependencies:
       - debug
 
@@ -5911,11 +5912,6 @@ snapshots:
       it-filter: 3.1.4
       it-merge: 3.0.12
       multiformats: 13.4.2
-
-  brace-expansion@1.1.12:
-    dependencies:
-      balanced-match: 1.0.2
-      concat-map: 0.0.1
 
   brace-expansion@2.0.3:
     dependencies:
@@ -6046,8 +6042,6 @@ snapshots:
   commander@14.0.3: {}
 
   commander@2.20.3: {}
-
-  concat-map@0.0.1: {}
 
   conf@11.0.2:
     dependencies:
@@ -6381,7 +6375,7 @@ snapshots:
 
   flow-enums-runtime@0.0.6: {}
 
-  follow-redirects@1.15.11(debug@4.4.3):
+  follow-redirects@1.16.0(debug@4.4.3):
     optionalDependencies:
       debug: 4.4.3
 
@@ -7349,7 +7343,7 @@ snapshots:
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.12
+      brace-expansion: 5.0.5
 
   minimatch@9.0.9:
     dependencies:
@@ -7595,7 +7589,7 @@ snapshots:
     dependencies:
       asap: 2.0.6
 
-  protobufjs@7.5.4:
+  protobufjs@8.0.1:
     dependencies:
       '@protobufjs/aspromise': 1.1.2
       '@protobufjs/base64': 1.1.2
@@ -7616,7 +7610,7 @@ snapshots:
       uint8arraylist: 2.4.8
       uint8arrays: 5.1.0
 
-  proxy-from-env@1.1.0: {}
+  proxy-from-env@2.1.0: {}
 
   pump@3.0.4:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,10 +5,10 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  protobufjs@<7.5.5: '>=7.5.5'
-  brace-expansion@<1.1.13: '>=1.1.13'
-  follow-redirects@<=1.15.11: '>=1.16.0'
-  axios@<1.15.0: '>=1.15.0'
+  protobufjs@<7.5.5: '>=7.5.5 <8'
+  brace-expansion@<1.1.13: '>=1.1.13 <2'
+  follow-redirects@<=1.15.11: '>=1.16.0 <2'
+  axios@<1.15.0: '>=1.15.0 <2'
 
 importers:
 
@@ -1602,6 +1602,9 @@ packages:
   blockstore-core@6.1.2:
     resolution: {integrity: sha512-yWU38RM8DJ6C7Y2shIeTNVgGiJX/ko2RXqDyNlxMakOc+aVS7k1SCiakMlh6ix0juRNPtj0ySMTXU8UBDXXRCQ==}
 
+  brace-expansion@1.1.14:
+    resolution: {integrity: sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==}
+
   brace-expansion@2.0.3:
     resolution: {integrity: sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==}
 
@@ -1724,6 +1727,9 @@ packages:
 
   commander@2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
+
+  concat-map@0.0.1:
+    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
   conf@11.0.2:
     resolution: {integrity: sha512-jjyhlQ0ew/iwmtwsS2RaB6s8DBifcE2GYBEaw2SJDUY/slJJbNfY4GlDVzOs/ff8cM/Wua5CikqXgbFl5eu85A==}
@@ -3025,8 +3031,8 @@ packages:
   promise@8.3.0:
     resolution: {integrity: sha512-rZPNPKTOYVNEEKFaq1HqTgOwZD+4/YHS5ukLzQCypkj+OkYx7iv0mA91lJlpPPZ8vMau3IIGj5Qlwrx+8iiSmg==}
 
-  protobufjs@8.0.1:
-    resolution: {integrity: sha512-NWWCCscLjs+cOKF/s/XVNFRW7Yih0fdH+9brffR5NZCy8k42yRdl5KlWKMVXuI1vfCoy4o1z80XR/W/QUb3V3w==}
+  protobufjs@7.5.5:
+    resolution: {integrity: sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==}
     engines: {node: '>=12.0.0'}
 
   protons-runtime@5.6.0:
@@ -4506,7 +4512,7 @@ snapshots:
       '@perma/map': 1.0.3
       actor: 2.3.1
       multiformats: 13.4.2
-      protobufjs: 8.0.1
+      protobufjs: 7.5.5
       rabin-rs: 2.1.0
 
   '@ipshipyard/libp2p-auto-tls@2.0.1':
@@ -5913,6 +5919,11 @@ snapshots:
       it-merge: 3.0.12
       multiformats: 13.4.2
 
+  brace-expansion@1.1.14:
+    dependencies:
+      balanced-match: 1.0.2
+      concat-map: 0.0.1
+
   brace-expansion@2.0.3:
     dependencies:
       balanced-match: 1.0.2
@@ -6042,6 +6053,8 @@ snapshots:
   commander@14.0.3: {}
 
   commander@2.20.3: {}
+
+  concat-map@0.0.1: {}
 
   conf@11.0.2:
     dependencies:
@@ -7343,7 +7356,7 @@ snapshots:
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 5.0.5
+      brace-expansion: 1.1.14
 
   minimatch@9.0.9:
     dependencies:
@@ -7589,7 +7602,7 @@ snapshots:
     dependencies:
       asap: 2.0.6
 
-  protobufjs@8.0.1:
+  protobufjs@7.5.5:
     dependencies:
       '@protobufjs/aspromise': 1.1.2
       '@protobufjs/base64': 1.1.2


### PR DESCRIPTION
## Summary

The previous release workflow asked for a reviewer approval on every push to `main`. On chore / docs / fix PR merges, the action's default behaviour (with both `version` and `publish` inputs) is to publish anything whose `package.json.version` is missing on the registry. Before the first 0.1.2 publish ships, that means all four packages at 0.1.1 — exactly what we don't want. PR #67 landing as a chore commit hit this state at the environment gate; cancelling was the right call but the design forced a near-miss every time.

This PR closes the gap by splitting the workflow into two jobs and gating the publish step.

## Two-job pattern

**`changesets` job** — runs on every main push; no environment gate; no npm contact.
- `pnpm install --frozen-lockfile`, `pnpm -r run build`, `pnpm -r run test`
- `changesets/action@v1` with **only** `version: pnpm changeset version`. No `publish` input → action only opens / updates the Version Packages PR when unreleased changesets exist; otherwise no-op.

**`publish` job** — `needs: changesets`. Runs only when:

```yaml
if: |
  needs.changesets.outputs.hasChangesets == 'false' &&
  contains(github.event.head_commit.message, 'chore: release packages')
```

Both conditions are required so that ordinary main pushes never trigger publish, and only the merge of the auto-generated Version Packages PR does. `environment: npm-publish` lives on this job — the required-reviewer prompt only fires when there's a real release at stake.

## Failure modes

- **Maintainer renames the Version Packages PR title before merging** → guard's `contains` check fails → publish job skipped → no release. Documented in `RELEASING.md` as a constraint.
- **Stale changesets accidentally land on main without going through the auto-generated PR** → `hasChangesets` is true → publish skipped, version PR opened normally on the next push.
- **Manual `package.json` version bump merged on a non-release branch** → `hasChangesets` is false BUT commit message is the feature PR's title (not "chore: release packages") → publish skipped. Reviewer should still flag manual bumps in code review.

## Source

Pattern is the `hasChangesets`-output-based "Custom Publishing" flow documented in the upstream [`changesets/action` README](https://github.com/changesets/action#readme). The default PR title `chore: release packages` is `changesets/action`'s `title` input default; we don't override it.

## Verification

- [x] `actionlint .github/workflows/release.yml` clean
- [x] `pnpm install` + `pnpm -r run build` + `pnpm -r run test` clean locally
- [ ] After merge: confirm a chore-only push to main runs only the `changesets` job (publish job skipped, no environment approval requested)
- [ ] At first 0.1.2 release: confirm the Version Packages PR merge triggers both jobs and reaches the environment approval

## Test plan

- [x] Workflow YAML lints
- [x] Local install / build / test still clean
- [ ] Post-merge smoke: a no-op push (e.g. another docs change) should produce one Actions run that ends green without an "Approve and deploy" prompt
