### PR TITLE
chore: add v0.1.2 release changeset

### DIFF
--- a/.changeset/v0-1-2-public-release.md
+++ b/.changeset/v0-1-2-public-release.md
@@ -1,0 +1,8 @@
+---
+"@piplabs/cdr-contracts": patch
+"@piplabs/cdr-crypto": patch
+"@piplabs/cdr-sdk": patch
+"@piplabs/cdr-cli": patch
+---
+
+Initial public release on npm. Includes contracts ABIs and addresses, TDH2/ECIES crypto primitives, the SDK client, and the cdr-cli command-line tool.


### PR DESCRIPTION
## Summary

Adds a single Changesets entry that bumps all four publishable packages from `0.1.1` to `0.1.2` for the **first public release** on npm.

| Package | Bump |
|---|---|
| `@piplabs/cdr-contracts` | patch |
| `@piplabs/cdr-crypto` | patch |
| `@piplabs/cdr-sdk` | patch |
| `@piplabs/cdr-cli` | patch |

## Release flow (after this PR merges)

1. The `Release` workflow runs the `changesets` job on `main`, sees the new `.changeset/v0-1-2-public-release.md` file, and **auto-opens a "Version Packages" PR** with title `chore: release packages`. That PR bumps the four `package.json` versions, regenerates `CHANGELOG.md` entries, and deletes the changeset md.
2. Reviewing and merging that auto-PR triggers the **`publish` job**, which is gated on the `npm-publish` environment (required reviewers: `lucas2brh`, `yingyangxu2026`, `wo-o`). The job runs `pnpm audit --prod`, build, dry-run preflight, then `pnpm changeset publish` with OIDC provenance, and pushes per-package git tags.

⚠️  **Do not rename the auto-PR title.** The publish guard checks `contains(github.event.head_commit.message, 'chore: release packages')`; renaming the title silently skips publish (documented in `docs/RELEASING.md`).

## Test plan

- [x] `pnpm changeset status` reports all four packages bumped at patch
- [ ] After merge: confirm Release workflow opens a "Version Packages" PR titled `chore: release packages`
- [ ] After Version Packages PR merge: confirm `publish` job pauses on the `npm-publish` environment gate, then publishes all four packages with provenance and tags