### PR TITLE
chore(packages): add repository field for npm provenance verification

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -34,5 +34,10 @@
     "tsx": "^4",
     "typescript": "^5.5",
     "vitest": "^2"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/piplabs/cdr-sdk.git",
+    "directory": "apps/cli"
   }
 }

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -24,5 +24,10 @@
   "devDependencies": {
     "typescript": "^5.5",
     "viem": "^2.47.6"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/piplabs/cdr-sdk.git",
+    "directory": "packages/contracts"
   }
 }

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -30,5 +30,10 @@
     "@vitest/coverage-v8": "^2",
     "typescript": "^5.5",
     "vitest": "^2"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/piplabs/cdr-sdk.git",
+    "directory": "packages/crypto"
   }
 }

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -56,5 +56,10 @@
     "typescript": "^5.5",
     "viem": "^2.47.6",
     "vitest": "^2"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/piplabs/cdr-sdk.git",
+    "directory": "packages/sdk"
   }
 }


### PR DESCRIPTION
## Summary
Add `repository` field to all four publishable packages so npm's Trusted Publisher provenance verification accepts the publish.

## Diagnostic from previous run
Run [25850036694](https://github.com/piplabs/cdr-sdk/actions/runs/25850036694) confirmed the GHA-side setup from PR #93 is correct (npm 11.14.1, no .npmrc, no NODE_AUTH_TOKEN, OIDC env present). The failure mode changed from **E404** (token-auth path) to **E422** (provenance-verification stage of the OIDC path):

```
422 Unprocessable Entity - PUT https://registry.npmjs.org/@piplabs%2fcdr-crypto
Error verifying sigstore provenance bundle: Failed to validate repository information:
package.json: "repository.url" is "", expected to match "https://github.com/piplabs/cdr-sdk" from provenance
```

→ OIDC handshake worked, provenance signed, registry accepted the auth — only failure is the package.json missing `repository.url`. npm cross-checks the provenance bundle's repo claim against package.json and refuses to publish if they mismatch (or in our case, if package.json is silent).

## Change
Each of the 4 publishable packages gets:

```json
"repository": {
  "type": "git",
  "url": "https://github.com/piplabs/cdr-sdk.git",
  "directory": "<workspace-relative path>"
}
```

`directory` is set per-package so npm/consumers can hop into the correct subdir when following the repo link.

| Package | directory |
|---|---|
| @piplabs/cdr-contracts | `packages/contracts` |
| @piplabs/cdr-crypto | `packages/crypto` |
| @piplabs/cdr-sdk | `packages/sdk` |
| @piplabs/cdr-cli | `apps/cli` |

## Test plan
- [ ] After merge, push empty commit `chore: release packages` to retrigger publish.
- [ ] Diagnostic step output remains clean (npm 11.x, no .npmrc, OIDC env set).
- [ ] Publish step succeeds for all 4 packages at 0.2.1 with provenance attestation.