### PR TITLE
ci(release): make bot PR title match publish guard exactly

### DIFF
--- a/.github/workflows/bot-sync.yml
+++ b/.github/workflows/bot-sync.yml
@@ -44,5 +44,13 @@ jobs:
           # Version Packages PR. Actual npm publish is handled by release.yml,
           # gated by the merge commit message of that PR.
           version: pnpm changeset version
+          # Set the bot PR title (and the internal "Version Packages" commit
+          # message on the bot's branch) to the exact string release.yml's
+          # publish guard checks for. With this, squash-merging the bot PR
+          # produces a merge commit message of "chore: release packages (#N)"
+          # which contains the marker string — no need to hand-edit the
+          # squash commit message at merge time.
+          title: "chore: release packages"
+          commit: "chore: release packages"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -27,7 +27,7 @@ The previous design ran build/test/audit AND `changesets/action` in the same job
 
 ### Load-bearing operational rule
 
-> **Do not rename the auto-generated "Version Packages" PR before merging.** The publish guard in `release.yml` checks that the merge commit message contains the literal string `"chore: release packages"`. A renamed title fails the guard closed → `release.yml` skips → no publish.
+> **Do not rename the auto-generated "chore: release packages" PR before merging.** The publish guard in `release.yml` checks that the merge commit message contains the literal string `"chore: release packages"`. A renamed title fails the guard closed → `release.yml` skips → no publish. (The bot uses that exact string as the PR title via the `title:` input on `changesets/action@v1` so the default squash-merge commit message already contains the marker — no need to hand-edit it.)
 
 For exact action behaviour see the upstream [`changesets/action` README](https://github.com/changesets/action#readme).
 


### PR DESCRIPTION
## Summary
Eliminate the manual-hand-edit-at-merge-time gotcha for the bot's Version Packages PR.

## Before
- Bot PR title defaulted to `Version Packages`
- Squash-merge commit message defaulted to `Version Packages (#N)`
- `release.yml` publish guard checks for `contains(commit_message, 'chore: release packages')` → miss
- Maintainer had to remember to hand-edit the squash commit message to `chore: release packages` at merge time. Easy to forget → no publish.

## After
- Pass `title: "chore: release packages"` (and `commit: "chore: release packages"`) to `changesets/action@v1`
- Bot PR title is the marker string directly
- Default squash-merge commit message is `chore: release packages (#N)` → guard hits
- No hand-edit required

`docs/RELEASING.md` updated accordingly. `actionlint` clean.