### PR TITLE
ci(release): drop setup-node registry-url so npm CLI falls through to OIDC

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,14 @@ jobs:
         with:
           node-version: '20'
           cache: pnpm
-          registry-url: 'https://registry.npmjs.org'
+          # No `registry-url` — that input causes setup-node to write a
+          # workspace-local .npmrc with `_authToken=${NODE_AUTH_TOKEN}`.
+          # When no NODE_AUTH_TOKEN secret is provided (we want OIDC instead),
+          # the placeholder literal "XXXXX-XXXXX-XXXXX-XXXXX" gets written
+          # verbatim as the bearer token, the npm CLI never falls through to
+          # the OIDC trusted-publisher path, and every PUT returns 404.
+          # Default registry (registry.npmjs.org) is correct; no explicit
+          # registry config needed.
 
       - run: pnpm install --frozen-lockfile
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,6 +51,42 @@ jobs:
           # Default registry (registry.npmjs.org) is correct; no explicit
           # registry config needed.
 
+      # Node 20 ships with npm 10.x. OIDC Trusted Publisher exchange was added
+      # in npm 11.x — without this upgrade, even with Trusted Publisher config
+      # and a clean .npmrc, the npm CLI would not know how to mint an OIDC
+      # token at publish time. `pnpm changeset publish` delegates the actual
+      # PUT to npm, so npm version is the binding constraint here.
+      - name: Upgrade npm to support OIDC Trusted Publisher
+        run: |
+          npm install -g npm@latest
+          npm --version
+
+      # Diagnostic: print the auth/OIDC-relevant state right before publish.
+      # Cheap insurance — any further regression will show us in one place
+      # whether .npmrc has stale auth, whether NODE_AUTH_TOKEN got injected,
+      # and whether the OIDC token-request env is present.
+      - name: Diagnose publish auth state
+        run: |
+          echo "--- versions ---"
+          echo "npm:  $(npm --version)"
+          echo "node: $(node --version)"
+          echo "pnpm: $(pnpm --version)"
+          echo "--- auth-related env vars (presence only, never the value) ---"
+          echo "NPM_CONFIG_USERCONFIG=${NPM_CONFIG_USERCONFIG:-unset}"
+          echo "NODE_AUTH_TOKEN=${NODE_AUTH_TOKEN:+set}"
+          echo "NPM_TOKEN=${NPM_TOKEN:+set}"
+          echo "GITHUB_ACTIONS=$GITHUB_ACTIONS"
+          echo "ACTIONS_ID_TOKEN_REQUEST_URL=${ACTIONS_ID_TOKEN_REQUEST_URL:+set}"
+          echo "ACTIONS_ID_TOKEN_REQUEST_TOKEN=${ACTIONS_ID_TOKEN_REQUEST_TOKEN:+set}"
+          echo "--- effective .npmrc (from NPM_CONFIG_USERCONFIG, if any) ---"
+          if [ -f "${NPM_CONFIG_USERCONFIG:-/dev/null}" ]; then
+            cat "$NPM_CONFIG_USERCONFIG"
+          else
+            echo "(no .npmrc at NPM_CONFIG_USERCONFIG)"
+          fi
+          echo "--- npm registry resolution ---"
+          npm config get registry
+
       - run: pnpm install --frozen-lockfile
 
       # Supply-chain gate. Audit production dependencies (the deps that ship


### PR DESCRIPTION
## Summary
Three changes in this PR to make GHA-side OIDC Trusted Publisher publish actually work. Previous attempts (PR #92 + first version of this PR) failed despite Trusted Publishers being configured on all 4 packages, because of two upstream surprises in the GHA tool chain.

## Root cause walkthrough (from run [25849517161](https://github.com/piplabs/cdr-sdk/actions/runs/25849517161) logs)
1. `actions/setup-node@v4` with `registry-url: https://registry.npmjs.org` writes a workspace-local \`.npmrc\` containing \`//registry.npmjs.org/:_authToken=\${NODE_AUTH_TOKEN}\`. The action ALSO sets the env var \`NODE_AUTH_TOKEN\` to its own placeholder default \`XXXXX-XXXXX-XXXXX-XXXXX\` when no real token is provided. Confirmed in the failed run's step env block:
   ```
   NPM_CONFIG_USERCONFIG: /home/runner/work/_temp/.npmrc
   NODE_AUTH_TOKEN: XXXXX-XXXXX-XXXXX-XXXXX
   ```
   The npm CLI then sends `XXXXX-XXXXX-XXXXX-XXXXX` as the Bearer auth header, the registry rejects it (returning the misleading "404 Not Found - PUT … is not in this registry"), and the CLI never falls through to the OIDC trusted-publisher exchange that would have worked.

2. Even with that .npmrc removed, **Node 20 ships with npm 10.x**. OIDC Trusted Publisher exchange was added in **npm 11.x** (current latest 11.14.1 per registry). Without an explicit npm upgrade, `pnpm changeset publish` (which delegates the actual PUT to npm) would still not negotiate the OIDC handshake.

## Changes
1. Drop `registry-url` from `actions/setup-node@v4`. No \`.npmrc\` is written. \`NODE_AUTH_TOKEN\` placeholder is no longer injected.
2. Add `npm install -g npm@latest` step before any publish-related work. Guarantees npm 11+ which supports OIDC Trusted Publisher.
3. Add a `Diagnose publish auth state` step right before install. Prints versions + presence-only of all auth-related env vars (\`NPM_CONFIG_USERCONFIG\`, \`NODE_AUTH_TOKEN\`, \`NPM_TOKEN\`, \`ACTIONS_ID_TOKEN_REQUEST_URL/TOKEN\`) + \`.npmrc\` contents if any. Never prints values, only set/unset. So if the publish step fails again, the diagnostic shows the exact state in one place.

## Verified
- `actionlint` clean.
- All 4 packages have npm Trusted Publisher configured pointing at this repo/workflow/environment.

## Test plan
- [ ] Merge this PR.
- [ ] Push an empty commit to main with message `chore: release packages: retry v0.2.1` to retrigger publish.
- [ ] Diagnostic step output should show npm 11.x, no NODE_AUTH_TOKEN, no NPM_TOKEN, OIDC env present.
- [ ] Publish job succeeds; 4 packages on npm at 0.2.1 with concrete deps (no `workspace:*` leak) + OIDC provenance attestation.