### PR TITLE
chore: release packages

### DIFF
--- a/.changeset/v0-1-2-public-release.md
+++ b/.changeset/v0-1-2-public-release.md
@@ -1,8 +1,0 @@
----
-"@piplabs/cdr-contracts": patch
-"@piplabs/cdr-crypto": patch
-"@piplabs/cdr-sdk": patch
-"@piplabs/cdr-cli": patch
----
-
-Initial public release on npm. Includes contracts ABIs and addresses, TDH2/ECIES crypto primitives, the SDK client, and the cdr-cli command-line tool.

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -1,0 +1,10 @@
+# @piplabs/cdr-cli
+
+## 0.1.2
+
+### Patch Changes
+
+- [#69](https://github.com/piplabs/cdr-sdk/pull/69) [`3d022d0`](https://github.com/piplabs/cdr-sdk/commit/3d022d0e015cbc050525253f2cb20b75af7a9858) Thanks [@lucas2brh](https://github.com/lucas2brh)! - Initial public release on npm. Includes contracts ABIs and addresses, TDH2/ECIES crypto primitives, the SDK client, and the cdr-cli command-line tool.
+
+- Updated dependencies [[`3d022d0`](https://github.com/piplabs/cdr-sdk/commit/3d022d0e015cbc050525253f2cb20b75af7a9858)]:
+  - @piplabs/cdr-sdk@0.1.2

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@piplabs/cdr-cli",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "type": "module",
   "license": "MIT",
   "bin": {

--- a/packages/contracts/CHANGELOG.md
+++ b/packages/contracts/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @piplabs/cdr-contracts
+
+## 0.1.2
+
+### Patch Changes
+
+- [#69](https://github.com/piplabs/cdr-sdk/pull/69) [`3d022d0`](https://github.com/piplabs/cdr-sdk/commit/3d022d0e015cbc050525253f2cb20b75af7a9858) Thanks [@lucas2brh](https://github.com/lucas2brh)! - Initial public release on npm. Includes contracts ABIs and addresses, TDH2/ECIES crypto primitives, the SDK client, and the cdr-cli command-line tool.

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@piplabs/cdr-contracts",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "type": "module",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/crypto/CHANGELOG.md
+++ b/packages/crypto/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @piplabs/cdr-crypto
+
+## 0.1.2
+
+### Patch Changes
+
+- [#69](https://github.com/piplabs/cdr-sdk/pull/69) [`3d022d0`](https://github.com/piplabs/cdr-sdk/commit/3d022d0e015cbc050525253f2cb20b75af7a9858) Thanks [@lucas2brh](https://github.com/lucas2brh)! - Initial public release on npm. Includes contracts ABIs and addresses, TDH2/ECIES crypto primitives, the SDK client, and the cdr-cli command-line tool.

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@piplabs/cdr-crypto",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "type": "module",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,0 +1,11 @@
+# @piplabs/cdr-sdk
+
+## 0.1.2
+
+### Patch Changes
+
+- [#69](https://github.com/piplabs/cdr-sdk/pull/69) [`3d022d0`](https://github.com/piplabs/cdr-sdk/commit/3d022d0e015cbc050525253f2cb20b75af7a9858) Thanks [@lucas2brh](https://github.com/lucas2brh)! - Initial public release on npm. Includes contracts ABIs and addresses, TDH2/ECIES crypto primitives, the SDK client, and the cdr-cli command-line tool.
+
+- Updated dependencies [[`3d022d0`](https://github.com/piplabs/cdr-sdk/commit/3d022d0e015cbc050525253f2cb20b75af7a9858)]:
+  - @piplabs/cdr-contracts@0.1.2
+  - @piplabs/cdr-crypto@0.1.2

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@piplabs/cdr-sdk",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "type": "module",
   "license": "MIT",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary

Bumps all four packages from `0.1.1` → `0.1.2` and generates per-package `CHANGELOG.md` entries. This is the **first public release** of `@piplabs/cdr-{contracts,crypto,sdk,cli}` on npm.

| Package | 0.1.1 → 0.1.2 |
|---|---|
| `@piplabs/cdr-contracts` | patch |
| `@piplabs/cdr-crypto` | patch |
| `@piplabs/cdr-sdk` | patch |
| `@piplabs/cdr-cli` | patch |

Source changeset: #69 (merged).

## ⚠️ Why this PR was opened manually

The Release workflow's `changesets/action` step ran `pnpm changeset version` correctly, committed the changes to `changeset-release/main` (`95cbc1e`), and pushed the branch — but failed to open the PR with:

```
HttpError: GitHub Actions is not permitted to create or approve pull requests.
```

Root cause: the piplabs org disables \"Allow GitHub Actions to create and approve pull requests\" at org level, and the repo admin cannot override it. This PR is therefore opened by a human user against the same `changeset-release/main` branch the action already pushed.

A follow-up PR will switch the workflow to use a non-`GITHUB_TOKEN` credential (PAT or GitHub App) so future cycles auto-open this PR without manual intervention.

## ⚠️ Title is intentionally `chore: release packages`

The publish job's guard checks `contains(github.event.head_commit.message, 'chore: release packages')`. The default `changesets/action` PR title is `Version Packages`, which would **not** match the guard and would silently skip publish. The same follow-up PR will set `title:` and `commit:` inputs explicitly so this no longer requires manual override.

**Squash-merge** this PR — the squash commit message will inherit this title and trigger the publish job correctly.

## What happens after merge

1. `Release` workflow re-runs on the merge commit
2. `changesets` job: audit + build + test (clean, no unreleased changesets remaining)
3. `publish` job: condition `hasChangesets == 'false' && contains(message, 'chore: release packages')` → both true → enters `npm-publish` environment gate
4. Required reviewer (`lucas2brh` / `yingyangxu2026` / `wo-o`) approves
5. install → build → dry-run preflight → `pnpm changeset publish` with OIDC provenance
6. 4 npm packages published, 4 git tags pushed (`@piplabs/cdr-sdk@0.1.2`, etc.), GitHub releases created

## Test plan

- [x] `pnpm changeset status` previously confirmed all 4 packages at patch
- [x] Diff against `main`: 8 files, 39 insertions, 4 deletions; only `package.json` versions and new `CHANGELOG.md` files
- [ ] Squash-merge with title preserved → publish job triggers and reaches environment gate
- [ ] After approval: 4 packages live on npm with provenance badge; `npx @piplabs/cdr-cli --help` works in a clean install