### PR TITLE
chore: add v0.2.1 hotfix changeset

### DIFF
--- a/.changeset/v021-hotfix.md
+++ b/.changeset/v021-hotfix.md
@@ -1,0 +1,20 @@
+---
+"@piplabs/cdr-sdk": patch
+"@piplabs/cdr-cli": patch
+---
+
+Hotfix re-publish: 0.2.0 of `@piplabs/cdr-sdk` and `@piplabs/cdr-cli` were
+inadvertently published via `npm publish` (instead of `pnpm publish`), which
+does not understand pnpm's `workspace:*` protocol. As a result the literal
+string `"workspace:*"` leaked into the published `package.json` dependencies
+and `npm install @piplabs/cdr-sdk@0.2.0` fails with
+`EUNSUPPORTEDPROTOCOL`.
+
+0.2.1 republishes both packages through the standard `pnpm changeset
+publish` path (release.yml), which correctly substitutes `workspace:*`
+with the resolved sibling version at publish time:
+
+- `@piplabs/cdr-sdk@0.2.1` depends on `@piplabs/cdr-contracts@0.2.0` and `@piplabs/cdr-crypto@0.2.0` (both already on npm, unchanged).
+- `@piplabs/cdr-cli@0.2.1` depends on `@piplabs/cdr-sdk@0.2.1`.
+
+The broken 0.2.0 versions will be `npm deprecate`'d after this release lands.

--- a/.changeset/v021-hotfix.md
+++ b/.changeset/v021-hotfix.md
@@ -1,20 +1,12 @@
 ---
+"@piplabs/cdr-contracts": patch
+"@piplabs/cdr-crypto": patch
 "@piplabs/cdr-sdk": patch
 "@piplabs/cdr-cli": patch
 ---
 
-Hotfix re-publish: 0.2.0 of `@piplabs/cdr-sdk` and `@piplabs/cdr-cli` were
-inadvertently published via `npm publish` (instead of `pnpm publish`), which
-does not understand pnpm's `workspace:*` protocol. As a result the literal
-string `"workspace:*"` leaked into the published `package.json` dependencies
-and `npm install @piplabs/cdr-sdk@0.2.0` fails with
-`EUNSUPPORTEDPROTOCOL`.
+Hotfix re-publish: 0.2.0 of `@piplabs/cdr-sdk` and `@piplabs/cdr-cli` was inadvertently published via `npm publish` (instead of `pnpm publish`), which does not understand pnpm's `workspace:*` protocol. As a result the literal string `"workspace:*"` leaked into those published `package.json` dependencies and `npm install @piplabs/cdr-sdk@0.2.0` fails with `EUNSUPPORTEDPROTOCOL`.
 
-0.2.1 republishes both packages through the standard `pnpm changeset
-publish` path (release.yml), which correctly substitutes `workspace:*`
-with the resolved sibling version at publish time:
+0.2.1 republishes all four packages through the standard `pnpm changeset publish` path (release.yml), which correctly substitutes `workspace:*` with the resolved sibling version at publish time. `@piplabs/cdr-contracts` and `@piplabs/cdr-crypto` are version-aligned to 0.2.1 even though their 0.2.0 tarballs were valid — keeping all four packages at the same version simplifies the release story and avoids consumer confusion about mismatched dist-tags.
 
-- `@piplabs/cdr-sdk@0.2.1` depends on `@piplabs/cdr-contracts@0.2.0` and `@piplabs/cdr-crypto@0.2.0` (both already on npm, unchanged).
-- `@piplabs/cdr-cli@0.2.1` depends on `@piplabs/cdr-sdk@0.2.1`.
-
-The broken 0.2.0 versions will be `npm deprecate`'d after this release lands.
+The broken 0.2.0 versions of `@piplabs/cdr-sdk` and `@piplabs/cdr-cli` will be `npm deprecate`'d after this release lands.


### PR DESCRIPTION
## Summary
Hotfix re-publish at 0.2.1 to fix the `workspace:*` protocol leak in 0.2.0 of `@piplabs/cdr-sdk` and `@piplabs/cdr-cli`. All four packages version-align to 0.2.1 for release-story simplicity.

## What broke
0.2.0 of `cdr-sdk` and `cdr-cli` was published via `npm publish` instead of `pnpm publish`. `npm` does not understand pnpm's `workspace:*` protocol, so the literal string was preserved in those published `package.json` dependencies:

\`\`\`json
"@piplabs/cdr-sdk@0.2.0": {
  "dependencies": {
    "@piplabs/cdr-contracts": "workspace:*",
    "@piplabs/cdr-crypto": "workspace:*"
  }
}
\`\`\`

`npm install @piplabs/cdr-sdk@0.2.0` fails with `EUNSUPPORTEDPROTOCOL`.

`cdr-contracts` and `cdr-crypto` 0.2.0 tarballs have no `workspace:` deps and are correct, but version-aligning all four keeps the release story coherent.

## What this PR does
Adds a changeset bumping all four packages (cdr-contracts, cdr-crypto, cdr-sdk, cdr-cli) patch to 0.2.1.

## What happens after merge
1. `bot-sync.yml` opens a "chore: release packages" PR with the 0.2.1 bumps (title is now correct out of the box via #89, no hand-edit needed).
2. Squash-merging that bot PR triggers `release.yml` publish via `pnpm changeset publish`, which substitutes `workspace:*` to concrete versions in the tarballs.
3. After 0.2.1 is on npm, manually `npm deprecate @piplabs/cdr-sdk@0.2.0` and `@piplabs/cdr-cli@0.2.0` to warn users.

## Verified
- `pnpm changeset status` shows all 4 packages patch-bumping (confirmed locally on this branch).
- `pnpm pack` of `packages/sdk` and `apps/cli` produces tarballs with concrete dependency versions — confirms `pnpm publish` will substitute correctly when `release.yml` runs.