### PR TITLE
chore: add v0.2.0 release changeset

### DIFF
--- a/.changeset/v020-release-changeset.md
+++ b/.changeset/v020-release-changeset.md
@@ -1,0 +1,18 @@
+---
+"@piplabs/cdr-cli": minor
+"@piplabs/cdr-contracts": minor
+"@piplabs/cdr-crypto": minor
+"@piplabs/cdr-sdk": minor
+---
+
+**BREAKING**: SDK now uses the Story-API REST endpoint in place of the CometBFT `abci_query` path (#73). Callers configured for ABCI must switch to the REST transport — see `packages/sdk/src/story-api/transport.ts`.
+
+Other notable changes since 0.1.2:
+
+- fix(sdk): consumer no longer selects a `/dkg/cdr_partials` bucket that does not match the current vault ciphertext (#74, #75)
+- fix(sdk): consumer uses the partial bucket's round threshold instead of the active round's threshold (#76)
+- fix(sdk): `accessCDR` short-circuits on `EmptyVaultError` before sending the paid read tx (#78)
+- fix(sdk): `accessCDR` pins the in-flight ciphertext to avoid races on updatable vaults (#79)
+- fix(sdk): cross-user partial collision in evm-events mode (`aes/gcm: invalid ghash tag`) (#72)
+- fix(cli): CLI rejects malformed UUIDs and invalid timeouts instead of silently accepting them (#80)
+- ci(integration): pull_request paths filter widened to cover the workflow's actual dependency surface (#77)


### PR DESCRIPTION
## Summary
Bump `@piplabs/cdr-{cli,contracts,crypto,sdk}` from 0.1.2 → 0.2.0 to ship the REST migration breaking change plus the AI-audit bug-fix batch.

**Highlight** (also captured in `.changeset/v020-release-changeset.md`):
- **BREAKING**: SDK migrated from CometBFT `abci_query` to Story-API REST (#73). Callers configured for ABCI must switch to the REST transport.
- consumer round-bucket / threshold mismatches (#72/#74/#75/#76)
- `accessCDR` `EmptyVaultError` fast-fail + ciphertext pinning (#78/#79)
- CLI numeric arg validation (#80)
- CI paths-filter widening (#77)

## Test plan
- [x] `pnpm changeset status` confirms 4 packages will minor-bump (verified locally on this branch).
- [ ] After merge: `release.yml` `changesets` job opens "chore: release packages" PR with version 0.2.0 bumps + CHANGELOG entries.
- [ ] Merge the bot PR (do NOT rename — `publish` guard requires `chore: release packages` in commit message per `docs/RELEASING.md`).
- [ ] `npm-publish` environment reviewer (not @lucas2brh — Prevent self-review) approves Stage 2 publish.
- [ ] All 4 packages publish to npm at v0.2.0 with OIDC provenance. This will be the first successful publish (lucas2brh was upgraded from developer → admin, resolving the original v0.1.2 first-publish 404 blocker per `reference_npm_org_roles.md`).