### PR TITLE
ci(release): switch npm publish auth to OIDC Trusted Publisher

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,15 +73,24 @@ jobs:
       # write. Catches regressions in `files` whitelists or workspace dep
       # resolution before any tarball is irrevocably uploaded.
       - name: Verify publish tarballs (dry-run)
+        # Dry-run does not contact the registry; no auth needed.
         run: pnpm -r publish --dry-run --no-git-checks
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Publish to npm
+        # Authentication is via npm Trusted Publishing: each of the four
+        # packages has this workflow (piplabs/cdr-sdk, release.yml,
+        # environment=npm-publish) configured as a trusted publisher in its
+        # npm package settings. The GHA OIDC token (id-token: write below) is
+        # exchanged for a short-lived npm publish token at publish time —
+        # no long-lived NPM_TOKEN secret is needed in this repo.
+        #
+        # NOTE: NPM_TOKEN must NOT be set in the env block. If both an
+        # NPM_TOKEN and an OIDC trusted-publisher path are available, npm
+        # CLI preferentially uses NPM_TOKEN, which bypasses the trusted-
+        # publisher contract and reintroduces the 404/provenance failure.
         run: pnpm changeset publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           # Emit OIDC-signed provenance so consumers can verify the tarball
           # was produced by this workflow.
           NPM_CONFIG_PROVENANCE: "true"


### PR DESCRIPTION
## Summary
Remove `NPM_TOKEN` from `release.yml`'s publish step in favor of OIDC-based npm Trusted Publishing.

## Why
Three publish attempts for v0.2.0 and v0.2.1 all failed with `404 Not Found` at the PUT step despite the granular `NPM_TOKEN` having Bypass-2FA enabled and the underlying user being admin on the `@piplabs` org. The provenance attestation step (`NPM_CONFIG_PROVENANCE=true`) succeeded in every run — sigstore transparency log indices are visible — but the registry rejected the actual PUT. This is a documented npm failure mode: provenance-enabled publishes effectively require either Trusted Publisher configuration on the target package, or a token whose permission scope explicitly authorizes attestation publishing (not exposed in the granular access token UI).

## Prereqs (done out-of-band)
Each of the four packages now has this workflow registered as a Trusted Publisher:

- `@piplabs/cdr-contracts`
- `@piplabs/cdr-crypto`
- `@piplabs/cdr-sdk`
- `@piplabs/cdr-cli`

Trusted Publisher fields per package:

| Field | Value |
|---|---|
| Organization | `piplabs` |
| Repository | `cdr-sdk` |
| Workflow filename | `release.yml` |
| Environment | `npm-publish` |

## Change
- `Publish to npm` step: removed `NPM_TOKEN` from `env`. The npm CLI will now use the GHA OIDC token (`id-token: write` already in `permissions`) to obtain a short-lived publish token bound to the Trusted Publisher contract.
- `Verify publish tarballs (dry-run)` step: also removed `NPM_TOKEN`. Dry-run does not contact the registry.
- `NPM_CONFIG_PROVENANCE: "true"` retained; provenance attestation now works because Trusted Publisher contract authorizes the publish.

## Test plan
- [x] `actionlint` clean
- [ ] After merge, the v0.2.1 release retry (rerun of run 25848829722, or fresh push since main is at the `chore: release packages` marker commit `6533ee9`) should reach `pnpm changeset publish` and succeed for all four packages.
- [ ] Verify on npm: `npm view @piplabs/cdr-sdk version` returns `0.2.1`; `dependencies` shows concrete `"@piplabs/cdr-contracts": "0.2.1"` etc. (no `workspace:*`).
- [ ] OIDC provenance attestation visible on npm package page.

## Follow-up housekeeping (not in this PR)
- Revoke leaked legacy NPM_TOKEN (`npm_shDB…`) once the OIDC path is proven.
- Delete `NPM_TOKEN` GitHub repo secret entirely.
- Mark v0.2.0 of `cdr-sdk` and `cdr-cli` deprecated on npm (`workspace:*` leak).