### PR TITLE
ci(integration): perf table + TL;DR summary + merge stress + pipeline stress

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -365,11 +365,17 @@ jobs:
               echo ""
               return
             fi
-            local files_passed files_failed tests_passed tests_failed dur_ms dur_s
+            local files_passed files_failed files_skipped tests_passed tests_failed tests_skipped dur_ms dur_s
             files_passed=$(jq -r '.numPassedTestSuites // 0' "$json")
             files_failed=$(jq -r '.numFailedTestSuites // 0' "$json")
+            # `numPendingTestSuites` = test files where every test was skipped
+            # (e.g. a whole describe gated off via `describe.skipIf`).
+            files_skipped=$(jq -r '.numPendingTestSuites // 0' "$json")
             tests_passed=$(jq -r '.numPassedTests // 0' "$json")
             tests_failed=$(jq -r '.numFailedTests // 0' "$json")
+            # `numPendingTests` = `.skip` or `skipIf`-gated. `numTodoTests`
+            # = `.todo` placeholders. Both render as ⏭️.
+            tests_skipped=$(jq -r '(.numPendingTests // 0) + (.numTodoTests // 0)' "$json")
             dur_ms=$(jq -r '
               ([.testResults[].endTime // 0] | max) as $end
               | (.startTime // 0) as $start
@@ -377,8 +383,8 @@ jobs:
             ' "$json")
             dur_s=$(awk -v ms="$dur_ms" 'BEGIN { printf "%.1f", ms / 1000 }')
             echo '```'
-            echo "Test Files  ${files_passed} passed | ${files_failed} failed"
-            echo "     Tests  ${tests_passed} passed | ${tests_failed} failed"
+            echo "Test Files  ${files_passed} passed | ${files_failed} failed | ${files_skipped} skipped"
+            echo "     Tests  ${tests_passed} passed | ${tests_failed} failed | ${tests_skipped} skipped"
             echo "  Duration  ${dur_s}s"
             echo '```'
             echo ""
@@ -410,7 +416,7 @@ jobs:
                 + " |"
             ' "$json")
             if [ -n "$rows" ]; then
-              echo "<details><summary>Per-case results (${tests_passed}✅ ${tests_failed}❌)</summary>"
+              echo "<details><summary>Per-case results (${tests_passed}✅ ${tests_failed}❌ ${tests_skipped}⏭️)</summary>"
               echo ""
               echo "| File | Test | Status | Duration |"
               echo "|---|---|---|---|"

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -426,6 +426,8 @@ jobs:
             [ "${#files[@]}" -gt 0 ] || { echo "_(no perf-stats output produced — nothing to summarize)_"; echo ""; return; }
             echo "Latencies are per-wallet (or per-cycle for the stress suite). All percentiles are nearest-rank, no interpolation."
             echo ""
+            echo "> **stress row caveat:** the \`Wallets\` column is the **concurrency** (10), not the cycle count, and \`failed\` counts **failed cycles**, not failed wallets — see the \`stress\` extras block below for total/failed cycle counts."
+            echo ""
             echo "| Suite | Wallets | Wall clock | min | p50 | mean | p95 | p99 | max | failed | refund |"
             echo "|---|---|---|---|---|---|---|---|---|---|---|"
             for f in "${files[@]}"; do
@@ -518,10 +520,6 @@ jobs:
             echo "| Wall time (s) | — | — | $ELAPSED_S |"
             echo ""
             echo "_DKG stage codes: 1 = Registration, 2 = Dealing, 3 = Finalization, 4 = Active._"
-            if [ "$ROUND_DELTA" != "?" ] && [ "$ROUND_DELTA" -gt 0 ]; then
-              echo ""
-              echo "> ⚠️ **DKG round rotated mid-run** (${ROUND_PRE} → ${ROUND_POST}). Vault reads spanning rotation may exercise the bucket-round filter (#75)."
-            fi
             echo ""
 
             echo "### Performance metrics"

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -16,12 +16,13 @@ on:
         default: devnet
       test_suite:
         type: choice
-        description: Which suite to run (gated inside test files via TEST_SUITE env)
+        description: Which suite to run
         options:
-          # default                 — basic SDK/CLI/Examples + 100w ephemeral tests
-          # all                     — default + 1000w perf + 60min stress (stress devnet-only)
-          # 1000-wallet-performance — basic + the 1000-wallet perf suite
-          # 1H-stress-devnet-only   — only the 60-min combined stress (DevNet only)
+          # default                 — functional (SDK/CLI/Examples) + 100w ephemeral
+          # all                     — default + 1000w perf + 60min stress
+          # 1000-wallet-performance — ONLY ephemeral-1000w-perf.test.ts (strict isolation:
+          #                           no functional, no CLI, no Examples — clean perf signal)
+          # 1H-stress-devnet-only   — ONLY ephemeral-60min-stress.test.ts (DevNet only)
           - default
           - all
           - 1000-wallet-performance
@@ -202,23 +203,37 @@ jobs:
       # because pnpm passes the `--` separator through to vitest, where yargs
       # treats it as end-of-options and the `--outputFile.json=…` flag is
       # silently dropped.
+      # Strict isolation for the perf-only suites:
+      #   - 1000-wallet-performance → SDK step runs ONLY the 1000w-perf file,
+      #     CLI + Examples steps skip entirely. Goal: clean perf signal
+      #     without ~10 min of functional-test noise on the funder wallet.
+      #   - default / all → SDK step runs everything (vitest's default glob),
+      #     minus the stress file (which has its own dedicated step below).
+      # The describe.skipIf gates inside test files still apply on top, so
+      # for `all` the 1000w-perf describe runs (gate matches "all"), and
+      # for `default` it gets skipIf'd out.
       - name: SDK integration
         id: sdk
         if: ${{ env.RUN_INTEGRATION == 'true' }}
         working-directory: packages/sdk
         run: |
           set -o pipefail
+          INCLUDE_ARGS=()
+          if [ "$TEST_SUITE" = "1000-wallet-performance" ]; then
+            INCLUDE_ARGS=('__integration__/ephemeral-1000w-perf.test.ts')
+          fi
           npx vitest run --no-file-parallelism \
             --exclude '**/__tests__/**' \
             --exclude '**/__integration__/ephemeral-60min-stress.test.ts' \
             --exclude '**/node_modules/**' \
             --exclude '**/dist/**' \
+            "${INCLUDE_ARGS[@]}" \
             --reporter=default --reporter=json \
             --outputFile.json=/tmp/results-sdk.json 2>&1 | tee /tmp/sdk-integration.log
 
       - name: CLI integration
         id: cli
-        if: ${{ env.RUN_INTEGRATION == 'true' }}
+        if: ${{ env.RUN_INTEGRATION == 'true' && env.TEST_SUITE != '1000-wallet-performance' }}
         working-directory: apps/cli
         run: |
           set -o pipefail
@@ -232,7 +247,7 @@ jobs:
 
       - name: Examples integration
         id: examples
-        if: ${{ env.RUN_INTEGRATION == 'true' }}
+        if: ${{ env.RUN_INTEGRATION == 'true' && env.TEST_SUITE != '1000-wallet-performance' }}
         working-directory: apps/examples
         run: |
           set -o pipefail

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -18,9 +18,9 @@ on:
         type: choice
         description: Which suite to run (gated inside test files via TEST_SUITE env)
         options:
-          # default          — basic SDK/CLI/Examples + 100w ephemeral tests
-          # all              — default + 1000w perf + 60min stress (stress devnet-only)
-          # 1000-wallet-performance — only the 1000-wallet perf suite
+          # default                 — basic SDK/CLI/Examples + 100w ephemeral tests
+          # all                     — default + 1000w perf + 60min stress (stress devnet-only)
+          # 1000-wallet-performance — basic + the 1000-wallet perf suite
           # 1H-stress-devnet-only   — only the 60-min combined stress (DevNet only)
           - default
           - all
@@ -30,16 +30,11 @@ on:
   pull_request:
     branches: [main]
     paths:
-      # SDK and its workspace deps — anything that affects what `pnpm build`
-      # produces or how the SDK's runtime behaves.
       - 'packages/sdk/**'
       - 'packages/crypto/**'
       - 'packages/contracts/**'
       - 'apps/cli/**'
       - 'apps/examples/**'
-      # Workspace-level inputs. A change to root config or the lockfile can
-      # break `pnpm install` / `pnpm build` even if no source code under
-      # packages/* or apps/* moved.
       - 'package.json'
       - 'pnpm-lock.yaml'
       - 'pnpm-workspace.yaml'
@@ -73,11 +68,9 @@ jobs:
             NETWORK="devnet"
             SUITE="default"
           fi
-
-          # Job gating from suite:
-          #   - integration job covers default + 1000w perf (single vitest run
-          #     with TEST_SUITE env steering describe.skipIf inside test files).
-          #   - stress job runs only the 60-min stress (separate vitest invocation).
+          # The single `integration` job below covers EVERY suite — the
+          # `run_integration` / `run_stress` flags steer which step blocks
+          # inside it run. There is no separate `stress` job anymore.
           case "$SUITE" in
             default|1000-wallet-performance)
               RUN_INTEGRATION=true
@@ -91,14 +84,13 @@ jobs:
             *)
               echo "::error::unknown test_suite=$SUITE"; exit 1 ;;
           esac
-
           echo "network=$NETWORK"        >> $GITHUB_OUTPUT
           echo "test_suite=$SUITE"       >> $GITHUB_OUTPUT
           echo "run_integration=$RUN_INTEGRATION" >> $GITHUB_OUTPUT
           echo "run_stress=$RUN_STRESS"  >> $GITHUB_OUTPUT
 
-      - name: Validate (stress + 1000w-perf+all are DevNet-only)
-        # 60-min stress is DevNet-only by design (needs anvil-0 funder).
+      - name: Validate (stress is DevNet-only)
+        # 60-min stress is DevNet-only by design (needs anvil-0 as funder).
         if: ${{ steps.resolve.outputs.run_stress == 'true' && steps.resolve.outputs.network != 'devnet' }}
         run: |
           echo "::error::test_suite=${{ steps.resolve.outputs.test_suite }} requires network=devnet (got ${{ steps.resolve.outputs.network }})"
@@ -122,14 +114,18 @@ jobs:
 
   integration:
     needs: prepare
-    if: ${{ needs.prepare.outputs.run_integration == 'true' }}
+    if: ${{ needs.prepare.outputs.run_integration == 'true' || needs.prepare.outputs.run_stress == 'true' }}
     runs-on: ubuntu-latest
-    # Suite-aware timeout: 1000-wallet perf is the heaviest non-stress case
-    # (~30-50 min budgeted). Other suites finish in <15 min.
-    timeout-minutes: ${{ needs.prepare.outputs.test_suite == '1000-wallet-performance' && 90 || (needs.prepare.outputs.test_suite == 'all' && 90 || 60) }}
+    # Timeout sized to the heaviest suite in play. Stress alone is 60 min
+    # wall time + ~15 min setup/teardown; `all` adds another 30-50 min
+    # for the 1000-wallet perf suite. `1000-wallet-performance` is 90 min
+    # without stress.
+    timeout-minutes: ${{ needs.prepare.outputs.test_suite == 'all' && 180 || (needs.prepare.outputs.test_suite == '1H-stress-devnet-only' && 120 || (needs.prepare.outputs.test_suite == '1000-wallet-performance' && 90 || 60)) }}
     env:
       NETWORK: ${{ needs.prepare.outputs.network }}
       TEST_SUITE: ${{ needs.prepare.outputs.test_suite }}
+      RUN_INTEGRATION: ${{ needs.prepare.outputs.run_integration }}
+      RUN_STRESS: ${{ needs.prepare.outputs.run_stress }}
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
@@ -138,10 +134,6 @@ jobs:
           node-version: '20'
           cache: pnpm
       - run: pnpm install
-
-      # Workspace deps (`@piplabs/cdr-crypto`, `@piplabs/cdr-contracts`)
-      # resolve via `main: dist/index.js`; without a build, vite fails to
-      # resolve them on a fresh CI checkout.
       - run: pnpm build
 
       - name: Configure network env
@@ -166,12 +158,10 @@ jobs:
             exit 1
           fi
 
-      # Capture chain state BEFORE the suite runs so the summary can show
-      # the delta (block height + DKG round) the run lived through. Story
-      # has no /dkg/params endpoint (see reference_dkg_params_immutable.md);
-      # we use /dkg/latest_active for round + stage, and eth_blockNumber for
-      # block height. Failures here are swallowed — the summary will show
-      # `?` for any field that couldn't be captured and the run continues.
+      # Capture chain state BEFORE the workload so the summary can show the
+      # delta (block height + DKG round) the run lived through. Failures
+      # here are swallowed — the summary will show `?` for any field that
+      # couldn't be captured and the run continues.
       - name: Capture pre-run chain state
         id: env_pre
         run: |
@@ -181,11 +171,10 @@ jobs:
             "$CDR_RPC_URL" 2>/dev/null | jq -r '.result // empty')
           if [ -n "$BLOCK_PRE_HEX" ]; then BLOCK_PRE=$(( BLOCK_PRE_HEX )); else BLOCK_PRE=""; fi
           LATEST_ACTIVE=$(curl -sS --max-time 10 "$CDR_API_URL/dkg/latest_active" 2>/dev/null)
-          # Diagnostic — surfaced only in the job step log, not in the
-          # Summary. If Story-API's response shape ever shifts again
-          # (it did in PR #73 → REST), the next failure will produce
-          # `?` in Summary; this echo lets the investigator see the
-          # raw body in one click instead of curling locally.
+          # Diagnostic for the step log (not the Summary). If Story-API's
+          # response shape shifts again, the next failure produces `?` in
+          # Summary; this echo lets the investigator see the raw body in
+          # one click.
           echo "/dkg/latest_active raw response: $LATEST_ACTIVE"
           ROUND_PRE=$(echo "$LATEST_ACTIVE" | jq -r '.msg.network.round // empty' 2>/dev/null)
           STAGE_PRE=$(echo "$LATEST_ACTIVE" | jq -r '.msg.network.stage // empty' 2>/dev/null)
@@ -196,17 +185,15 @@ jobs:
           echo "ts=$TS_PRE"       >> $GITHUB_OUTPUT
           echo "pre-run: block=$BLOCK_PRE round=$ROUND_PRE stage=$STAGE_PRE"
 
-      # All three suites share the funder wallet (anvil-0 on DevNet, the
-      # long-lived Aeneid wallet otherwise), so they must run sequentially —
-      # parallel would collide on the nonce stream.
-      #
+      # All integration suites share the funder wallet, so the three steps
+      # must run sequentially — parallel would collide on the nonce stream.
       # Each step calls vitest directly via `npx` (NOT `pnpm test:integration -- …`)
       # because pnpm passes the `--` separator through to vitest, where yargs
       # treats it as end-of-options and the `--outputFile.json=…` flag is
-      # silently dropped. Two reporters: `default` (tee'd to *-integration.log)
-      # + `json` (parsed by the summary step into a per-case ✓/✗ table).
+      # silently dropped.
       - name: SDK integration
         id: sdk
+        if: ${{ env.RUN_INTEGRATION == 'true' }}
         working-directory: packages/sdk
         run: |
           set -o pipefail
@@ -220,6 +207,7 @@ jobs:
 
       - name: CLI integration
         id: cli
+        if: ${{ env.RUN_INTEGRATION == 'true' }}
         working-directory: apps/cli
         run: |
           set -o pipefail
@@ -233,6 +221,7 @@ jobs:
 
       - name: Examples integration
         id: examples
+        if: ${{ env.RUN_INTEGRATION == 'true' }}
         working-directory: apps/examples
         run: |
           set -o pipefail
@@ -243,37 +232,46 @@ jobs:
             --reporter=default --reporter=json \
             --outputFile.json=/tmp/results-examples.json 2>&1 | tee /tmp/examples-integration.log
 
+      # ─── Stress (DevNet-only, only when run_stress=true) ──────────────────────
+      # The 60-min pipelined stress test (ephemeral-60min-stress.test.ts).
+      # Runs as conditional steps inside the same job as the integration
+      # suites so the jobs sidebar shows a single 'integration' entry
+      # instead of an orphan 'stress' job that's perpetually skipped on
+      # non-stress runs.
+      - name: Run stress (60 min, DevNet only)
+        id: stress
+        if: ${{ env.RUN_STRESS == 'true' }}
+        working-directory: packages/sdk
+        run: |
+          set -o pipefail
+          npx vitest run __integration__/ephemeral-60min-stress.test.ts \
+            --reporter=default --reporter=json \
+            --outputFile.json=/tmp/results-stress.json 2>&1 | tee /tmp/stress-stdout.log
+
+      - name: Upload cdr-stress.log artifact
+        if: ${{ always() && env.RUN_STRESS == 'true' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: cdr-stress-log-${{ github.run_id }}
+          path: /tmp/cdr-stress.log
+          if-no-files-found: warn
+          retention-days: 14
+
+      # ─── Summary (always) ─────────────────────────────────────────────────────
       - name: Write integration summary
         if: always()
         env:
           SDK_OUTCOME: ${{ steps.sdk.outcome }}
           CLI_OUTCOME: ${{ steps.cli.outcome }}
           EXAMPLES_OUTCOME: ${{ steps.examples.outcome }}
+          STRESS_OUTCOME: ${{ steps.stress.outcome }}
           BLOCK_PRE: ${{ steps.env_pre.outputs.block }}
           ROUND_PRE: ${{ steps.env_pre.outputs.round }}
           STAGE_PRE: ${{ steps.env_pre.outputs.stage }}
           TS_PRE:    ${{ steps.env_pre.outputs.ts }}
         run: |
-          # Strip ANSI color codes; capture vitest's three summary lines if present.
+          set -u
           strip_ansi() { sed -E $'s/\x1b\\[[0-9;]*[a-zA-Z]//g'; }
-          # Capture post-run chain state. Swallow errors so the summary
-          # still renders even if the chain is unreachable at this point.
-          BLOCK_POST_HEX=$(curl -sS --max-time 10 -X POST -H 'Content-Type: application/json' \
-            --data '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}' \
-            "$CDR_RPC_URL" 2>/dev/null | jq -r '.result // empty' 2>/dev/null || true)
-          if [ -n "$BLOCK_POST_HEX" ]; then BLOCK_POST=$(( BLOCK_POST_HEX )); else BLOCK_POST=""; fi
-          LATEST_ACTIVE=$(curl -sS --max-time 10 "$CDR_API_URL/dkg/latest_active" 2>/dev/null || echo '{}')
-          ROUND_POST=$(echo "$LATEST_ACTIVE" | jq -r '.msg.network.round // empty' 2>/dev/null)
-          STAGE_POST=$(echo "$LATEST_ACTIVE" | jq -r '.msg.network.stage // empty' 2>/dev/null)
-          TS_POST=$(date +%s)
-          fmt() { [ -n "$1" ] && echo "$1" || echo "?"; }
-          if [ -n "$BLOCK_PRE" ] && [ -n "$BLOCK_POST" ]; then
-            BLOCK_DELTA=$(( BLOCK_POST - BLOCK_PRE ))
-          else BLOCK_DELTA="?"; fi
-          if [ -n "$ROUND_PRE" ] && [ -n "$ROUND_POST" ]; then
-            ROUND_DELTA=$(( ROUND_POST - ROUND_PRE ))
-          else ROUND_DELTA="?"; fi
-          if [ -n "$TS_PRE" ]; then ELAPSED_S=$(( TS_POST - TS_PRE )); else ELAPSED_S="?"; fi
           icon() {
             case "$1" in
               success) echo "✅" ;;
@@ -283,30 +281,61 @@ jobs:
               *) echo "❔" ;;
             esac
           }
-          # Parse a vitest JSON reporter file ($1) into a per-case markdown
-          # table. The JSON reporter mirrors Jest's shape:
-          #   { numTotalTests, numPassedTests, numFailedTests,
-          #     testResults: [ { name, status,
-          #       assertionResults: [ { fullName, title, status, duration,
-          #                            failureMessages: [...] } ] } ] }
-          # Output:
-          #   - Roll-up counts (files passed/failed, tests passed/failed,
-          #     total duration in seconds)
-          #   - A `| File | Test | Status | Duration |` markdown table with
-          #     every assertion, ordered by file then in-file order.
-          #   - For each failing assertion, the first failureMessages line.
+          fmt() { [ -n "$1" ] && echo "$1" || echo "?"; }
+
+          # ─── Post-run chain state ─────────────────────────────────────────────
+          BLOCK_POST_HEX=$(curl -sS --max-time 10 -X POST -H 'Content-Type: application/json' \
+            --data '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}' \
+            "$CDR_RPC_URL" 2>/dev/null | jq -r '.result // empty' 2>/dev/null || true)
+          if [ -n "$BLOCK_POST_HEX" ]; then BLOCK_POST=$(( BLOCK_POST_HEX )); else BLOCK_POST=""; fi
+          LATEST_ACTIVE=$(curl -sS --max-time 10 "$CDR_API_URL/dkg/latest_active" 2>/dev/null || echo '{}')
+          ROUND_POST=$(echo "$LATEST_ACTIVE" | jq -r '.msg.network.round // empty' 2>/dev/null)
+          STAGE_POST=$(echo "$LATEST_ACTIVE" | jq -r '.msg.network.stage // empty' 2>/dev/null)
+          TS_POST=$(date +%s)
+          if [ -n "$BLOCK_PRE" ] && [ -n "$BLOCK_POST" ]; then
+            BLOCK_DELTA=$(( BLOCK_POST - BLOCK_PRE ))
+          else BLOCK_DELTA="?"; fi
+          if [ -n "$ROUND_PRE" ] && [ -n "$ROUND_POST" ]; then
+            ROUND_DELTA=$(( ROUND_POST - ROUND_PRE ))
+          else ROUND_DELTA="?"; fi
+          if [ -n "$TS_PRE" ]; then ELAPSED_S=$(( TS_POST - TS_PRE )); else ELAPSED_S="?"; fi
+
+          # ─── Aggregate counts across every JSON reporter file produced ─────────
+          # The four optional files match the four step outcomes above.
+          TOTAL_PASSED=0
+          TOTAL_FAILED=0
+          TOTAL_SKIPPED=0
+          for json in /tmp/results-sdk.json /tmp/results-cli.json /tmp/results-examples.json /tmp/results-stress.json; do
+            [ -f "$json" ] || continue
+            p=$(jq -r '.numPassedTests // 0' "$json")
+            f=$(jq -r '.numFailedTests // 0' "$json")
+            # vitest's `numPendingTests` covers `.skip` + skipIf. Treat empty as 0.
+            s=$(jq -r '(.numPendingTests // 0) + (.numTodoTests // 0)' "$json")
+            TOTAL_PASSED=$(( TOTAL_PASSED + p ))
+            TOTAL_FAILED=$(( TOTAL_FAILED + f ))
+            TOTAL_SKIPPED=$(( TOTAL_SKIPPED + s ))
+          done
+          if [ "$TOTAL_FAILED" -gt 0 ]; then HEADLINE_EMOJI="❌"
+          elif [ "$TOTAL_PASSED" -eq 0 ] && [ "$TOTAL_SKIPPED" -eq 0 ]; then HEADLINE_EMOJI="❔"
+          else HEADLINE_EMOJI="✅"; fi
+
+          # ─── Helpers: parse JSON, emit per-suite block ─────────────────────────
+          # Renders failures INLINE (no <details> wrapper) above the per-case
+          # table so a reader's eye lands on the failure first; per-case
+          # table follows for context.
           summarize() {
             local title=$1 outcome=$2 scope=$3 json=$4 log=$5
             local emoji; emoji=$(icon "$outcome")
-            echo "### ${emoji} ${title} — \`${outcome}\`"
+            echo "#### ${emoji} ${title} — \`${outcome}\`"
             echo ""
             echo "_${scope}_"
             echo ""
+            if [ "$outcome" = "skipped" ]; then
+              echo "_(step skipped — not part of this suite)_"
+              echo ""
+              return
+            fi
             if [ ! -f "$json" ]; then
-              # JSON reporter file missing — usually means the test process
-              # crashed before vitest could write (e.g. TS compile error).
-              # Fall back to the tee'd log if present so the user has
-              # SOMETHING to read.
               echo "_(no JSON reporter output at \`$json\` — vitest likely crashed before writing; raw log:)_"
               if [ -f "$log" ]; then
                 echo ""
@@ -317,15 +346,11 @@ jobs:
               echo ""
               return
             fi
-            # Roll-up counts. `// 0` guards against missing fields on early
-            # vitest runs where a setup error short-circuits the run.
             local files_passed files_failed tests_passed tests_failed dur_ms dur_s
             files_passed=$(jq -r '.numPassedTestSuites // 0' "$json")
             files_failed=$(jq -r '.numFailedTestSuites // 0' "$json")
             tests_passed=$(jq -r '.numPassedTests // 0' "$json")
             tests_failed=$(jq -r '.numFailedTests // 0' "$json")
-            # startTime + max(testResults[].endTime) gives total wall time
-            # — vitest doesn't emit a single "duration" field in its JSON.
             dur_ms=$(jq -r '
               ([.testResults[].endTime // 0] | max) as $end
               | (.startTime // 0) as $start
@@ -338,45 +363,136 @@ jobs:
             echo "  Duration  ${dur_s}s"
             echo '```'
             echo ""
+            # Inline failures FIRST — readers care about red, not green.
+            local failures
+            failures=$(jq -r '
+              .testResults[] as $f
+              | ($f.name | split("/") | last) as $file
+              | $f.assertionResults[]
+              | select(.status == "failed")
+              | "**❌ `" + $file + "` → " + .title + "**\n\n```\n"
+                + ((.failureMessages // [])[0] // "(no failureMessage)")
+                + "\n```\n"
+            ' "$json")
+            if [ -n "$failures" ]; then
+              echo "**Failures (${tests_failed}):**"
+              echo ""
+              echo "$failures"
+            fi
+            # Then the full per-case table.
             local rows
             rows=$(jq -r '
               .testResults[] as $f
               | ($f.name | split("/") | last) as $file
               | $f.assertionResults[]
               | "| `" + $file + "` | " + .title
-                + " | " + (if .status == "passed" then "✅" else if .status == "failed" then "❌" else "⏭️" end end)
+                + " | " + (if .status == "passed" then "✅" else (if .status == "failed" then "❌" else "⏭️" end) end)
                 + " | " + (if (.duration // 0) > 0 then ((.duration / 1000) | tostring + "s") else "—" end)
                 + " |"
             ' "$json")
             if [ -n "$rows" ]; then
+              echo "<details><summary>Per-case results (${tests_passed}✅ ${tests_failed}❌)</summary>"
+              echo ""
               echo "| File | Test | Status | Duration |"
               echo "|---|---|---|---|"
               echo "$rows"
               echo ""
-              # Surface failures inline: first failure message per failing case.
-              local failures
-              failures=$(jq -r '
+              echo "</details>"
+              echo ""
+            fi
+          }
+
+          # ─── Aggregate failures across ALL JSON files (top-of-summary block) ──
+          aggregate_failures() {
+            for json in /tmp/results-sdk.json /tmp/results-cli.json /tmp/results-examples.json /tmp/results-stress.json; do
+              [ -f "$json" ] || continue
+              jq -r --arg scope "$(basename "$json" .json | sed 's/^results-//')" '
                 .testResults[] as $f
                 | ($f.name | split("/") | last) as $file
                 | $f.assertionResults[]
                 | select(.status == "failed")
-                | "**`" + $file + "` → " + .title + "`**\n\n```\n"
+                | "**❌ [" + $scope + "] `" + $file + "` → " + .title + "**\n\n```\n"
                   + ((.failureMessages // [])[0] // "(no failureMessage)")
                   + "\n```\n"
-              ' "$json")
-              if [ -n "$failures" ]; then
-                echo "<details><summary>Failures (${tests_failed})</summary>"
+              ' "$json"
+            done
+          }
+
+          # ─── Perf-stats table (B): glob /tmp/perf-stats-*.json ────────────────
+          render_perf_table() {
+            shopt -s nullglob
+            local files=(/tmp/perf-stats-*.json)
+            shopt -u nullglob
+            [ "${#files[@]}" -gt 0 ] || { echo "_(no perf-stats output produced — nothing to summarize)_"; echo ""; return; }
+            echo "Latencies are per-wallet (or per-cycle for the stress suite). All percentiles are nearest-rank, no interpolation."
+            echo ""
+            echo "| Suite | Wallets | Wall clock | min | p50 | mean | p95 | p99 | max | failed | refund |"
+            echo "|---|---|---|---|---|---|---|---|---|---|---|"
+            for f in "${files[@]}"; do
+              jq -r '
+                def humanMs: if . == null or . == 0 then "—" else
+                  if . < 1000 then (. | tostring) + "ms"
+                  else ((. / 1000 * 10 | floor) / 10 | tostring) + "s"
+                  end
+                end;
+                def humanWei: if . == null then "—" else
+                  ((. | tonumber) / 1e18 | tostring | (. + "0000")[0:6]) + " IP"
+                end;
+                # `accessMs` is the canonical latency. If absent, fall back to uploadMs.
+                ((.accessMs // .uploadMs) // {}) as $lat |
+                "| " + .label
+                + " | " + (.wallets | tostring)
+                + " | " + (.wall_clock_ms | humanMs)
+                + " | " + ($lat.min_ms // 0 | humanMs)
+                + " | " + ($lat.p50_ms // 0 | humanMs)
+                + " | " + ($lat.mean_ms // 0 | humanMs)
+                + " | " + ($lat.p95_ms // 0 | humanMs)
+                + " | " + ($lat.p99_ms // 0 | humanMs)
+                + " | " + ($lat.max_ms // 0 | humanMs)
+                + " | " + (.failed | tostring)
+                + " | " + (if .refund == null then "—"
+                           else (.refund.refunded_wei | humanWei) + " / " + (.refund.funded_wei | humanWei)
+                           end)
+                + " |"
+              ' "$f"
+            done
+            echo ""
+            # Per-suite extras (e.g. stress cycles, upload p50 when distinct from access)
+            for f in "${files[@]}"; do
+              local label
+              label=$(jq -r '.label' "$f")
+              local up_p50
+              up_p50=$(jq -r '.uploadMs.p50_ms // empty' "$f")
+              local extra
+              extra=$(jq -r '.extra // empty | to_entries[]? | "  - " + .key + " = " + (.value | tostring)' "$f")
+              if [ -n "$up_p50" ] || [ -n "$extra" ]; then
+                echo "**${label}** extras:"
                 echo ""
-                echo "$failures"
-                echo "</details>"
+                [ -n "$up_p50" ] && {
+                  local up_p95 up_mean
+                  up_p95=$(jq -r '.uploadMs.p95_ms // 0' "$f")
+                  up_mean=$(jq -r '.uploadMs.mean_ms // 0' "$f")
+                  echo "  - upload p50/p95/mean = ${up_p50}ms / ${up_p95}ms / ${up_mean}ms"
+                }
+                [ -n "$extra" ] && echo "$extra"
                 echo ""
               fi
-            else
-              echo "_(JSON reporter wrote but contained no assertion results)_"
+            done
+          }
+
+          # ─── Now write everything to GITHUB_STEP_SUMMARY in the new order ─────
+          {
+            echo "## ${HEADLINE_EMOJI} Overall — ${TOTAL_PASSED} passed | ${TOTAL_FAILED} failed | ${TOTAL_SKIPPED} skipped — wall ${ELAPSED_S}s"
+            echo ""
+
+            FAILURES_BLOCK="$(aggregate_failures)"
+            if [ -n "$FAILURES_BLOCK" ]; then
+              echo "## 🚨 Failures"
+              echo ""
+              echo "$FAILURES_BLOCK"
               echo ""
             fi
-          }
-          {
+
             echo "## Integration test results"
             echo ""
             echo "| Field | Value |"
@@ -387,7 +503,11 @@ jobs:
             echo "| CDR_RPC_URL | \`${CDR_RPC_URL}\` |"
             echo "| Branch | \`${{ github.ref_name }}\` |"
             echo "| Commit | \`${{ github.sha }}\` |"
+            if [ "$RUN_STRESS" = "true" ]; then
+              echo "| Stress log artifact | \`cdr-stress-log-${{ github.run_id }}\` (14-day retention) |"
+            fi
             echo ""
+
             echo "### Chain state during run"
             echo ""
             echo "| | Pre | Post | Δ |"
@@ -403,6 +523,11 @@ jobs:
               echo "> ⚠️ **DKG round rotated mid-run** (${ROUND_PRE} → ${ROUND_POST}). Vault reads spanning rotation may exercise the bucket-round filter (#75)."
             fi
             echo ""
+
+            echo "### Performance metrics"
+            echo ""
+            render_perf_table
+
             echo "### Per-suite results"
             echo ""
             summarize "SDK integration" "$SDK_OUTCOME" \
@@ -414,145 +539,19 @@ jobs:
             summarize "Examples integration" "$EXAMPLES_OUTCOME" \
               "apps/examples/__integration__ — query-dkg-state, upload-cdr, access-cdr, e2e-demo" \
               /tmp/results-examples.json /tmp/examples-integration.log
-          } >> $GITHUB_STEP_SUMMARY
-
-  stress:
-    needs: prepare
-    if: ${{ needs.prepare.outputs.run_stress == 'true' }}
-    runs-on: ubuntu-latest
-    timeout-minutes: 120
-    env:
-      NETWORK: ${{ needs.prepare.outputs.network }}
-      TEST_SUITE: ${{ needs.prepare.outputs.test_suite }}
-    steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-          cache: pnpm
-      - run: pnpm install
-      - run: pnpm build
-
-      - name: Configure DevNet env
-        run: |
-          echo "CDR_API_URL=http://172.207.250.203:1317" >> $GITHUB_ENV
-          echo "CDR_RPC_URL=http://172.207.250.203:8545" >> $GITHUB_ENV
-          echo "CDR_TEST_PRIVATE_KEY=${{ secrets.CDR_DEVNET_TEST_PRIVATE_KEY }}" >> $GITHUB_ENV
-
-      # Same env snapshot the integration job takes — gives the stress
-      # summary the same "before/after" block + round delta.
-      - name: Capture pre-run chain state
-        id: env_pre
-        run: |
-          set +e
-          BLOCK_PRE_HEX=$(curl -sS --max-time 10 -X POST -H 'Content-Type: application/json' \
-            --data '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}' \
-            "$CDR_RPC_URL" 2>/dev/null | jq -r '.result // empty')
-          if [ -n "$BLOCK_PRE_HEX" ]; then BLOCK_PRE=$(( BLOCK_PRE_HEX )); else BLOCK_PRE=""; fi
-          LATEST_ACTIVE=$(curl -sS --max-time 10 "$CDR_API_URL/dkg/latest_active" 2>/dev/null)
-          echo "/dkg/latest_active raw response: $LATEST_ACTIVE"
-          ROUND_PRE=$(echo "$LATEST_ACTIVE" | jq -r '.msg.network.round // empty' 2>/dev/null)
-          STAGE_PRE=$(echo "$LATEST_ACTIVE" | jq -r '.msg.network.stage // empty' 2>/dev/null)
-          TS_PRE=$(date +%s)
-          echo "block=$BLOCK_PRE" >> $GITHUB_OUTPUT
-          echo "round=$ROUND_PRE" >> $GITHUB_OUTPUT
-          echo "stage=$STAGE_PRE" >> $GITHUB_OUTPUT
-          echo "ts=$TS_PRE"       >> $GITHUB_OUTPUT
-          echo "pre-run: block=$BLOCK_PRE round=$ROUND_PRE stage=$STAGE_PRE"
-
-      - name: Record stress start
-        id: started
-        run: echo "ts=$(date +%s)" >> $GITHUB_OUTPUT
-
-      - name: Run stress (60 min)
-        id: stress
-        working-directory: packages/sdk
-        run: |
-          set -o pipefail
-          pnpm test:stress 2>&1 | tee /tmp/stress-stdout.log
-
-      - name: Upload stress log
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: cdr-stress-log-${{ github.run_id }}
-          path: /tmp/cdr-stress.log
-          retention-days: 14
-
-      - name: Write stress summary
-        if: always()
-        env:
-          STRESS_OUTCOME: ${{ steps.stress.outcome }}
-          STARTED_TS: ${{ steps.started.outputs.ts }}
-          BLOCK_PRE: ${{ steps.env_pre.outputs.block }}
-          ROUND_PRE: ${{ steps.env_pre.outputs.round }}
-          STAGE_PRE: ${{ steps.env_pre.outputs.stage }}
-          TS_PRE:    ${{ steps.env_pre.outputs.ts }}
-        run: |
-          icon() {
-            case "$1" in
-              success) echo "✅" ;;
-              failure) echo "❌" ;;
-              skipped) echo "⏭️" ;;
-              cancelled) echo "🛑" ;;
-              *) echo "❔" ;;
-            esac
-          }
-          emoji=$(icon "$STRESS_OUTCOME")
-          now=$(date +%s)
-          elapsed=$(( now - ${STARTED_TS:-$now} ))
-          mins=$(( elapsed / 60 ))
-          secs=$(( elapsed % 60 ))
-          # Post-run chain state — match the integration job's table.
-          BLOCK_POST_HEX=$(curl -sS --max-time 10 -X POST -H 'Content-Type: application/json' \
-            --data '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}' \
-            "$CDR_RPC_URL" 2>/dev/null | jq -r '.result // empty' 2>/dev/null || true)
-          if [ -n "$BLOCK_POST_HEX" ]; then BLOCK_POST=$(( BLOCK_POST_HEX )); else BLOCK_POST=""; fi
-          LATEST_ACTIVE=$(curl -sS --max-time 10 "$CDR_API_URL/dkg/latest_active" 2>/dev/null || echo '{}')
-          ROUND_POST=$(echo "$LATEST_ACTIVE" | jq -r '.msg.network.round // empty' 2>/dev/null)
-          STAGE_POST=$(echo "$LATEST_ACTIVE" | jq -r '.msg.network.stage // empty' 2>/dev/null)
-          fmt() { [ -n "$1" ] && echo "$1" || echo "?"; }
-          if [ -n "$BLOCK_PRE" ] && [ -n "$BLOCK_POST" ]; then
-            BLOCK_DELTA=$(( BLOCK_POST - BLOCK_PRE ))
-          else BLOCK_DELTA="?"; fi
-          if [ -n "$ROUND_PRE" ] && [ -n "$ROUND_POST" ]; then
-            ROUND_DELTA=$(( ROUND_POST - ROUND_PRE ))
-          else ROUND_DELTA="?"; fi
-
-          {
-            echo "## ${emoji} Stress test — \`${STRESS_OUTCOME}\`"
-            echo ""
-            echo "| Field | Value |"
-            echo "|---|---|"
-            echo "| Network | DevNet (\`${CDR_API_URL}\`) |"
-            echo "| Test suite | \`${TEST_SUITE}\` |"
-            echo "| Funder | anvil-0 (\`${CDR_TEST_PRIVATE_KEY:+set}\`) |"
-            echo "| Elapsed | ${mins}m${secs}s |"
-            echo "| Log artifact | \`cdr-stress-log-${{ github.run_id }}\` (14-day retention) |"
-            echo ""
-            echo "### Chain state during run"
-            echo ""
-            echo "| | Pre | Post | Δ |"
-            echo "|---|---|---|---|"
-            echo "| EL block | $(fmt "$BLOCK_PRE") | $(fmt "$BLOCK_POST") | $BLOCK_DELTA |"
-            echo "| DKG round | $(fmt "$ROUND_PRE") | $(fmt "$ROUND_POST") | $ROUND_DELTA |"
-            echo "| DKG stage | $(fmt "$STAGE_PRE") | $(fmt "$STAGE_POST") | — |"
-            echo ""
-            echo "_DKG stage codes: 1 = Registration, 2 = Dealing, 3 = Finalization, 4 = Active._"
-            if [ "$ROUND_DELTA" != "?" ] && [ "$ROUND_DELTA" -gt 0 ]; then
-              echo ""
-              echo "> ⚠️ **DKG round rotated mid-run** (${ROUND_PRE} → ${ROUND_POST})."
-            fi
-            echo ""
-            if [ -f /tmp/cdr-stress.log ]; then
-              total=$(wc -l < /tmp/cdr-stress.log | tr -d ' ')
-              echo "### cdr-stress.log — last 80 of ${total} lines"
-              echo ""
-              echo '```'
-              tail -80 /tmp/cdr-stress.log
-              echo '```'
-            else
-              echo "_(no /tmp/cdr-stress.log produced)_"
+            if [ "$RUN_STRESS" = "true" ]; then
+              summarize "Stress (60 min, pipelined)" "$STRESS_OUTCOME" \
+                "packages/sdk/__integration__/ephemeral-60min-stress.test.ts — 10 wallets back-to-back upload+access on DevNet" \
+                /tmp/results-stress.json /tmp/stress-stdout.log
+              if [ -f /tmp/cdr-stress.log ]; then
+                total=$(wc -l < /tmp/cdr-stress.log | tr -d ' ')
+                echo "<details><summary>cdr-stress.log — last 80 of ${total} lines</summary>"
+                echo ""
+                echo '```'
+                tail -80 /tmp/cdr-stress.log
+                echo '```'
+                echo "</details>"
+                echo ""
+              fi
             fi
           } >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -98,17 +98,28 @@ jobs:
 
       - name: Write run summary
         if: always()
+        # head_ref is attacker-controlled (any PR opener picks the
+        # branch name); shell-interpolating it directly is a known
+        # script-injection vector (Wiz SAST flagged this on PR #83).
+        # Pipe via env vars so values are quoted by the shell, not
+        # by the ${{ }} expression engine.
+        env:
+          GH_EVENT_NAME: ${{ github.event_name }}
+          GH_BRANCH: ${{ github.head_ref || github.ref_name }}
+          GH_SHA: ${{ github.sha }}
+          NETWORK: ${{ steps.resolve.outputs.network }}
+          TEST_SUITE: ${{ steps.resolve.outputs.test_suite }}
         run: |
           {
             echo "## Run configuration"
             echo ""
             echo "| Field | Value |"
             echo "|---|---|"
-            echo "| Trigger | \`${{ github.event_name }}\` |"
-            echo "| Branch | \`${{ github.head_ref || github.ref_name }}\` |"
-            echo "| Commit | \`${{ github.sha }}\` |"
-            echo "| Network | \`${{ steps.resolve.outputs.network }}\` |"
-            echo "| Test suite | \`${{ steps.resolve.outputs.test_suite }}\` |"
+            echo "| Trigger | \`${GH_EVENT_NAME}\` |"
+            echo "| Branch | \`${GH_BRANCH}\` |"
+            echo "| Commit | \`${GH_SHA}\` |"
+            echo "| Network | \`${NETWORK}\` |"
+            echo "| Test suite | \`${TEST_SUITE}\` |"
             echo ""
           } >> $GITHUB_STEP_SUMMARY
 
@@ -260,6 +271,11 @@ jobs:
       # ─── Summary (always) ─────────────────────────────────────────────────────
       - name: Write integration summary
         if: always()
+        # head_ref is attacker-controlled — pass via env (NOT inline
+        # interpolation) so the shell sees the value as a quoted
+        # parameter, not as part of the script. Same reasoning for
+        # the GH context fields below (sha + run_id are GH-controlled
+        # but threaded through env for consistency).
         env:
           SDK_OUTCOME: ${{ steps.sdk.outcome }}
           CLI_OUTCOME: ${{ steps.cli.outcome }}
@@ -269,6 +285,9 @@ jobs:
           ROUND_PRE: ${{ steps.env_pre.outputs.round }}
           STAGE_PRE: ${{ steps.env_pre.outputs.stage }}
           TS_PRE:    ${{ steps.env_pre.outputs.ts }}
+          GH_BRANCH: ${{ github.head_ref || github.ref_name }}
+          GH_SHA: ${{ github.sha }}
+          GH_RUN_ID: ${{ github.run_id }}
         run: |
           set -u
           strip_ansi() { sed -E $'s/\x1b\\[[0-9;]*[a-zA-Z]//g'; }
@@ -503,10 +522,10 @@ jobs:
             echo "| Test suite | \`${TEST_SUITE}\` |"
             echo "| CDR_API_URL | \`${CDR_API_URL}\` |"
             echo "| CDR_RPC_URL | \`${CDR_RPC_URL}\` |"
-            echo "| Branch | \`${{ github.head_ref || github.ref_name }}\` |"
-            echo "| Commit | \`${{ github.sha }}\` |"
+            echo "| Branch | \`${GH_BRANCH}\` |"
+            echo "| Commit | \`${GH_SHA}\` |"
             if [ "$RUN_STRESS" = "true" ]; then
-              echo "| Stress log artifact | \`cdr-stress-log-${{ github.run_id }}\` (14-day retention) |"
+              echo "| Stress log artifact | \`cdr-stress-log-${GH_RUN_ID}\` (14-day retention) |"
             fi
             echo ""
 

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -438,64 +438,96 @@ jobs:
           }
 
           # ─── Perf-stats table (B): glob /tmp/perf-stats-*.json ────────────────
+          # One row PER (suite, op) tuple. For a suite that only does
+          # accessCDR (e.g. 100w-shared / 1000w-perf) there's a single
+          # `access` row. For suites that do both (100w-fresh, stress)
+          # both an `upload` row and an `access` row appear so the
+          # reader doesn't have to mentally separate the two latency
+          # paths — and a separate extras block below covers anything
+          # that doesn't fit the per-op latency shape (stress cycle
+          # counters etc.).
+          #
+          # `Wall clock`, `failed`, and `refund` are suite-level totals
+          # (not per-op) — emitted only on the suite's FIRST row, with
+          # `—` on subsequent op rows of the same suite. This avoids
+          # double-counting failures or implying access-only refund.
           render_perf_table() {
             shopt -s nullglob
             local files=(/tmp/perf-stats-*.json)
             shopt -u nullglob
             [ "${#files[@]}" -gt 0 ] || { echo "_(no perf-stats output produced — nothing to summarize)_"; echo ""; return; }
-            echo "Latencies are per-wallet (or per-cycle for the stress suite). All percentiles are nearest-rank, no interpolation."
+            echo "**One row per (suite, operation).** The \`Op\` column is the operation being timed —"
+            echo "\`upload\` = \`uploadCDR\` (allocate + write txs); \`access\` = \`accessCDR\` (read tx + validator partial-collection + decrypt). Suites that do both emit two rows so upload + access latencies are side-by-side."
             echo ""
-            echo "> **stress row caveat:** the \`Wallets\` column is the **concurrency** (10), not the cycle count, and \`failed\` counts **failed cycles**, not failed wallets — see the \`stress\` extras block below for total/failed cycle counts."
+            echo "Latencies are **per-wallet** (or per-cycle for stress). All percentiles are nearest-rank, no interpolation."
+            echo "Suite-level totals (\`Wall clock\`, \`failed\`, \`refund\`) appear only on each suite's first row."
             echo ""
-            echo "| Suite | Wallets | Wall clock | min | p50 | mean | p95 | p99 | max | failed | refund |"
-            echo "|---|---|---|---|---|---|---|---|---|---|---|"
+            echo "> **stress row caveat:** the \`Wallets\` column is **concurrency** (10), not the cycle count, and \`failed\` counts **failed cycles**, not failed wallets — see the stress extras block below for total/failed cycle counts."
+            echo ""
+            echo "| Suite | Op | Wallets | min | p50 | mean | p95 | p99 | max | Wall clock | failed | refund |"
+            echo "|---|---|---|---|---|---|---|---|---|---|---|---|"
             for f in "${files[@]}"; do
+              # Emit upload row first (chronologically upload precedes access
+              # within a cycle), then access row. Suite-level columns —
+              # Wall clock / failed / refund — go on the FIRST row of the
+              # suite; subsequent rows get `—` to avoid double-counting.
               jq -r '
                 def humanMs: if . == null or . == 0 then "—" else
                   if . < 1000 then (. | tostring) + "ms"
                   else ((. / 1000 * 10 | floor) / 10 | tostring) + "s"
                   end
                 end;
-                def humanWei: if . == null then "—" else
-                  ((. | tonumber) / 1e18 | tostring | (. + "0000")[0:6]) + " IP"
-                end;
-                # `accessMs` is the canonical latency. If absent, fall back to uploadMs.
-                ((.accessMs // .uploadMs) // {}) as $lat |
-                "| " + .label
-                + " | " + (.wallets | tostring)
-                + " | " + (.wall_clock_ms | humanMs)
-                + " | " + ($lat.min_ms // 0 | humanMs)
-                + " | " + ($lat.p50_ms // 0 | humanMs)
-                + " | " + ($lat.mean_ms // 0 | humanMs)
-                + " | " + ($lat.p95_ms // 0 | humanMs)
-                + " | " + ($lat.p99_ms // 0 | humanMs)
-                + " | " + ($lat.max_ms // 0 | humanMs)
-                + " | " + (.failed | tostring)
-                + " | " + (if .refund == null then "—"
-                           else (.refund.refunded_wei | humanWei) + " / " + (.refund.funded_wei | humanWei)
-                           end)
+                def fmtIp:
+                  ((. | tonumber) / 1e18) as $ip |
+                  ($ip * 10000 | floor) as $n |
+                  ($n / 10000 | floor | tostring) as $whole |
+                  ($n % 10000 | tostring) as $fracraw |
+                  ("0000" + $fracraw)[-4:] as $frac |
+                  $whole + "." + $frac + " IP";
+                def refundCell:
+                  if . == null then "—"
+                  else (.refunded_wei | fmtIp) + " / " + (.funded_wei | fmtIp)
+                  end;
+                # Ordered list of (op_name, stats) pairs for this suite,
+                # filtered to only those present. Upload first if present.
+                [
+                  (if .uploadMs != null then {op: "upload", lat: .uploadMs} else empty end),
+                  (if .accessMs != null then {op: "access", lat: .accessMs} else empty end)
+                ] as $ops |
+                # Suite-level summary columns are emitted on row 0 only.
+                ([$ops | length] | add) as $n_ops |
+                . as $self |
+                $ops | to_entries[] |
+                .value as $row |
+                .key as $i |
+                "| " + $self.label
+                + " | " + $row.op
+                + " | " + ($self.wallets | tostring)
+                + " | " + ($row.lat.min_ms  // 0 | humanMs)
+                + " | " + ($row.lat.p50_ms  // 0 | humanMs)
+                + " | " + ($row.lat.mean_ms // 0 | humanMs)
+                + " | " + ($row.lat.p95_ms  // 0 | humanMs)
+                + " | " + ($row.lat.p99_ms  // 0 | humanMs)
+                + " | " + ($row.lat.max_ms  // 0 | humanMs)
+                + " | " + (if $i == 0 then ($self.wall_clock_ms | humanMs) else "—" end)
+                + " | " + (if $i == 0 then ($self.failed | tostring)       else "—" end)
+                + " | " + (if $i == 0 then ($self.refund | refundCell)     else "—" end)
                 + " |"
               ' "$f"
             done
             echo ""
-            # Per-suite extras (e.g. stress cycles, upload p50 when distinct from access)
+            # Suite-specific extras (stress cycles + failure rate etc.) —
+            # upload p50/p95/mean is no longer here since it's a first-class
+            # row in the table above.
             for f in "${files[@]}"; do
               local label
               label=$(jq -r '.label' "$f")
-              local up_p50
-              up_p50=$(jq -r '.uploadMs.p50_ms // empty' "$f")
               local extra
               extra=$(jq -r '.extra // empty | to_entries[]? | "  - " + .key + " = " + (.value | tostring)' "$f")
-              if [ -n "$up_p50" ] || [ -n "$extra" ]; then
+              if [ -n "$extra" ]; then
                 echo "**${label}** extras:"
                 echo ""
-                [ -n "$up_p50" ] && {
-                  local up_p95 up_mean
-                  up_p95=$(jq -r '.uploadMs.p95_ms // 0' "$f")
-                  up_mean=$(jq -r '.uploadMs.mean_ms // 0' "$f")
-                  echo "  - upload p50/p95/mean = ${up_p50}ms / ${up_p95}ms / ${up_mean}ms"
-                }
-                [ -n "$extra" ] && echo "$extra"
+                echo "$extra"
                 echo ""
               fi
             done

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -105,7 +105,7 @@ jobs:
             echo "| Field | Value |"
             echo "|---|---|"
             echo "| Trigger | \`${{ github.event_name }}\` |"
-            echo "| Branch | \`${{ github.ref_name }}\` |"
+            echo "| Branch | \`${{ github.head_ref || github.ref_name }}\` |"
             echo "| Commit | \`${{ github.sha }}\` |"
             echo "| Network | \`${{ steps.resolve.outputs.network }}\` |"
             echo "| Test suite | \`${{ steps.resolve.outputs.test_suite }}\` |"
@@ -501,7 +501,7 @@ jobs:
             echo "| Test suite | \`${TEST_SUITE}\` |"
             echo "| CDR_API_URL | \`${CDR_API_URL}\` |"
             echo "| CDR_RPC_URL | \`${CDR_RPC_URL}\` |"
-            echo "| Branch | \`${{ github.ref_name }}\` |"
+            echo "| Branch | \`${{ github.head_ref || github.ref_name }}\` |"
             echo "| Commit | \`${{ github.sha }}\` |"
             if [ "$RUN_STRESS" = "true" ]; then
               echo "| Stress log artifact | \`cdr-stress-log-${{ github.run_id }}\` (14-day retention) |"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -102,11 +102,13 @@ jobs:
               echo ""
               return
             fi
-            local files_passed files_failed tests_passed tests_failed dur_ms dur_s
+            local files_passed files_failed files_skipped tests_passed tests_failed tests_skipped dur_ms dur_s
             files_passed=$(jq -r '.numPassedTestSuites // 0' "$json")
             files_failed=$(jq -r '.numFailedTestSuites // 0' "$json")
+            files_skipped=$(jq -r '.numPendingTestSuites // 0' "$json")
             tests_passed=$(jq -r '.numPassedTests // 0' "$json")
             tests_failed=$(jq -r '.numFailedTests // 0' "$json")
+            tests_skipped=$(jq -r '(.numPendingTests // 0) + (.numTodoTests // 0)' "$json")
             dur_ms=$(jq -r '
               ([.testResults[].endTime // 0] | max) as $end
               | (.startTime // 0) as $start
@@ -114,8 +116,8 @@ jobs:
             ' "$json")
             dur_s=$(awk -v ms="$dur_ms" 'BEGIN { printf "%.1f", ms / 1000 }')
             echo '```'
-            echo "Test Files  ${files_passed} passed | ${files_failed} failed"
-            echo "     Tests  ${tests_passed} passed | ${tests_failed} failed"
+            echo "Test Files  ${files_passed} passed | ${files_failed} failed | ${files_skipped} skipped"
+            echo "     Tests  ${tests_passed} passed | ${tests_failed} failed | ${tests_skipped} skipped"
             echo "  Duration  ${dur_s}s"
             echo '```'
             echo ""

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -153,7 +153,7 @@ jobs:
             echo ""
             echo "| Field | Value |"
             echo "|---|---|"
-            echo "| Branch | \`${{ github.ref_name }}\` |"
+            echo "| Branch | \`${{ github.head_ref || github.ref_name }}\` |"
             echo "| Commit | \`${{ github.sha }}\` |"
             echo ""
             echo "### Per-package results"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,10 +60,15 @@ jobs:
 
       - name: Write unit-test summary
         if: always()
+        # head_ref is attacker-controlled — pass via env so the shell
+        # sees the value as a quoted parameter, not as script (Wiz SAST
+        # finding on PR #83).
         env:
           SDK_OUTCOME: ${{ steps.unit_sdk.outcome }}
           CRYPTO_OUTCOME: ${{ steps.unit_crypto.outcome }}
           CLI_OUTCOME: ${{ steps.unit_cli.outcome }}
+          GH_BRANCH: ${{ github.head_ref || github.ref_name }}
+          GH_SHA: ${{ github.sha }}
         run: |
           strip_ansi() { sed -E $'s/\x1b\\[[0-9;]*[a-zA-Z]//g'; }
           icon() {
@@ -153,8 +158,8 @@ jobs:
             echo ""
             echo "| Field | Value |"
             echo "|---|---|"
-            echo "| Branch | \`${{ github.head_ref || github.ref_name }}\` |"
-            echo "| Commit | \`${{ github.sha }}\` |"
+            echo "| Branch | \`${GH_BRANCH}\` |"
+            echo "| Commit | \`${GH_SHA}\` |"
             echo ""
             echo "### Per-package results"
             echo ""

--- a/packages/sdk/__integration__/_helpers.ts
+++ b/packages/sdk/__integration__/_helpers.ts
@@ -114,3 +114,89 @@ export function formatMs(ms: number): string {
   if (ms < 1000) return `${ms.toFixed(0)}ms`;
   return `${(ms / 1000).toFixed(2)}s`;
 }
+
+/**
+ * Statistical summary of a latency sample, in milliseconds. All percentiles
+ * use the nearest-rank method (no interpolation) — same as `quantile()` above
+ * so values cross-check against the raw sample log cleanly.
+ */
+export interface LatencyStats {
+  count: number;
+  min_ms: number;
+  p50_ms: number;
+  mean_ms: number;
+  p95_ms: number;
+  p99_ms: number;
+  max_ms: number;
+}
+
+export function statsOf(samples: number[]): LatencyStats {
+  if (samples.length === 0) {
+    return { count: 0, min_ms: 0, p50_ms: 0, mean_ms: 0, p95_ms: 0, p99_ms: 0, max_ms: 0 };
+  }
+  const sorted = [...samples].sort((a, b) => a - b);
+  return {
+    count: sorted.length,
+    min_ms: Math.round(sorted[0]),
+    p50_ms: Math.round(p50(sorted)),
+    mean_ms: Math.round(mean(sorted)),
+    p95_ms: Math.round(p95(sorted)),
+    p99_ms: Math.round(p99(sorted)),
+    max_ms: Math.round(sorted[sorted.length - 1]),
+  };
+}
+
+/**
+ * Per-suite perf stats written to `/tmp/perf-stats-{label}.json` at the end
+ * of each ephemeral suite. The integration workflow's summary step globs
+ * these files and renders one table row per file in the Step Summary, so
+ * a single CI run lists every suite's latency distribution side by side.
+ *
+ * `accessMs` is always present; `uploadMs` is null for read-only suites
+ * (e.g. 100w-shared, 1000w-perf). `refund` is null for suites that don't
+ * sweep wallets (none today, but reserved).
+ */
+export interface PerfStatsFile {
+  label: string;
+  network: string;
+  wallets: number;
+  fulfilled: number;
+  failed: number;
+  wall_clock_ms: number;
+  accessMs: LatencyStats | null;
+  uploadMs: LatencyStats | null;
+  tickMs: LatencyStats | null;
+  refund: {
+    funded_wei: string;
+    refunded_wei: string;
+    burned_wei: string;
+    failed_sweeps: number;
+  } | null;
+  /** Optional: stress-style derived counters that don't fit the per-wallet model. */
+  extra: Record<string, number | string> | null;
+}
+
+/**
+ * Persist a perf-stats summary to disk for the workflow to pick up.
+ *
+ * Writes synchronously with `fs.writeFileSync` — the test typically calls
+ * this from `afterAll`, where async I/O is fine but `writeFileSync` is
+ * simpler and matches the existing `/tmp/cdr-stress.log` pattern. Failing
+ * to write is logged but never thrown (a write failure shouldn't fail
+ * the actual test).
+ */
+export function writePerfStats(file: PerfStatsFile): void {
+  // `fs` is intentionally imported lazily so this module stays browser-
+  // safe (the unit tests under packages/sdk/src/__tests__ run in jsdom).
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const fs = require("node:fs") as typeof import("node:fs");
+  const path = `/tmp/perf-stats-${file.label}.json`;
+  try {
+    fs.writeFileSync(path, JSON.stringify(file, null, 2));
+    // eslint-disable-next-line no-console
+    console.log(`[perf-stats] wrote ${path}`);
+  } catch (e) {
+    // eslint-disable-next-line no-console
+    console.warn(`[perf-stats] failed to write ${path}: ${(e as Error).message}`);
+  }
+}

--- a/packages/sdk/__integration__/ephemeral-1000w-perf.test.ts
+++ b/packages/sdk/__integration__/ephemeral-1000w-perf.test.ts
@@ -53,6 +53,8 @@ import {
   p50,
   p95,
   p99,
+  statsOf,
+  writePerfStats,
 } from "./_helpers.js";
 
 const WALLET_COUNT = 1000;
@@ -165,6 +167,12 @@ describe.skipIf(skipUnlessSuite("1000-wallet-performance"))(
     let sharedDataKey: Uint8Array;
     let wallets: EphemeralWallet[];
     let totalFundedWei = 0n;
+    let perfBuffer: {
+      fulfilled: number;
+      failed: number;
+      wallClockMs: number;
+      accessLats: number[];
+    } | null = null;
 
     beforeAll(async () => {
       await initWasm();
@@ -227,6 +235,26 @@ describe.skipIf(skipUnlessSuite("1000-wallet-performance"))(
         failedRefunds: refund.failedRefunds,
         refundElapsedMs: formatMs(Date.now() - refundStart),
       });
+      if (perfBuffer) {
+        writePerfStats({
+          label: "1000w-perf",
+          network: NETWORK,
+          wallets: WALLET_COUNT,
+          fulfilled: perfBuffer.fulfilled,
+          failed: perfBuffer.failed,
+          wall_clock_ms: perfBuffer.wallClockMs,
+          accessMs: statsOf(perfBuffer.accessLats),
+          uploadMs: null,
+          tickMs: null,
+          refund: {
+            funded_wei: totalFundedWei.toString(),
+            refunded_wei: refund.totalRefundedWei.toString(),
+            burned_wei: (totalFundedWei - refund.totalRefundedWei).toString(),
+            failed_sweeps: refund.failedRefunds,
+          },
+          extra: null,
+        });
+      }
     }, 15 * 60 * 1000);
 
     it(
@@ -290,6 +318,12 @@ describe.skipIf(skipUnlessSuite("1000-wallet-performance"))(
           },
           failedReasonsSample: failed.slice(0, 5),
         });
+        perfBuffer = {
+          fulfilled: fulfilled.length,
+          failed: failed.length,
+          wallClockMs: totalMs,
+          accessLats: lats,
+        };
 
         expect(failed.length, `${failed.length} wallets failed accessCDR`).toBe(0);
         expect(fulfilled.length).toBe(WALLET_COUNT);

--- a/packages/sdk/__integration__/ephemeral-100w-fresh.test.ts
+++ b/packages/sdk/__integration__/ephemeral-100w-fresh.test.ts
@@ -46,7 +46,7 @@ import {
   generateEphemeralWallets,
   refundWallets,
 } from "./_ephemeral-wallets.js";
-import { formatMs, logCase, mean, p50, p95 } from "./_helpers.js";
+import { formatMs, logCase, mean, p50, p95, statsOf, writePerfStats } from "./_helpers.js";
 
 const WALLET_COUNT = 100;
 const PER_WALLET_FUND = parseEther("0.1");
@@ -126,6 +126,14 @@ describe.skipIf(skipUnlessSuite("default"))(
     let funderAddress: `0x${string}`;
     let openCondition: `0x${string}`;
     let wallets: EphemeralWallet[];
+    let totalFundedWei = 0n;
+    let perfBuffer: {
+      fulfilled: number;
+      failed: number;
+      wallClockMs: number;
+      uploadLats: number[];
+      accessLats: number[];
+    } | null = null;
 
     beforeAll(async () => {
       await initWasm();
@@ -144,6 +152,7 @@ describe.skipIf(skipUnlessSuite("default"))(
         wallets,
         PER_WALLET_FUND,
       );
+      totalFundedWei = fund.totalFundedWei;
       logCase("multicall3 batch fund", {
         multicall3: fund.multicall3Address,
         wallets: wallets.length,
@@ -165,6 +174,26 @@ describe.skipIf(skipUnlessSuite("default"))(
         totalRefundedWei: refund.totalRefundedWei.toString(),
         failedRefunds: refund.failedRefunds,
       });
+      if (perfBuffer) {
+        writePerfStats({
+          label: "100w-fresh",
+          network: NETWORK,
+          wallets: WALLET_COUNT,
+          fulfilled: perfBuffer.fulfilled,
+          failed: perfBuffer.failed,
+          wall_clock_ms: perfBuffer.wallClockMs,
+          accessMs: statsOf(perfBuffer.accessLats),
+          uploadMs: statsOf(perfBuffer.uploadLats),
+          tickMs: null,
+          refund: {
+            funded_wei: totalFundedWei.toString(),
+            refunded_wei: refund.totalRefundedWei.toString(),
+            burned_wei: (totalFundedWei - refund.totalRefundedWei).toString(),
+            failed_sweeps: refund.failedRefunds,
+          },
+          extra: null,
+        });
+      }
     }, 5 * 60 * 1000);
 
     it(
@@ -246,6 +275,13 @@ describe.skipIf(skipUnlessSuite("default"))(
           },
           failedReasons: failed.slice(0, 5),
         });
+        perfBuffer = {
+          fulfilled: fulfilled.length,
+          failed: failed.length,
+          wallClockMs: totalMs,
+          uploadLats,
+          accessLats,
+        };
 
         expect(failed.length, `${failed.length} wallets failed`).toBe(0);
         expect(fulfilled.length).toBe(WALLET_COUNT);

--- a/packages/sdk/__integration__/ephemeral-100w-shared.test.ts
+++ b/packages/sdk/__integration__/ephemeral-100w-shared.test.ts
@@ -54,7 +54,7 @@ import {
   generateEphemeralWallets,
   refundWallets,
 } from "./_ephemeral-wallets.js";
-import { formatMs, logCase, mean, p50, p95 } from "./_helpers.js";
+import { formatMs, logCase, mean, p50, p95, statsOf, writePerfStats } from "./_helpers.js";
 
 const WALLET_COUNT = 100;
 const PER_WALLET_FUND = parseEther("0.05");
@@ -143,6 +143,18 @@ describe.skipIf(skipUnlessSuite("default"))(
     let sharedVaultUuid: number;
     let sharedDataKey: Uint8Array;
     let wallets: EphemeralWallet[];
+    let totalFundedWei = 0n;
+    // Captured by `it`, written to /tmp/perf-stats-100w-shared.json by
+    // `afterAll` (so the workflow can render a perf table). null until
+    // the workload completes; afterAll skips the write when it's null
+    // (e.g. when `it` is skipped or the suite errored before reaching
+    // the workload).
+    let perfBuffer: {
+      fulfilled: number;
+      failed: number;
+      wallClockMs: number;
+      accessLats: number[];
+    } | null = null;
 
     beforeAll(async () => {
       await initWasm();
@@ -177,6 +189,7 @@ describe.skipIf(skipUnlessSuite("default"))(
         wallets,
         PER_WALLET_FUND,
       );
+      totalFundedWei = fund.totalFundedWei;
       logCase("multicall3 batch fund", {
         multicall3: fund.multicall3Address,
         wallets: wallets.length,
@@ -198,6 +211,26 @@ describe.skipIf(skipUnlessSuite("default"))(
         totalRefundedWei: refund.totalRefundedWei.toString(),
         failedRefunds: refund.failedRefunds,
       });
+      if (perfBuffer) {
+        writePerfStats({
+          label: "100w-shared",
+          network: NETWORK,
+          wallets: WALLET_COUNT,
+          fulfilled: perfBuffer.fulfilled,
+          failed: perfBuffer.failed,
+          wall_clock_ms: perfBuffer.wallClockMs,
+          accessMs: statsOf(perfBuffer.accessLats),
+          uploadMs: null,
+          tickMs: null,
+          refund: {
+            funded_wei: totalFundedWei.toString(),
+            refunded_wei: refund.totalRefundedWei.toString(),
+            burned_wei: (totalFundedWei - refund.totalRefundedWei).toString(),
+            failed_sweeps: refund.failedRefunds,
+          },
+          extra: null,
+        });
+      }
     }, 5 * 60 * 1000);
 
     it(
@@ -249,6 +282,12 @@ describe.skipIf(skipUnlessSuite("default"))(
           },
           failedReasons: failed.slice(0, 5),
         });
+        perfBuffer = {
+          fulfilled: fulfilled.length,
+          failed: failed.length,
+          wallClockMs: totalMs,
+          accessLats: lats,
+        };
 
         expect(failed.length, `${failed.length} wallets failed accessCDR`).toBe(0);
         expect(fulfilled.length).toBe(WALLET_COUNT);

--- a/packages/sdk/__integration__/ephemeral-60min-stress.test.ts
+++ b/packages/sdk/__integration__/ephemeral-60min-stress.test.ts
@@ -1,40 +1,46 @@
 /**
- * 60-minute combined-load stress test against a live CDR DevNet.
+ * 60-minute pipelined-load stress test against a live CDR DevNet.
  *
  * Suite gating: `1H-stress-devnet-only` (and `all`). **DevNet only** —
  * the workflow's prepare-step hard-rejects this suite when network !=
  * devnet (the 60-min stress depends on anvil-0 as funder).
  *
- * Pattern (1 hour total, 10s tick):
- *   1. Funder deploys an open-condition contract + uploads 1 shared
- *      CDR vault with a random dataKey.
+ * Pattern (1 hour total, **no artificial pacing**):
+ *   1. Funder deploys an open-condition contract + uploads 1 shared CDR
+ *      vault with a random dataKey.
  *   2. 10 ephemeral wallets, Multicall3 batch-funded with 1000 IP each
- *      (PER_WALLET_FUND deliberately oversized — the wallets must survive
- *      ~360 ticks × 2 ops each, plus avoid hitting the mempool reserve
- *      after a failed tick).
- *   3. Every TICK_INTERVAL_MS, all 10 wallets concurrently run a
- *      SEQUENTIAL flow: uploadCDR (own fresh vault, fresh dataKey) →
- *      accessCDR (shared vault). Per-wallet sequential keeps the wallet's
- *      nonce stream monotonic; cross-wallet parallel exercises 10-way
- *      concurrent load.
- *   4. Strict failure: any wallet's upload throws OR any access recovers
- *      a mismatched dataKey → the tick fails. allSettled lets every
- *      wallet attempt to finish so all failures surface in the log
- *      before we throw.
- *   5. Refund all wallets via refundWallets helper.
+ *      (deliberately oversized — pipeline mode does hundreds of cycles
+ *      per wallet over the hour).
+ *   3. **Pipeline mode:** each wallet runs an independent async loop —
+ *      `while (elapsed < 60min) { uploadCDR(fresh vault); accessCDR(shared); }` —
+ *      with no sleep between cycles. 10 wallet loops in parallel via
+ *      `Promise.all`. The chain + DKG path see steady back-to-back load.
+ *   4. **Soft failures:** a single cycle that throws (or recovers a
+ *      mismatched dataKey on the shared vault) is recorded in a failure
+ *      counter, but does NOT abort the wallet — the loop moves on to the
+ *      next cycle. This matches what stress is for: surface failure
+ *      rates under load, not assert zero failures.
+ *   5. Final assertion: at least some cycles completed (smoke check).
+ *      The real signal is the perf-stats JSON output: upload + access
+ *      latency distribution, total cycles, failure ratio.
  *
- * Why this combines (5) + (6):
- *   `ephemeral-100w-shared` exercises shared-vault reads at scale, and
- *   `ephemeral-100w-fresh` exercises fresh-vault writes at scale. Neither
- *   stays "warm" for an hour. This test runs both shapes interleaved in
- *   the same wallet flow, so cross-flow contention (e.g. the validator's
- *   partial-collection path competing with chain ingestion of new vault
- *   txs) is what we measure.
+ * Why pipeline (vs the old 10s-tick model):
+ *   The previous version slept up to 10s between batches to maintain a
+ *   fixed cadence. That capped throughput artificially — the chain
+ *   often finished a batch in 6-8s and then idled the rest of the tick.
+ *   For a stress test that's the wrong shape; we want sustained pressure,
+ *   not a chopped sawtooth.
  *
- * Real-time log: every event is appended to `/tmp/cdr-stress.log` so you
- * can `tail -f` from another terminal — vitest buffers test-internal
- * stdout, but `fs.appendFileSync` is unaffected. The integration workflow
- * uploads this file as a 14-day artifact (`cdr-stress-log-<run_id>`).
+ * Real-time log: every cycle event is appended to `/tmp/cdr-stress.log`
+ * so you can `tail -f` from another terminal — vitest buffers test-
+ * internal stdout, but `fs.appendFileSync` is unaffected. The
+ * integration workflow uploads this file as a 14-day artifact
+ * (`cdr-stress-log-<run_id>`).
+ *
+ * Perf-stats JSON: `/tmp/perf-stats-stress.json` is written in afterAll
+ * with the `PerfStatsFile` shape (uploadMs, accessMs, refund summary,
+ * extra.total_cycles / extra.failed_cycles), so the workflow's summary
+ * step renders the same per-suite perf row as the 100w/1000w suites.
  *
  * Run locally (DevNet only):
  *   pnpm test:stress
@@ -58,25 +64,28 @@ import {
 } from "viem";
 import { privateKeyToAccount } from "viem/accounts";
 import { CDRClient, initWasm } from "../src/index.js";
-import { skipUnlessDevnet, skipUnlessSuite } from "./_suite.js";
+import { NETWORK, skipUnlessDevnet, skipUnlessSuite } from "./_suite.js";
 import {
   type EphemeralWallet,
   fundWallets,
   generateEphemeralWallets,
   refundWallets,
 } from "./_ephemeral-wallets.js";
-import { formatMs, mean, p50, p95, p99 } from "./_helpers.js";
+import { statsOf, writePerfStats } from "./_helpers.js";
 
 const DURATION_MS = 60 * 60 * 1000; // 1 hour
-const TICK_INTERVAL_MS = 10 * 1000; // 10 s
 const CONCURRENCY = 10;
 const PER_WALLET_FUND = parseEther("1000");
 // Generous reserve absorbs any pending-tx mempool cost when refund runs
-// right after a failed tick. Loses ~10 IP across 10 wallets — DevNet
+// right after the last cycle. Loses ~10 IP across 10 wallets — DevNet
 // anvil-0 has unlimited dev IP, so trading a little waste for refund
 // reliability is fine.
 const REFUND_GAS_RESERVE = parseEther("1");
 const LOG_FILE = "/tmp/cdr-stress.log";
+// Per-wallet accessCDR timeout. The shared vault read should normally
+// finish in ~10-30s on DevNet; 120s is a generous ceiling so a single
+// slow validator doesn't immediately count as a failed cycle.
+const ACCESS_TIMEOUT_MS = 120_000;
 
 const API_URL = process.env.CDR_API_URL;
 const RPC_URL = process.env.CDR_RPC_URL;
@@ -174,7 +183,7 @@ function logLine(line: string): void {
 }
 
 describe.skipIf(skipUnlessSuite("1H-stress-devnet-only") || skipUnlessDevnet())(
-  `60-min stress: ${CONCURRENCY} wallets upload+access loop on DevNet`,
+  `60-min pipelined stress: ${CONCURRENCY} wallets upload+access loop on DevNet`,
   () => {
     let funderPublic: PublicClient;
     let funderWallet: WalletClient;
@@ -184,6 +193,18 @@ describe.skipIf(skipUnlessSuite("1H-stress-devnet-only") || skipUnlessDevnet())(
     let sharedVaultUuid: number;
     let sharedDataKey: Uint8Array;
     let stressWallets: StressWallet[] = [];
+    let totalFundedWei = 0n;
+    // Populated by `it`, consumed by `afterAll` to emit the perf-stats
+    // JSON. `null` until the workload completes; afterAll skips the write
+    // when this is `null` (e.g. when `it` is skipped or beforeAll errored
+    // before reaching the workload).
+    let perfBuffer: {
+      uploadLats: number[];
+      accessLats: number[];
+      totalCycles: number;
+      failedCycles: number;
+      wallClockMs: number;
+    } | null = null;
 
     beforeAll(async () => {
       fs.writeFileSync(LOG_FILE, "");
@@ -213,7 +234,9 @@ describe.skipIf(skipUnlessSuite("1H-stress-devnet-only") || skipUnlessDevnet())(
         accessAuxData: "0x",
       });
       sharedVaultUuid = upload.uuid;
-      logLine(`[suite-setup] shared vault uuid=${sharedVaultUuid} (owned by funder)`);
+      logLine(
+        `[suite-setup] shared vault uuid=${sharedVaultUuid} (owned by funder)`,
+      );
 
       const ephs = generateEphemeralWallets(CONCURRENCY);
       const fund = await fundWallets(
@@ -222,6 +245,7 @@ describe.skipIf(skipUnlessSuite("1H-stress-devnet-only") || skipUnlessDevnet())(
         ephs,
         PER_WALLET_FUND,
       );
+      totalFundedWei = fund.totalFundedWei;
       stressWallets = ephs.map(makeStressWallet);
       logLine(
         `[suite-setup] funded ${stressWallets.length} wallets via Multicall3 ` +
@@ -233,7 +257,7 @@ describe.skipIf(skipUnlessSuite("1H-stress-devnet-only") || skipUnlessDevnet())(
       if (stressWallets.length === 0) return;
 
       // Wait up to 60s per wallet for any pending tx left over from a
-      // failed tick to settle, otherwise refund underflows when the
+      // failed cycle to settle, otherwise refund underflows when the
       // mempool reserves the pending tx's cost from balance.
       logLine(`[suite-teardown] waiting for any pending txs to settle...`);
       await Promise.all(
@@ -269,100 +293,163 @@ describe.skipIf(skipUnlessSuite("1H-stress-devnet-only") || skipUnlessDevnet())(
         `[suite-teardown] refund total=${formatEther(refund.totalRefundedWei)} IP ` +
           `failed=${refund.failedRefunds}/${stressWallets.length}`,
       );
+
+      if (perfBuffer) {
+        writePerfStats({
+          label: "stress",
+          network: NETWORK,
+          wallets: CONCURRENCY,
+          fulfilled: perfBuffer.totalCycles,
+          failed: perfBuffer.failedCycles,
+          wall_clock_ms: perfBuffer.wallClockMs,
+          uploadMs: statsOf(perfBuffer.uploadLats),
+          accessMs: statsOf(perfBuffer.accessLats),
+          tickMs: null,
+          refund: {
+            funded_wei: totalFundedWei.toString(),
+            refunded_wei: refund.totalRefundedWei.toString(),
+            burned_wei: (totalFundedWei - refund.totalRefundedWei).toString(),
+            failed_sweeps: refund.failedRefunds,
+          },
+          extra: {
+            duration_minutes: Math.round(perfBuffer.wallClockMs / 60_000),
+            total_cycles: perfBuffer.totalCycles,
+            failed_cycles: perfBuffer.failedCycles,
+            failure_rate_pct: (
+              (perfBuffer.failedCycles /
+                Math.max(1, perfBuffer.totalCycles + perfBuffer.failedCycles)) *
+              100
+            ).toFixed(2),
+          },
+        });
+      }
     }, 10 * 60 * 1000);
 
     it(
-      `${CONCURRENCY} wallets concurrent upload + concurrent shared-access, ${TICK_INTERVAL_MS / 1000}s tick, 1h`,
+      `${CONCURRENCY} wallets pipeline upload+access for 1h, no inter-cycle delay`,
       async () => {
         const startTime = Date.now();
-        const tickLatencies: number[] = [];
-        let tick = 0;
+        const uploadLats: number[] = [];
+        const accessLats: number[] = [];
+        let totalCycles = 0;
+        let failedCycles = 0;
 
-        while (Date.now() - startTime < DURATION_MS) {
-          tick++;
-          const tickStart = Date.now();
-
-          const results = await Promise.allSettled(
-            stressWallets.map(async (w, idx) => {
-              // ----- UPLOAD (own fresh vault) -----
-              const dataKey = crypto.getRandomValues(new Uint8Array(32));
-              const globalPubKey = await w.client.observer.getGlobalPubKey();
-              const t0 = Date.now();
-              const upload = await w.client.uploader.uploadCDR({
-                dataKey,
-                globalPubKey,
-                updatable: false,
-                writeConditionAddr: openCondition,
-                readConditionAddr: openCondition,
-                writeConditionData: "0x",
-                readConditionData: "0x",
-                accessAuxData: "0x",
-              });
-              const uploadDur = Date.now() - t0;
-              logLine(
-                `[tick=${tick} w[${idx}] UPLOAD ok] uuid=${upload.uuid} ${uploadDur}ms`,
-              );
-
-              // ----- ACCESS shared vault -----
-              const t1 = Date.now();
-              const access = await w.client.consumer.accessCDR({
-                uuid: sharedVaultUuid,
-                accessAuxData: "0x",
-                timeoutMs: 120_000,
-              });
-              const accessDur = Date.now() - t1;
-              const ok = bytesEqual(access.dataKey, sharedDataKey);
-              logLine(
-                `[tick=${tick} w[${idx}] ACCESS ${ok ? "ok" : "MISMATCH"}] uuid=${sharedVaultUuid} tx=${access.txHash} ${accessDur}ms`,
-              );
-              if (!ok) {
-                throw new Error(
-                  `tick=${tick} w[${idx}] dataKey mismatch on shared uuid=${sharedVaultUuid}`,
+        // Each wallet's loop is independent — Promise.all runs all 10 in
+        // parallel. Within a wallet the cycle is sequential (upload then
+        // access) so the wallet's nonce stream stays monotonic; across
+        // wallets there's no synchronization (no tick boundary).
+        await Promise.all(
+          stressWallets.map(async (w, idx) => {
+            let cycleIdx = 0;
+            while (Date.now() - startTime < DURATION_MS) {
+              cycleIdx++;
+              try {
+                // ----- UPLOAD (own fresh vault) -----
+                const dataKey = crypto.getRandomValues(new Uint8Array(32));
+                const globalPubKey = await w.client.observer.getGlobalPubKey();
+                const tUpload = Date.now();
+                const upload = await w.client.uploader.uploadCDR({
+                  dataKey,
+                  globalPubKey,
+                  updatable: false,
+                  writeConditionAddr: openCondition,
+                  readConditionAddr: openCondition,
+                  writeConditionData: "0x",
+                  readConditionData: "0x",
+                  accessAuxData: "0x",
+                });
+                const uploadDur = Date.now() - tUpload;
+                uploadLats.push(uploadDur);
+                logLine(
+                  `[w[${idx}] cycle=${cycleIdx} UPLOAD ok] uuid=${upload.uuid} ${uploadDur}ms`,
                 );
+
+                // ----- ACCESS shared vault -----
+                const tAccess = Date.now();
+                const access = await w.client.consumer.accessCDR({
+                  uuid: sharedVaultUuid,
+                  accessAuxData: "0x",
+                  timeoutMs: ACCESS_TIMEOUT_MS,
+                });
+                const accessDur = Date.now() - tAccess;
+                accessLats.push(accessDur);
+                const ok = bytesEqual(access.dataKey, sharedDataKey);
+                logLine(
+                  `[w[${idx}] cycle=${cycleIdx} ACCESS ${ok ? "ok" : "MISMATCH"}] uuid=${sharedVaultUuid} tx=${access.txHash} ${accessDur}ms`,
+                );
+                if (!ok) {
+                  throw new Error(
+                    `w[${idx}] cycle=${cycleIdx} dataKey mismatch on shared uuid=${sharedVaultUuid}`,
+                  );
+                }
+                totalCycles++;
+              } catch (e) {
+                failedCycles++;
+                const msg = e instanceof Error ? e.message : String(e);
+                logLine(
+                  `[w[${idx}] cycle=${cycleIdx} FAILED] ${msg.slice(0, 240)}`,
+                );
+                // Continue to next cycle — stress measures failure rate,
+                // not absence of failures.
               }
-            }),
-          );
-
-          const failures = results.flatMap((r, idx) =>
-            r.status === "rejected" ? [{ idx, reason: r.reason }] : [],
-          );
-          if (failures.length > 0) {
-            for (const fail of failures) {
-              const msg =
-                fail.reason instanceof Error
-                  ? fail.reason.message
-                  : String(fail.reason);
-              logLine(`[tick=${tick} w[${fail.idx}] FAILED] ${msg}`);
             }
-            throw new Error(
-              `tick=${tick}: ${failures.length}/${CONCURRENCY} wallets failed`,
-            );
-          }
-
-          const tickDur = Date.now() - tickStart;
-          tickLatencies.push(tickDur);
-          const elapsedMin = ((Date.now() - startTime) / 60_000).toFixed(1);
-          const nextTickTarget = startTime + tick * TICK_INTERVAL_MS;
-          const sleepFor = nextTickTarget - Date.now();
-          logLine(
-            `[stress tick=${tick}] batch=${tickDur}ms elapsed=${elapsedMin}min ${
-              sleepFor > 0 ? `sleep=${sleepFor}ms` : `late=${-sleepFor}ms`
-            }`,
-          );
-          if (sleepFor > 0) await sleep(sleepFor);
-        }
-
-        const opsTotal = tick * CONCURRENCY * 2; // upload + access per wallet per tick
-        logLine(
-          `[stress summary] ticks=${tick} duration_min=${((Date.now() - startTime) / 60_000).toFixed(1)} ` +
-            `ops_total=${opsTotal} ` +
-            `tick_p50=${formatMs(p50(tickLatencies))} ` +
-            `tick_p95=${formatMs(p95(tickLatencies))} ` +
-            `tick_p99=${formatMs(p99(tickLatencies))} ` +
-            `tick_mean=${formatMs(Math.round(mean(tickLatencies)))} ` +
-            `tick_max=${formatMs(Math.max(...tickLatencies))}`,
+            logLine(`[w[${idx}] done] cycles_attempted=${cycleIdx}`);
+          }),
         );
-        expect(tick).toBeGreaterThan(0);
+
+        const wallClockMs = Date.now() - startTime;
+        const stats = {
+          duration_min: (wallClockMs / 60_000).toFixed(1),
+          total_cycles: totalCycles,
+          failed_cycles: failedCycles,
+          failure_rate_pct: (
+            (failedCycles / Math.max(1, totalCycles + failedCycles)) *
+            100
+          ).toFixed(2),
+          upload: {
+            count: uploadLats.length,
+            p50_ms: Math.round(
+              [...uploadLats].sort((a, b) => a - b)[
+                Math.floor(uploadLats.length * 0.5)
+              ] ?? 0,
+            ),
+            p95_ms: Math.round(
+              [...uploadLats].sort((a, b) => a - b)[
+                Math.floor(uploadLats.length * 0.95)
+              ] ?? 0,
+            ),
+            max_ms: uploadLats.length > 0 ? Math.max(...uploadLats) : 0,
+          },
+          access: {
+            count: accessLats.length,
+            p50_ms: Math.round(
+              [...accessLats].sort((a, b) => a - b)[
+                Math.floor(accessLats.length * 0.5)
+              ] ?? 0,
+            ),
+            p95_ms: Math.round(
+              [...accessLats].sort((a, b) => a - b)[
+                Math.floor(accessLats.length * 0.95)
+              ] ?? 0,
+            ),
+            max_ms: accessLats.length > 0 ? Math.max(...accessLats) : 0,
+          },
+        };
+        logLine(`[stress summary] ${JSON.stringify(stats)}`);
+        perfBuffer = {
+          uploadLats,
+          accessLats,
+          totalCycles,
+          failedCycles,
+          wallClockMs,
+        };
+
+        // Smoke check only — stress doesn't assert zero failures. The
+        // signal is in the perf-stats JSON.
+        expect(
+          totalCycles + failedCycles,
+          "stress test finished with zero cycle attempts — wallets didn't even reach the first try",
+        ).toBeGreaterThan(0);
       },
       DURATION_MS + 15 * 60 * 1000,
     );

--- a/packages/sdk/__integration__/ephemeral-60min-stress.test.ts
+++ b/packages/sdk/__integration__/ephemeral-60min-stress.test.ts
@@ -359,7 +359,6 @@ describe.skipIf(skipUnlessSuite("1H-stress-devnet-only") || skipUnlessDevnet())(
                   accessAuxData: "0x",
                 });
                 const uploadDur = Date.now() - tUpload;
-                uploadLats.push(uploadDur);
                 logLine(
                   `[w[${idx}] cycle=${cycleIdx} UPLOAD ok] uuid=${upload.uuid} ${uploadDur}ms`,
                 );
@@ -372,7 +371,6 @@ describe.skipIf(skipUnlessSuite("1H-stress-devnet-only") || skipUnlessDevnet())(
                   timeoutMs: ACCESS_TIMEOUT_MS,
                 });
                 const accessDur = Date.now() - tAccess;
-                accessLats.push(accessDur);
                 const ok = bytesEqual(access.dataKey, sharedDataKey);
                 logLine(
                   `[w[${idx}] cycle=${cycleIdx} ACCESS ${ok ? "ok" : "MISMATCH"}] uuid=${sharedVaultUuid} tx=${access.txHash} ${accessDur}ms`,
@@ -382,6 +380,13 @@ describe.skipIf(skipUnlessSuite("1H-stress-devnet-only") || skipUnlessDevnet())(
                     `w[${idx}] cycle=${cycleIdx} dataKey mismatch on shared uuid=${sharedVaultUuid}`,
                   );
                 }
+                // Push BOTH latencies together — only when the full cycle
+                // succeeded end-to-end. Pushing uploadDur eagerly above
+                // would let partially-failed cycles' upload times bias
+                // the upload p50/p95, decoupling the two arrays from
+                // `totalCycles`. Reviewer caught this on PR #83.
+                uploadLats.push(uploadDur);
+                accessLats.push(accessDur);
                 totalCycles++;
               } catch (e) {
                 failedCycles++;
@@ -398,6 +403,12 @@ describe.skipIf(skipUnlessSuite("1H-stress-devnet-only") || skipUnlessDevnet())(
         );
 
         const wallClockMs = Date.now() - startTime;
+        // Use `statsOf` — same nearest-rank quantile method `writePerfStats`
+        // uses in afterAll, so the numbers in this log line match the
+        // numbers in /tmp/perf-stats-stress.json exactly. The previous
+        // inline math used floor-based indexing and produced slightly
+        // different p50/p95 from the JSON — reviewer caught the
+        // inconsistency on PR #83.
         const stats = {
           duration_min: (wallClockMs / 60_000).toFixed(1),
           total_cycles: totalCycles,
@@ -406,34 +417,8 @@ describe.skipIf(skipUnlessSuite("1H-stress-devnet-only") || skipUnlessDevnet())(
             (failedCycles / Math.max(1, totalCycles + failedCycles)) *
             100
           ).toFixed(2),
-          upload: {
-            count: uploadLats.length,
-            p50_ms: Math.round(
-              [...uploadLats].sort((a, b) => a - b)[
-                Math.floor(uploadLats.length * 0.5)
-              ] ?? 0,
-            ),
-            p95_ms: Math.round(
-              [...uploadLats].sort((a, b) => a - b)[
-                Math.floor(uploadLats.length * 0.95)
-              ] ?? 0,
-            ),
-            max_ms: uploadLats.length > 0 ? Math.max(...uploadLats) : 0,
-          },
-          access: {
-            count: accessLats.length,
-            p50_ms: Math.round(
-              [...accessLats].sort((a, b) => a - b)[
-                Math.floor(accessLats.length * 0.5)
-              ] ?? 0,
-            ),
-            p95_ms: Math.round(
-              [...accessLats].sort((a, b) => a - b)[
-                Math.floor(accessLats.length * 0.95)
-              ] ?? 0,
-            ),
-            max_ms: accessLats.length > 0 ? Math.max(...accessLats) : 0,
-          },
+          upload: statsOf(uploadLats),
+          access: statsOf(accessLats),
         };
         logLine(`[stress summary] ${JSON.stringify(stats)}`);
         perfBuffer = {

--- a/packages/sdk/__integration__/security.test.ts
+++ b/packages/sdk/__integration__/security.test.ts
@@ -7,7 +7,6 @@
  *
  *   SEC-01 (#17) WASM binary hash verified at initWasm()
  *   SEC-02 (#18) cdr-crypto deps use exact-version pinning
- *   SEC-03 (#19) validationRpcUrls cross-validates getGlobalPubKey
  *   SEC-04 (#20) minThresholdRatio raises SDK-side threshold
  *   SEC-05 (#21) Consumer.downloadFile method surface exists
  *   SEC-06 (#22) allocate validates condition contract interface
@@ -15,6 +14,12 @@
  *   SEC-08 (#24) SGX DCAP Quote v3 parse + verify (positive + negative
  *                + on-chain attestation reports)
  *   SEC-09 (#25) write() validates ciphertext-embedded label vs uuid
+ *
+ * SEC-03 (#19, multi-RPC validationRpcUrls) was previously kept as an
+ * `it.skip` placeholder. The current CDRClient constructor doesn't
+ * accept that knob, and the skipped stub added noise without coverage
+ * — dropped entirely. Re-add it (without `.skip`) only after the SDK
+ * grows a real multi-RPC validation hook.
  */
 
 import { readFileSync } from "node:fs";
@@ -115,15 +120,6 @@ describe(`Security tests (live: ${API_URL})`, () => {
       );
     }
   });
-
-  // SEC-03 (Issue #19) tests multi-RPC cross-validation of getGlobalPubKey.
-  // The current CDRClient constructor doesn't accept `validationRpcUrls`
-  // — that knob was on a prior API surface in story-cdr-e2e's setup.ts
-  // shim. Until the SDK re-introduces a multi-RPC validation hook this
-  // case stays skipped. The fundamental sanity-check (getGlobalPubKey
-  // returns non-empty bytes) is exercised by every test in this file
-  // via `client.observer.getGlobalPubKey()`.
-  it.skip("SEC-03: validationRpcUrls cross-validates getGlobalPubKey (Issue #19) — pending SDK API", () => {});
 
   // 30s timeout — observed ~725ms on DevNet; cushion for Aeneid + slow CI.
   it("SEC-04: minThresholdRatio raises SDK-side threshold above chain default (Issue #20)", { timeout: 30_000 }, async () => {


### PR DESCRIPTION
## Summary

Post-merge polish on the integration workflow, prompted by reviewing the first few Aeneid / 1000-wallet-performance dispatches:

- **Stress was an orphan job** — even on default/1000w runs the Jobs sidebar showed a 'stress' box stuck on skipped (⊘), confusing for anyone reading the run page. Now merged into the `integration` job as conditional steps.
- **Per-suite perf data lived in stdout only** — the 100w/1000w/stress logs printed `accessMs.{p50, p95, ...}` via `logCase()`, but the Step Summary just showed pass/fail counts. Now every ephemeral suite writes `/tmp/perf-stats-<label>.json` and the summary renders a single perf table covering every suite that ran.
- **Stress was tick-paced** — the old design slept up to 10s between batches to maintain a fixed cadence, capping throughput artificially. Rewritten as a pipeline: each wallet runs an independent loop with no inter-cycle sleep.
- **Summary order buried the headline** — pass/fail counts were per-section; failures lived inside `<details>`. Now there's a TL;DR + aggregated failures at the very top.

## What's in (4 commits)

### `feat(integration): write perf-stats JSON from ephemeral 100w/1000w suites` ([98b4659](98b4659))

New `LatencyStats` / `PerfStatsFile` types + `statsOf()` / `writePerfStats()` helpers in `_helpers.ts`. Each ephemeral suite (100w-shared, 100w-fresh, 1000w-perf) persists its per-wallet latency distribution + funding/refund accounting to `/tmp/perf-stats-<label>.json` in afterAll. Schema:

```json
{
  "label": "100w-fresh",
  "network": "aeneid",
  "wallets": 100,
  "fulfilled": 84, "failed": 16,
  "wall_clock_ms": 67520,
  "accessMs": { "count": 84, "min_ms": ..., "p50_ms": ..., "mean_ms": ..., "p95_ms": ..., "p99_ms": ..., "max_ms": ... },
  "uploadMs": { ... } | null,
  "refund": { "funded_wei": "...", "refunded_wei": "...", "burned_wei": "...", "failed_sweeps": 0 },
  "extra": { ... } | null
}
```

Skipped suites produce no file (buffer stays null until the workload runs); the workflow's render step just doesn't see them. Write failures are `console.warn`'d, never thrown.

### `refactor(stress): pipeline mode — drop 10s tick, run wallets at line rate` ([fd8d945](fd8d945))

Each wallet runs an independent async loop: `while (elapsed < 60min) { uploadCDR(fresh vault); accessCDR(shared vault); }` — back-to-back, no inter-cycle sleep. All 10 wallet loops in parallel via `Promise.all`. Within a wallet the cycle stays sequential (upload → access) so the nonce stream is monotonic; across wallets there's no synchronization.

Failure handling switched from hard-throw to soft counting: a cycle that throws is recorded in `failedCycles` but the wallet continues to the next cycle. Stress should surface failure rates under load, not abort on the first one. Final assertion is just 'we attempted at least one cycle'.

Writes `/tmp/perf-stats-stress.json` with `uploadMs` + `accessMs` + `extra: { duration_minutes, total_cycles, failed_cycles, failure_rate_pct }`.

### `ci(integration): merge stress into integration job + perf table + TL;DR summary` ([8ada984](8ada984))

Three workflow changes squashed because they all touch overlapping YAML:

1. **Merge stress into integration** as conditional steps gated on `env.RUN_STRESS == 'true'`. Dynamic `timeout-minutes`: 180 for `all`, 120 for `1H-stress-devnet-only`, 90 for `1000-wallet-performance`, 60 baseline.

2. **Render `Performance metrics` table** — globs `/tmp/perf-stats-*.json`, one row per suite with min/p50/mean/p95/p99/max + failed count + wall clock + refund. Per-suite extras (upload-side stats when distinct from access; stress cycles + failure rate) emitted as bullet lists below.

3. **Reorder Step Summary** so the headline lands first:
    ```
    ## ✅/❌ Overall — N passed | M failed | K skipped — wall Xs
    ## 🚨 Failures (only when any test failed; full inline blocks)
    ## Integration test results
    ### Chain state during run
    ### Performance metrics
    ### Per-suite results
      #### SDK / CLI / Examples / Stress (each: failures inline first,
                                           then per-case table in <details>)
    ```

    Failures appear three times — top-aggregated, inline per-suite, and (color only) in per-case tables — so they're impossible to miss whichever entry point the reader uses.

## Test plan

- [ ] PR-trigger run (`default × devnet`) — should produce a perf table covering `100w-shared` + `100w-fresh`, no stress section, Overall headline at the top.
- [ ] Manual `1000-wallet-performance × devnet` — perf table includes `1000w-perf` row.
- [ ] Manual `1H-stress-devnet-only × devnet` — only stress runs, perf table single row, `cdr-stress.log` artifact uploaded.
- [ ] Manual `all × devnet` — every row in the perf table, longest path through the workflow.
- [ ] Manual `default × aeneid` — confirm the Aeneid RPC 429 behavior surfaces correctly in the Failures block (the [aeneid.storyrpc.io rate-limit issue](https://github.com/piplabs/cdr-sdk/actions/runs/25789429673) is tracked separately with infra; this PR just makes the symptoms easier to read).