### PR TITLE
ci(release): split release.yml into bot-sync.yml + release.yml

### DIFF
--- a/.github/workflows/bot-sync.yml
+++ b/.github/workflows/bot-sync.yml
@@ -1,0 +1,48 @@
+name: Bot Sync
+
+# Lightweight job that runs on every push to main and lets `changesets/action`
+# open / update / close the "Version Packages" PR aggregating outstanding
+# `.changeset/*.md` files.
+#
+# Deliberately NO build / test / audit steps in this workflow — those run in
+# test.yml (unit tests on every PR + main push) and release.yml (audit + dry
+# run before npm publish on release commits). Keeping bot-sync minimal means
+# a single failing CVE or broken test on main never blocks the bot from
+# maintaining the Version Packages PR — it just blocks the actual publish.
+
+on:
+  push:
+    branches: [main]
+
+concurrency: ${{ github.workflow }}-${{ github.ref }}
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write       # commit version bumps for the auto-PR
+      pull-requests: write  # open / update / close the "Version Packages" PR
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0    # full history needed for changelog generation
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Open / update / close Version Packages PR
+        uses: changesets/action@v1
+        with:
+          # Intentionally NO `publish` input. This workflow only manages the
+          # Version Packages PR. Actual npm publish is handled by release.yml,
+          # gated by the merge commit message of that PR.
+          version: pnpm changeset version
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,32 +1,40 @@
 name: Release
 
+# Publish to npm. Triggers ONLY on main pushes whose commit message contains
+# the marker string "chore: release packages" — the default title of the auto-
+# generated Version Packages PR (changesets/action input `title`, default
+# value). Ordinary chore / docs / feature / CI commits to main are filtered
+# out at the job-level `if` guard and do not consume environment approval.
+#
+# The Version Packages PR itself is opened and maintained by bot-sync.yml
+# (a separate workflow that runs on every main push). Splitting the two
+# workflows means a single failing audit / test on main never blocks the
+# bot — only the actual publish path is gated.
+
 on:
   push:
     branches: [main]
 
-# Avoid two release jobs racing on rapid main commits.
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:
-  # ---------------------------------------------------------------------------
-  # Stage 1: Version Packages PR management. Runs on every main push, no
-  # environment gate, no npm contact. If unreleased `.changeset/*.md` files
-  # exist, opens or updates a "Version Packages" PR. Otherwise no-op. This
-  # stage never publishes — chore / docs / bug-fix-without-release commits
-  # land here and exit cleanly without requesting reviewer approval.
-  # ---------------------------------------------------------------------------
-  changesets:
+  publish:
+    # The publish job is gated entirely on the commit message marker. If a
+    # maintainer manually renames the auto-PR title before merging, this
+    # guard fails closed and no publish happens — RELEASING.md documents
+    # this constraint as a load-bearing operational rule.
+    if: |
+      contains(github.event.head_commit.message, 'chore: release packages')
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 20
+    environment: npm-publish
     permissions:
-      contents: write       # commit version bumps for the auto-PR
-      pull-requests: write  # open / update the "Version Packages" PR
-    outputs:
-      hasChangesets: ${{ steps.changesets.outputs.hasChangesets }}
+      contents: write   # push git tags + create GitHub Releases
+      id-token: write   # mint OIDC token for npm provenance
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0    # full history needed for changelog generation
+          fetch-depth: 0
 
       - uses: pnpm/action-setup@v4
 
@@ -34,6 +42,7 @@ jobs:
         with:
           node-version: '20'
           cache: pnpm
+          registry-url: 'https://registry.npmjs.org'
 
       - run: pnpm install --frozen-lockfile
 
@@ -56,60 +65,6 @@ jobs:
             exit 1
           fi
           echo "No high+ severity vulnerabilities in production deps."
-
-      - run: pnpm -r run build
-
-      # Vitest unit tests across all packages that declare a `test` script.
-      # Failure aborts the release pipeline before any publish.
-      - run: pnpm -r run test
-
-      - name: Open / update Version Packages PR
-        id: changesets
-        uses: changesets/action@v1
-        with:
-          # Intentionally NO `publish` input. This stage only opens PRs;
-          # publishing is gated by the separate `publish` job below.
-          version: pnpm changeset version
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-  # ---------------------------------------------------------------------------
-  # Stage 2: Publish to npm. Runs only when:
-  #   1. The previous stage saw no unreleased changesets (hasChangesets=false),
-  #      AND
-  #   2. The merge commit message contains "chore: release packages" — the
-  #      default title of the auto-generated Version Packages PR
-  #      (changesets/action input `title`, default value).
-  # Both conditions are required so that ordinary chore / docs / fix commits
-  # to main never trigger publish, only the merge of an actual release PR
-  # does. If a maintainer manually renames the auto-PR title, this guard
-  # fails closed — RELEASING.md documents this constraint.
-  # ---------------------------------------------------------------------------
-  publish:
-    needs: changesets
-    if: |
-      needs.changesets.outputs.hasChangesets == 'false' &&
-      contains(github.event.head_commit.message, 'chore: release packages')
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-    environment: npm-publish
-    permissions:
-      contents: write   # push git tags
-      id-token: write   # mint OIDC token for npm provenance
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - uses: pnpm/action-setup@v4
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-          cache: pnpm
-          registry-url: 'https://registry.npmjs.org'
-
-      - run: pnpm install --frozen-lockfile
 
       - run: pnpm -r run build
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,27 +1,33 @@
 # Releasing @piplabs/cdr-sdk
 
-Maintainer-facing guide for cutting a new version of `@piplabs/cdr-contracts`, `@piplabs/cdr-crypto`, and `@piplabs/cdr-sdk` to the npm public registry.
+Maintainer-facing guide for cutting a new version of `@piplabs/cdr-contracts`, `@piplabs/cdr-crypto`, `@piplabs/cdr-sdk`, and `@piplabs/cdr-cli` to the npm public registry.
 
 > The release pipeline is fully automated by [Changesets](https://github.com/changesets/changesets) + [`changesets/action`](https://github.com/changesets/action), gated by a GitHub `npm-publish` environment with required reviewers. **Do not run `pnpm publish` manually.** All releases go through `main` and the gates below.
 
-## Pipeline gates
+## Pipeline architecture
 
-Every push to `main` triggers `.github/workflows/release.yml`, which runs in two stages:
+Two **independent** workflows trigger on every push to `main`. They are split so a single failure in one workflow (e.g., audit catches a new CVE) never blocks the other.
 
-**Stage 1 — `changesets` job** (always runs, no approval gate, no npm contact)
-- `pnpm install --frozen-lockfile` — reproducible install
-- `pnpm -r run build` — TypeScript compiles
-- `pnpm -r run test` — vitest unit suites pass
-- `changesets/action@v1` — opens / updates the "Version Packages" PR when unreleased changesets exist; otherwise no-op
+**`.github/workflows/bot-sync.yml` — Version Packages PR manager** (runs on every main push)
+- `pnpm install --frozen-lockfile` — minimal install (needed by `changesets/action`)
+- `changesets/action@v1` — opens / updates / closes the "Version Packages" PR depending on whether unreleased `.changeset/*.md` files exist
+- No build, no test, no audit. Cannot publish (no `publish` input passed to the action).
 
-**Stage 2 — `publish` job** (runs only on actual release commits)
-- Conditional `if`: `hasChangesets == 'false' && contains(commit message, 'chore: release packages')`
-- `environment: npm-publish` — required reviewer must click **Approve and deploy** before any step runs
-- `pnpm install --frozen-lockfile` + `pnpm -r run build` + `pnpm changeset publish` (with OIDC provenance)
+**`.github/workflows/release.yml` — npm publish** (runs only on release commits)
+- Job-level guard: `if: contains(github.event.head_commit.message, 'chore: release packages')`. Any main push whose merge commit message lacks this marker is skipped before the runner starts.
+- `pnpm install --frozen-lockfile` + audit (high+ severity prod-dep gate) + `pnpm -r run build` + `pnpm -r publish --dry-run` + `pnpm changeset publish` (with OIDC provenance).
+- `environment: npm-publish` — required reviewer must click **Approve and deploy** before any step runs.
 
-The two-stage split means ordinary chore / docs / fix commits never request reviewer approval — they finish in stage 1 and never reach the publish job. Approval is requested only when the merged commit is the auto-generated Version Packages PR (default title `chore: release packages`).
+**`.github/workflows/test.yml` — unit tests** (runs on every PR + main push)
+- Independent of the release pipeline. Branch-protection-required for PR merges to `main`, so by the time a commit reaches `main` the unit tests are known to be green.
 
-> **Important constraint**: do not rename the Version Packages PR title before merging. The publish guard checks the merge commit message contains `"chore: release packages"`. A renamed title fails the guard closed → the publish job is skipped → no release.
+### Why the split
+
+The previous design ran build/test/audit AND `changesets/action` in the same job, meaning a failing audit step short-circuited the bot — no Version Packages PR could be opened or updated until the audit-blocking CVE was hotfixed. With the split: audit only blocks the actual publish; the bot keeps maintaining the Version Packages PR regardless of audit / test state.
+
+### Load-bearing operational rule
+
+> **Do not rename the auto-generated "Version Packages" PR before merging.** The publish guard in `release.yml` checks that the merge commit message contains the literal string `"chore: release packages"`. A renamed title fails the guard closed → `release.yml` skips → no publish.
 
 For exact action behaviour see the upstream [`changesets/action` README](https://github.com/changesets/action#readme).
 
@@ -51,13 +57,14 @@ A PR with no `.changeset/*.md` is fine for pure docs / chore work that should no
 
 After your PR merges to `main`:
 
-1. release.yml `changesets` job runs install / build / test, then `changesets/action` sees your `.md` file and opens (or updates) a PR titled **"chore: release packages"** that:
+1. **`bot-sync.yml`** runs (install + `changesets/action`). It sees your `.md` file and opens (or updates) a PR titled **"chore: release packages"** that:
    - Bumps the affected packages' `version` fields in `package.json`
    - Appends a CHANGELOG entry per package using `@changesets/changelog-github` (auto-links your PR + handle)
    - Deletes the consumed `.changeset/*.md`
-2. The `publish` job's `if` guard evaluates false on this commit (the merge commit message is your feature PR's title, not `chore: release packages`), so the job is skipped and no environment approval is requested.
+   `test.yml` also runs in parallel to verify unit tests still pass on the new `main` commit.
+2. **`release.yml`** triggers but its `if` guard evaluates false (the merge commit message is your feature PR's title, not `chore: release packages`), so the job is skipped before the runner starts. No environment approval is requested.
 3. Maintainer reviews the "chore: release packages" PR (see [Reviewing the Version Packages PR](#reviewing-the-version-packages-pr) below) and merges it. **Do not rename the PR title** — the publish guard depends on it.
-4. release.yml runs again. `changesets` job no-ops (no `.md` files left). `publish` job's `if` guard evaluates true → reaches the `environment: npm-publish` gate.
+4. On that merge, **`bot-sync.yml`** runs again and no-ops (no `.md` files left). **`release.yml`** triggers, its `if` guard evaluates true, the runner starts, and the `publish` job reaches the `environment: npm-publish` gate.
 5. A reviewer (someone in the environment's required reviewers list, not yourself due to **Prevent self-review**) approves in the Actions UI.
 6. `pnpm changeset publish` runs, which:
    - Publishes each bumped package (whose `package.json.version > npm dist-tags.latest`)


### PR DESCRIPTION
## Summary
Decouple the Version Packages PR manager from the publish path so that a single failing audit / test / build step never blocks the bot from maintaining the bot PR. Realized while diagnosing why #85 merge did not trigger the bot to open a "chore: release packages" PR — root cause was the audit step in the (then-monolithic) `release.yml` failing on a transitive CVE and short-circuiting every subsequent step, including `changesets/action`.

## Architecture (after this PR)
Two **independent** workflows, both `on: push: branches: [main]`:

- **`bot-sync.yml`**: minimal install + `changesets/action@v1`. Opens / updates / closes the "Version Packages" PR depending on whether unreleased `.changeset/*.md` files exist. No build, no test, no audit. Cannot publish (no `publish` input passed to the action).
- **`release.yml`**: gated by `if: contains(github.event.head_commit.message, 'chore: release packages')`. Runs install + audit + build + dry-run + `pnpm changeset publish` under the `environment: npm-publish` reviewer-approval gate.

`test.yml` (unit tests on every PR + main push) is unchanged and remains the source of truth for code-level validation.

## Behavioral changes
- Chore / docs / CI / feature PR merges no longer run audit / build / test as part of the release pipeline. Those PRs are still validated by `test.yml`.
- A new high-severity CVE in production deps no longer prevents the bot from maintaining the Version Packages PR. The bot keeps the PR fresh; the actual publish is the only step that blocks until overrides catch up.
- Dropped the previous `hasChangesets == 'false'` guard — it was belt-and-suspenders alongside the commit-message check. Commit-message check + `environment: npm-publish` reviewer approval are both still required for publish.

## Load-bearing rule (unchanged, restated)
The publish guard in `release.yml` checks the merge commit message contains the literal string `"chore: release packages"`. **Do not rename the auto-generated Version Packages PR title before merging** — a renamed title fails the guard closed → `release.yml` skips → no publish.

## Test plan
- [x] `actionlint .github/workflows/bot-sync.yml .github/workflows/release.yml` — exit 0
- [x] `docs/RELEASING.md` updated to describe the two-workflow layout; no stale "Stage 1 / Stage 2" references remain.
- [ ] Once #86 (transitive CVE override bump) lands, this PR's merge should: trigger `bot-sync.yml` (no-op if no outstanding changesets) and skip `release.yml` (commit message is this PR's title, not "chore: release packages"). Verified post-merge.
- [ ] After #85 + #86 + this PR all merge, `bot-sync.yml` should open the v0.2.0 "chore: release packages" PR on the next main push (or already on the merge commit of #86).