### PR TITLE
fix(sdk): correct validateConditionContract preflight is a no-op + docs/CONDITIONS.md uses stale 3-arg signature 

### DIFF
--- a/apps/cli/__integration__/cli.test.ts
+++ b/apps/cli/__integration__/cli.test.ts
@@ -74,6 +74,10 @@ const READ_ONLY_ENV = {
   CDR_RPC_URL: RPC_URL!,
 };
 
+// Accepts the deployed CDR condition selectors and cleanly rejects unknown selectors.
+const OPEN_CONDITION_BYTECODE =
+  "0x602a600c600039602a6000f360003560e01c80635645dbbf14601f5780638db3eb1714601f5760006000fd5b600160005260206000f3" as `0x${string}`;
+
 /**
  * Spawn the built CLI binary with an explicit env (no parent inheritance,
  * so the test's own env doesn't leak). `reject: false` lets us inspect
@@ -106,13 +110,10 @@ beforeAll(async () => {
   const publicClient = createPublicClient({ transport: http(RPC_URL) }) as PublicClient;
   const walletClient = createWalletClient({ account, transport: http(RPC_URL) }) as WalletClient;
 
-  // Same 10-byte runtime as packages/sdk/__integration__: returns 32-byte
-  // 0x...01 for any call → CDR contract reads as "condition met".
-  const bytecode = "0x600a600c600039600a6000f3600160005260206000f3" as `0x${string}`;
   const txHash = await walletClient.sendTransaction({
     chain: walletClient.chain ?? null,
     account: walletClient.account ?? null,
-    data: bytecode,
+    data: OPEN_CONDITION_BYTECODE,
   });
   const receipt = await publicClient.waitForTransactionReceipt({ hash: txHash });
   if (!receipt.contractAddress) {

--- a/apps/examples/__integration__/examples.test.ts
+++ b/apps/examples/__integration__/examples.test.ts
@@ -49,6 +49,10 @@ const BASE_ENV = {
   CDR_TEST_PRIVATE_KEY: PRIVATE_KEY!,
 };
 
+// Accepts the deployed CDR condition selectors and cleanly rejects unknown selectors.
+const OPEN_CONDITION_BYTECODE =
+  "0x602a600c600039602a6000f360003560e01c80635645dbbf14601f5780638db3eb1714601f5760006000fd5b600160005260206000f3" as `0x${string}`;
+
 /**
  * Per-case diagnostic logger; mirrors the SDK / CLI suites.
  */
@@ -87,13 +91,10 @@ beforeAll(async () => {
   const publicClient = createPublicClient({ transport: http(RPC_URL) }) as PublicClient;
   const walletClient = createWalletClient({ account, transport: http(RPC_URL) }) as WalletClient;
 
-  // Deploy the open-condition contract (same 10-byte runtime as
-  // packages/sdk/__integration__).
-  const bytecode = "0x600a600c600039600a6000f3600160005260206000f3" as `0x${string}`;
   const deployTx = await walletClient.sendTransaction({
     chain: walletClient.chain ?? null,
     account: walletClient.account ?? null,
-    data: bytecode,
+    data: OPEN_CONDITION_BYTECODE,
   });
   const deployReceipt = await publicClient.waitForTransactionReceipt({ hash: deployTx });
   if (!deployReceipt.contractAddress) {

--- a/docs/CONDITIONS.md
+++ b/docs/CONDITIONS.md
@@ -71,7 +71,7 @@ const { dataKey } = await client.consumer.accessCDR({
 When someone calls `write()` or `read()` on the CDR contract, the contract:
 
 1. Looks up the vault's condition address (`writeConditionAddr` or `readConditionAddr`)
-2. Calls the condition contract with the caller's address, the condition data stored at allocation time, and the `accessAuxData` provided by the caller
+2. Calls the condition contract with the vault `uuid`, the `accessAuxData` provided by the caller, the condition data stored at allocation time, and the caller's address
 3. If the condition contract returns false (or reverts), the operation is rejected
 
 This happens at the protocol level — the SDK does not enforce conditions locally. Your transaction will revert on-chain if conditions aren't met.
@@ -83,16 +83,18 @@ Condition contracts must implement these functions:
 ```solidity
 // For write conditions
 function checkWriteCondition(
-    address caller,
+    uint32 uuid,
+    bytes calldata accessAuxData,
     bytes calldata conditionData,
-    bytes calldata accessAuxData
+    address caller
 ) external view returns (bool);
 
 // For read conditions
 function checkReadCondition(
-    address caller,
+    uint32 uuid,
+    bytes calldata accessAuxData,
     bytes calldata conditionData,
-    bytes calldata accessAuxData
+    address caller
 ) external view returns (bool);
 ```
 
@@ -100,9 +102,10 @@ function checkReadCondition(
 
 | Parameter | Source | Description |
 |-----------|--------|-------------|
-| `caller` | `msg.sender` of the CDR write/read call | The address attempting the operation |
-| `conditionData` | Stored at vault allocation time | Static config set by the vault creator (e.g., an allowlist root, a token address, a role identifier) |
+| `uuid` | Vault being accessed | The CDR vault UUID the write/read targets |
 | `accessAuxData` | Passed by the caller at write/read time | Dynamic data the caller provides to satisfy the condition (e.g., a Merkle proof, a signature) |
+| `conditionData` | Stored at vault allocation time | Static config set by the vault creator (e.g., an allowlist root, a token address, a role identifier) |
+| `caller` | `msg.sender` of the CDR write/read call | The address attempting the operation |
 
 ## How to Set Conditions
 
@@ -150,17 +153,19 @@ pragma solidity ^0.8.0;
 
 contract OpenCondition {
     function checkWriteCondition(
-        address,
+        uint32,
         bytes calldata,
-        bytes calldata
+        bytes calldata,
+        address
     ) external pure returns (bool) {
         return true;
     }
 
     function checkReadCondition(
-        address,
+        uint32,
         bytes calldata,
-        bytes calldata
+        bytes calldata,
+        address
     ) external pure returns (bool) {
         return true;
     }
@@ -177,18 +182,20 @@ pragma solidity ^0.8.0;
 
 contract OwnerCondition {
     function checkWriteCondition(
-        address caller,
+        uint32,
+        bytes calldata,
         bytes calldata conditionData,
-        bytes calldata
+        address caller
     ) external pure returns (bool) {
         address owner = abi.decode(conditionData, (address));
         return caller == owner;
     }
 
     function checkReadCondition(
-        address caller,
+        uint32,
+        bytes calldata,
         bytes calldata conditionData,
-        bytes calldata
+        address caller
     ) external pure returns (bool) {
         address owner = abi.decode(conditionData, (address));
         return caller == owner;
@@ -227,18 +234,20 @@ import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 contract TokenGateCondition {
     function checkReadCondition(
-        address caller,
+        uint32,
+        bytes calldata,
         bytes calldata conditionData,
-        bytes calldata
+        address caller
     ) external view returns (bool) {
         (address token, uint256 minBalance) = abi.decode(conditionData, (address, uint256));
         return IERC20(token).balanceOf(caller) >= minBalance;
     }
 
     function checkWriteCondition(
-        address caller,
+        uint32,
+        bytes calldata,
         bytes calldata conditionData,
-        bytes calldata
+        address caller
     ) external view returns (bool) {
         (address token, uint256 minBalance) = abi.decode(conditionData, (address, uint256));
         return IERC20(token).balanceOf(caller) >= minBalance;
@@ -258,9 +267,10 @@ import "@openzeppelin/contracts/utils/cryptography/MerkleProof.sol";
 
 contract MerkleCondition {
     function checkReadCondition(
-        address caller,
+        uint32,
+        bytes calldata accessAuxData,
         bytes calldata conditionData,
-        bytes calldata accessAuxData
+        address caller
     ) external pure returns (bool) {
         bytes32 root = abi.decode(conditionData, (bytes32));
         bytes32[] memory proof = abi.decode(accessAuxData, (bytes32[]));
@@ -269,9 +279,10 @@ contract MerkleCondition {
     }
 
     function checkWriteCondition(
-        address caller,
+        uint32,
+        bytes calldata accessAuxData,
         bytes calldata conditionData,
-        bytes calldata accessAuxData
+        address caller
     ) external pure returns (bool) {
         bytes32 root = abi.decode(conditionData, (bytes32));
         bytes32[] memory proof = abi.decode(accessAuxData, (bytes32[]));

--- a/packages/sdk/__integration__/_helpers.ts
+++ b/packages/sdk/__integration__/_helpers.ts
@@ -12,6 +12,18 @@ import { cdrAbi, contractAddresses, type Network } from "@piplabs/cdr-contracts"
 import { bytesToHex } from "../src/story-api/index.js";
 
 /**
+ * Creation bytecode for a minimal always-true condition contract that
+ * implements the deployed CDR condition ABI:
+ *   - checkWriteCondition(uint32,bytes,bytes,address)
+ *   - checkReadCondition(uint32,bytes,bytes,address)
+ *
+ * Unknown selectors revert with empty data so the SDK's sentinel preflight
+ * can distinguish this from a catch-all fallback.
+ */
+export const OPEN_CONDITION_BYTECODE =
+  "0x602a600c600039602a6000f360003560e01c80635645dbbf14601f5780638db3eb1714601f5760006000fd5b600160005260206000f3" as `0x${string}`;
+
+/**
  * `JSON.stringify` replacer for live response logging:
  *   - `Map`        → plain object (so commPubKey-by-validator dumps cleanly)
  *   - `Uint8Array` → hex (truncated for fields longer than 80 hex chars,

--- a/packages/sdk/__integration__/consumer.test.ts
+++ b/packages/sdk/__integration__/consumer.test.ts
@@ -44,7 +44,7 @@ import { CDRClient, initWasm } from "../src/index.js";
 import { PartialCollectionTimeoutError, EmptyVaultError } from "../src/errors.js";
 import { uuidToLabel } from "../src/label.js";
 import { queryCDRPartials, queryLatestActiveDKGNetwork } from "../src/story-api/index.js";
-import { logCase, countFetchCallsTo } from "./_helpers.js";
+import { OPEN_CONDITION_BYTECODE, logCase, countFetchCallsTo } from "./_helpers.js";
 
 const API_URL = process.env.CDR_API_URL;
 const RPC_URL = process.env.CDR_RPC_URL;
@@ -83,20 +83,17 @@ function makeCDRClient(): {
 }
 
 /**
- * Deploy a minimal "always-true" condition contract — same pattern as
- * `__integration__/uploader.test.ts`. The runtime returns 32-byte `0x...01`
- * for any call, which the CDR contract reads as "condition met".
+ * Deploy a minimal "always-true" condition contract that implements the
+ * condition selectors and cleanly rejects unknown selectors.
  */
 async function deployOpenCondition(
   publicClient: PublicClient,
   walletClient: WalletClient,
 ): Promise<`0x${string}`> {
-  const bytecode =
-    "0x600a600c600039600a6000f3600160005260206000f3" as `0x${string}`;
   const txHash = await walletClient.sendTransaction({
     chain: walletClient.chain ?? null,
     account: walletClient.account ?? null,
-    data: bytecode,
+    data: OPEN_CONDITION_BYTECODE,
   });
   const receipt = await publicClient.waitForTransactionReceipt({ hash: txHash });
   if (!receipt.contractAddress) {

--- a/packages/sdk/__integration__/dx-improvements.test.ts
+++ b/packages/sdk/__integration__/dx-improvements.test.ts
@@ -24,6 +24,7 @@ import {
 } from "viem";
 import { generatePrivateKey, privateKeyToAccount } from "viem/accounts";
 import { CDRClient, conditions, initWasm } from "../src/index.js";
+import { OPEN_CONDITION_BYTECODE } from "./_helpers.js";
 
 const API_URL = process.env.CDR_API_URL;
 const RPC_URL = process.env.CDR_RPC_URL;
@@ -61,12 +62,10 @@ async function deployOpenCondition(
   publicClient: PublicClient,
   walletClient: WalletClient,
 ): Promise<`0x${string}`> {
-  const bytecode =
-    "0x600a600c600039600a6000f3600160005260206000f3" as `0x${string}`;
   const tx = await walletClient.sendTransaction({
     chain: walletClient.chain ?? null,
     account: walletClient.account ?? null,
-    data: bytecode,
+    data: OPEN_CONDITION_BYTECODE,
   });
   const receipt = await publicClient.waitForTransactionReceipt({ hash: tx });
   if (!receipt.contractAddress) {

--- a/packages/sdk/__integration__/ephemeral-1000w-perf.test.ts
+++ b/packages/sdk/__integration__/ephemeral-1000w-perf.test.ts
@@ -49,6 +49,7 @@ import {
   logCase,
   max as arrMax,
   mean,
+  OPEN_CONDITION_BYTECODE,
   p50,
   p95,
   p99,
@@ -116,12 +117,10 @@ async function deployOpenCondition(
   publicClient: PublicClient,
   walletClient: WalletClient,
 ): Promise<`0x${string}`> {
-  const bytecode =
-    "0x600a600c600039600a6000f3600160005260206000f3" as `0x${string}`;
   const tx = await walletClient.sendTransaction({
     chain: walletClient.chain ?? null,
     account: walletClient.account ?? null,
-    data: bytecode,
+    data: OPEN_CONDITION_BYTECODE,
   });
   const receipt = await publicClient.waitForTransactionReceipt({ hash: tx });
   if (!receipt.contractAddress) {

--- a/packages/sdk/__integration__/ephemeral-100w-fresh-aeneid.test.ts
+++ b/packages/sdk/__integration__/ephemeral-100w-fresh-aeneid.test.ts
@@ -46,6 +46,7 @@ import {
   formatMs,
   logCase,
   mean,
+  OPEN_CONDITION_BYTECODE,
   p50,
   p95,
   sizeFundAndReport,
@@ -111,12 +112,10 @@ async function deployOpenCondition(
   publicClient: PublicClient,
   walletClient: WalletClient,
 ): Promise<`0x${string}`> {
-  const bytecode =
-    "0x600a600c600039600a6000f3600160005260206000f3" as `0x${string}`;
   const tx = await walletClient.sendTransaction({
     chain: walletClient.chain ?? null,
     account: walletClient.account ?? null,
-    data: bytecode,
+    data: OPEN_CONDITION_BYTECODE,
   });
   const receipt = await publicClient.waitForTransactionReceipt({ hash: tx });
   if (!receipt.contractAddress) {

--- a/packages/sdk/__integration__/ephemeral-100w-fresh.test.ts
+++ b/packages/sdk/__integration__/ephemeral-100w-fresh.test.ts
@@ -49,6 +49,7 @@ import {
   formatMs,
   logCase,
   mean,
+  OPEN_CONDITION_BYTECODE,
   p50,
   p95,
   sizeFundAndReport,
@@ -112,12 +113,10 @@ async function deployOpenCondition(
   publicClient: PublicClient,
   walletClient: WalletClient,
 ): Promise<`0x${string}`> {
-  const bytecode =
-    "0x600a600c600039600a6000f3600160005260206000f3" as `0x${string}`;
   const tx = await walletClient.sendTransaction({
     chain: walletClient.chain ?? null,
     account: walletClient.account ?? null,
-    data: bytecode,
+    data: OPEN_CONDITION_BYTECODE,
   });
   const receipt = await publicClient.waitForTransactionReceipt({ hash: tx });
   if (!receipt.contractAddress) {

--- a/packages/sdk/__integration__/ephemeral-100w-shared.test.ts
+++ b/packages/sdk/__integration__/ephemeral-100w-shared.test.ts
@@ -57,6 +57,7 @@ import {
   formatMs,
   logCase,
   mean,
+  OPEN_CONDITION_BYTECODE,
   p50,
   p95,
   sizeFundAndReport,
@@ -126,12 +127,10 @@ async function deployOpenCondition(
   publicClient: PublicClient,
   walletClient: WalletClient,
 ): Promise<`0x${string}`> {
-  const bytecode =
-    "0x600a600c600039600a6000f3600160005260206000f3" as `0x${string}`;
   const tx = await walletClient.sendTransaction({
     chain: walletClient.chain ?? null,
     account: walletClient.account ?? null,
-    data: bytecode,
+    data: OPEN_CONDITION_BYTECODE,
   });
   const receipt = await publicClient.waitForTransactionReceipt({ hash: tx });
   if (!receipt.contractAddress) {

--- a/packages/sdk/__integration__/ephemeral-60min-stress.test.ts
+++ b/packages/sdk/__integration__/ephemeral-60min-stress.test.ts
@@ -85,6 +85,7 @@ import {
   refundWallets,
 } from "./_ephemeral-wallets.js";
 import {
+  OPEN_CONDITION_BYTECODE,
   sizeFundAndReport,
   statsOf,
   writePerfStats,
@@ -181,12 +182,10 @@ async function deployOpenCondition(
   publicClient: PublicClient,
   walletClient: WalletClient,
 ): Promise<`0x${string}`> {
-  const bytecode =
-    "0x600a600c600039600a6000f3600160005260206000f3" as `0x${string}`;
   const tx = await walletClient.sendTransaction({
     chain: walletClient.chain ?? null,
     account: walletClient.account ?? null,
-    data: bytecode,
+    data: OPEN_CONDITION_BYTECODE,
   });
   const receipt = await publicClient.waitForTransactionReceipt({ hash: tx });
   if (!receipt.contractAddress) {

--- a/packages/sdk/__integration__/perf-micro.test.ts
+++ b/packages/sdk/__integration__/perf-micro.test.ts
@@ -33,6 +33,7 @@ import {
 } from "viem";
 import { privateKeyToAccount } from "viem/accounts";
 import { CDRClient, getWasm, initWasm } from "../src/index.js";
+import { OPEN_CONDITION_BYTECODE } from "./_helpers.js";
 
 const API_URL = process.env.CDR_API_URL;
 const RPC_URL = process.env.CDR_RPC_URL;
@@ -70,12 +71,10 @@ async function deployOpenCondition(
   publicClient: PublicClient,
   walletClient: WalletClient,
 ): Promise<`0x${string}`> {
-  const bytecode =
-    "0x600a600c600039600a6000f3600160005260206000f3" as `0x${string}`;
   const tx = await walletClient.sendTransaction({
     chain: walletClient.chain ?? null,
     account: walletClient.account ?? null,
-    data: bytecode,
+    data: OPEN_CONDITION_BYTECODE,
   });
   const receipt = await publicClient.waitForTransactionReceipt({ hash: tx });
   if (!receipt.contractAddress) {

--- a/packages/sdk/__integration__/security.test.ts
+++ b/packages/sdk/__integration__/security.test.ts
@@ -46,6 +46,7 @@ import {
   uuidToLabel,
   verifyAttestation,
 } from "../src/index.js";
+import { OPEN_CONDITION_BYTECODE } from "./_helpers.js";
 
 const API_URL = process.env.CDR_API_URL;
 const RPC_URL = process.env.CDR_RPC_URL;
@@ -83,12 +84,10 @@ async function deployOpenCondition(
   publicClient: PublicClient,
   walletClient: WalletClient,
 ): Promise<`0x${string}`> {
-  const bytecode =
-    "0x600a600c600039600a6000f3600160005260206000f3" as `0x${string}`;
   const tx = await walletClient.sendTransaction({
     chain: walletClient.chain ?? null,
     account: walletClient.account ?? null,
-    data: bytecode,
+    data: OPEN_CONDITION_BYTECODE,
   });
   const receipt = await publicClient.waitForTransactionReceipt({ hash: tx });
   if (!receipt.contractAddress) {

--- a/packages/sdk/__integration__/uploader.test.ts
+++ b/packages/sdk/__integration__/uploader.test.ts
@@ -39,7 +39,7 @@ import {
   InvalidConditionContractError,
 } from "../src/errors.js";
 import { uuidToLabel } from "../src/label.js";
-import { logCase } from "./_helpers.js";
+import { OPEN_CONDITION_BYTECODE, logCase } from "./_helpers.js";
 
 const API_URL = process.env.CDR_API_URL;
 const RPC_URL = process.env.CDR_RPC_URL;
@@ -78,28 +78,17 @@ function makeCDRClient(): {
 }
 
 /**
- * Deploy a minimal "always-true" condition contract.
- *
- * Bytecode layout:
- *   PUSH1 0x0a  PUSH1 0x0c  PUSH1 0x00  CODECOPY
- *   PUSH1 0x0a  PUSH1 0x00  RETURN
- *   --- runtime (10 bytes) ---
- *   PUSH1 0x01  PUSH1 0x00  MSTORE  PUSH1 0x20  PUSH1 0x00  RETURN
- *
- * The runtime returns the 32-byte word `0x...01` for any call, which the
- * CDR contract interprets as "condition met". Same pattern used by
- * `piplabs/story-cdr-e2e` integration tests.
+ * Deploy a minimal "always-true" condition contract that implements the
+ * condition selectors and cleanly rejects unknown selectors.
  */
 async function deployOpenCondition(
   publicClient: PublicClient,
   walletClient: WalletClient,
 ): Promise<`0x${string}`> {
-  const bytecode =
-    "0x600a600c600039600a6000f3600160005260206000f3" as `0x${string}`;
   const txHash = await walletClient.sendTransaction({
     chain: walletClient.chain ?? null,
     account: walletClient.account ?? null,
-    data: bytecode,
+    data: OPEN_CONDITION_BYTECODE,
   });
   const receipt = await publicClient.waitForTransactionReceipt({ hash: txHash });
   if (!receipt.contractAddress) {

--- a/packages/sdk/__tests__/errors.test.ts
+++ b/packages/sdk/__tests__/errors.test.ts
@@ -107,6 +107,23 @@ describe("errors", () => {
       expect(err.message).toContain("read");
       expect(err.message).toContain(addr);
     });
+
+    it("exposes reason field, defaulting to selector-miss", () => {
+      const addr = "0x1234567890abcdef1234567890abcdef12345678";
+      const defaultErr = new InvalidConditionContractError(addr, "write");
+      expect(defaultErr.reason).toBe("selector-miss");
+
+      const ambiguousErr = new InvalidConditionContractError(
+        addr,
+        "read",
+        "ambiguous-fallback",
+      );
+      expect(ambiguousErr.reason).toBe("ambiguous-fallback");
+      // Message routes users to the escape hatch so they can self-diagnose
+      // the false-negative branch (Diamond proxies, deliberate payload-
+      // reverting fallbacks) without having to read the SDK source.
+      expect(ambiguousErr.message).toContain("skipConditionValidation");
+    });
   });
 
   describe("LabelMismatchError", () => {

--- a/packages/sdk/__tests__/upload-file.test.ts
+++ b/packages/sdk/__tests__/upload-file.test.ts
@@ -13,6 +13,8 @@ import { ContentSizeExceededError } from "../src/errors.js";
 import type { StorageProvider } from "../src/storage/types.js";
 import type { Observer } from "../src/observer.js";
 
+const SENTINEL_CONDITION_FUNCTION = "__cdrSentinelProbeNoImpl__";
+
 function fakeObserver(opts: { maxSize?: bigint } = {}): Observer {
   return {
     getMaxEncryptedDataSize: vi.fn().mockResolvedValue(opts.maxSize ?? 10_000n),
@@ -58,9 +60,16 @@ function mockClients() {
   const publicClient = {
     readContract: vi.fn(),
     waitForTransactionReceipt: vi.fn(),
-    // Default: simulateContract succeeds, modelling a valid condition
-    // contract whose checkRead/Write function returned a bool.
-    simulateContract: vi.fn().mockResolvedValue({ result: true, request: {} }),
+    // Default validation path: real selector returns, sentinel selector misses.
+    simulateContract: vi
+      .fn()
+      .mockImplementation(({ functionName }: { functionName: string }) =>
+        functionName === SENTINEL_CONDITION_FUNCTION
+          ? Promise.reject({
+              cause: { name: "ContractFunctionRevertedError", raw: "0x" },
+            })
+          : Promise.resolve({ result: true, request: {} }),
+      ),
   } as any;
   const walletClient = {
     writeContract: vi.fn(),

--- a/packages/sdk/__tests__/upload-file.test.ts
+++ b/packages/sdk/__tests__/upload-file.test.ts
@@ -58,7 +58,9 @@ function mockClients() {
   const publicClient = {
     readContract: vi.fn(),
     waitForTransactionReceipt: vi.fn(),
-    simulateContract: vi.fn().mockRejectedValue({ cause: { name: "ContractFunctionRevertedError" } }),
+    // Default: simulateContract succeeds, modelling a valid condition
+    // contract whose checkRead/Write function returned a bool.
+    simulateContract: vi.fn().mockResolvedValue({ result: true, request: {} }),
   } as any;
   const walletClient = {
     writeContract: vi.fn(),

--- a/packages/sdk/__tests__/uploader.test.ts
+++ b/packages/sdk/__tests__/uploader.test.ts
@@ -69,7 +69,11 @@ function mockClients() {
     readContract: vi.fn(),
     waitForTransactionReceipt: vi.fn(),
     getTransactionReceipt: vi.fn(),
-    simulateContract: vi.fn().mockRejectedValue({ cause: { name: "ContractFunctionRevertedError" } }),
+    // Default: simulateContract succeeds, modelling a valid condition
+    // contract whose checkRead/Write function returned a bool. Tests
+    // exercising the rejection paths override this with explicit
+    // mockRejectedValue / mockImplementation.
+    simulateContract: vi.fn().mockResolvedValue({ result: true, request: {} }),
   } as any;
   const walletClient = {
     writeContract: vi.fn(),
@@ -172,12 +176,77 @@ describe("Uploader", () => {
     expect(walletClient.writeContract).not.toHaveBeenCalled();
   });
 
-  it("allocate accepts when condition function body reverts with non-empty data", async () => {
-    // Function exists and reverted with an Error(string) payload —
-    // selector 0x08c379a0 + abi-encoded "demo". The preflight treats any
-    // non-empty revert payload as "selector found, body ran."
+  it("allocate rejects condition revert whose cause has no raw field (#95)", async () => {
+    // Regression for #95: the original guard `cause.raw !== "0x"` was
+    // silently true when `raw` was undefined, passing the contract as
+    // valid. The typeof tightening now routes this to selector-miss.
     const { publicClient, walletClient } = mockClients();
     publicClient.simulateContract.mockRejectedValue({
+      cause: { name: "ContractFunctionRevertedError" }, // no `raw`
+    });
+
+    const uploader = new Uploader({
+      network: "testnet",
+      publicClient,
+      walletClient,
+      observer: fakeObserver(),
+    });
+
+    await expect(
+      uploader.allocate({
+        updatable: false,
+        writeConditionAddr: "0x1111111111111111111111111111111111111111",
+        readConditionAddr: "0x2222222222222222222222222222222222222222",
+        writeConditionData: "0x",
+        readConditionData: "0x",
+      }),
+    ).rejects.toMatchObject({
+      code: "INVALID_CONDITION_CONTRACT",
+      reason: "selector-miss",
+    });
+    expect(walletClient.writeContract).not.toHaveBeenCalled();
+  });
+
+  it("allocate rejects when condition call surfaces ContractFunctionZeroDataError (EOA / no code)", async () => {
+    // viem returns this when the call returns `0x` with no revert —
+    // what an EOA, or a contract whose dispatcher returns nothing,
+    // looks like. Distinct shape from ContractFunctionRevertedError;
+    // also maps to selector-miss.
+    const { publicClient, walletClient } = mockClients();
+    publicClient.simulateContract.mockRejectedValue({
+      cause: { name: "ContractFunctionZeroDataError" },
+    });
+
+    const uploader = new Uploader({
+      network: "testnet",
+      publicClient,
+      walletClient,
+      observer: fakeObserver(),
+    });
+
+    await expect(
+      uploader.allocate({
+        updatable: false,
+        writeConditionAddr: "0x1111111111111111111111111111111111111111",
+        readConditionAddr: "0x2222222222222222222222222222222222222222",
+        writeConditionData: "0x",
+        readConditionData: "0x",
+      }),
+    ).rejects.toMatchObject({
+      code: "INVALID_CONDITION_CONTRACT",
+      reason: "selector-miss",
+    });
+    expect(walletClient.writeContract).not.toHaveBeenCalled();
+  });
+
+  it("allocate accepts when condition function body reverts with non-empty data", async () => {
+    // Function exists and reverted with an Error(string) payload —
+    // selector 0x08c379a0 + abi-encoded "demo". The preflight treats a
+    // non-empty revert payload as "selector found, body ran" only when
+    // the sentinel probe confirms the contract doesn't have a catch-all
+    // fallback that would produce the same shape.
+    const { publicClient, walletClient } = mockClients();
+    const realRevert = {
       cause: {
         name: "ContractFunctionRevertedError",
         raw:
@@ -186,7 +255,18 @@ describe("Uploader", () => {
           "0000000000000000000000000000000000000000000000000000000000000004" +
           "64656d6f00000000000000000000000000000000000000000000000000000000",
       },
-    });
+    };
+    const sentinelRevert = {
+      cause: { name: "ContractFunctionRevertedError", raw: "0x" },
+    };
+    publicClient.simulateContract.mockImplementation(
+      ({ functionName }: { functionName: string }) =>
+        Promise.reject(
+          functionName === "__cdrSentinelProbeNoImpl__"
+            ? sentinelRevert
+            : realRevert,
+        ),
+    );
     publicClient.readContract.mockResolvedValueOnce(1000n);
     walletClient.writeContract.mockResolvedValueOnce("0xtxhash" as `0x${string}`);
     publicClient.waitForTransactionReceipt.mockResolvedValueOnce({
@@ -209,6 +289,90 @@ describe("Uploader", () => {
     });
 
     expect(result.uuid).toBe(99);
+  });
+
+  it("allocate rejects when contract has a payload-reverting fallback (ambiguous)", async () => {
+    // Both the real-selector and sentinel-selector calls revert with the
+    // same Error(string) payload — modelling a contract whose fallback
+    // reverts with a non-empty payload. We cannot tell whether the real
+    // call's payload came from the function body or the fallback, so the
+    // preflight rejects conservatively with reason="ambiguous-fallback".
+    const { publicClient, walletClient } = mockClients();
+    const payloadRevert = {
+      cause: {
+        name: "ContractFunctionRevertedError",
+        raw:
+          "0x08c379a0" +
+          "0000000000000000000000000000000000000000000000000000000000000020" +
+          "0000000000000000000000000000000000000000000000000000000000000004" +
+          "64656d6f00000000000000000000000000000000000000000000000000000000",
+      },
+    };
+    publicClient.simulateContract.mockRejectedValue(payloadRevert);
+
+    const uploader = new Uploader({
+      network: "testnet",
+      publicClient,
+      walletClient,
+      observer: fakeObserver(),
+    });
+
+    await expect(
+      uploader.allocate({
+        updatable: false,
+        writeConditionAddr: "0x1111111111111111111111111111111111111111",
+        readConditionAddr: "0x2222222222222222222222222222222222222222",
+        writeConditionData: "0x",
+        readConditionData: "0x",
+      }),
+    ).rejects.toMatchObject({
+      code: "INVALID_CONDITION_CONTRACT",
+      reason: "ambiguous-fallback",
+    });
+
+    expect(walletClient.writeContract).not.toHaveBeenCalled();
+  });
+
+  it("allocate rejects when sentinel probe returns OK (swallow-all fallback)", async () => {
+    // Real-selector call reverts with a payload (looks like a body
+    // revert), but the sentinel call returns successfully — the
+    // contract has a fallback that accepts any selector, so we cannot
+    // trust the original payload-revert came from the real function.
+    // Conservative reject.
+    const { publicClient, walletClient } = mockClients();
+    const realRevert = {
+      cause: {
+        name: "ContractFunctionRevertedError",
+        raw: "0x08c379a0",
+      },
+    };
+    publicClient.simulateContract.mockImplementation(
+      ({ functionName }: { functionName: string }) =>
+        functionName === "__cdrSentinelProbeNoImpl__"
+          ? Promise.resolve({ result: true, request: {} })
+          : Promise.reject(realRevert),
+    );
+
+    const uploader = new Uploader({
+      network: "testnet",
+      publicClient,
+      walletClient,
+      observer: fakeObserver(),
+    });
+
+    await expect(
+      uploader.allocate({
+        updatable: false,
+        writeConditionAddr: "0x1111111111111111111111111111111111111111",
+        readConditionAddr: "0x2222222222222222222222222222222222222222",
+        writeConditionData: "0x",
+        readConditionData: "0x",
+      }),
+    ).rejects.toMatchObject({
+      code: "INVALID_CONDITION_CONTRACT",
+      reason: "ambiguous-fallback",
+    });
+    expect(walletClient.writeContract).not.toHaveBeenCalled();
   });
 
   it("allocate preflight probes condition contracts with the 4-arg signature", async () => {

--- a/packages/sdk/__tests__/uploader.test.ts
+++ b/packages/sdk/__tests__/uploader.test.ts
@@ -12,6 +12,13 @@ import { tdh2Encrypt } from "@piplabs/cdr-crypto";
 import { ContentSizeExceededError, InvalidConditionContractError } from "../src/errors.js";
 import type { Observer } from "../src/observer.js";
 
+const SENTINEL_CONDITION_FUNCTION = "__cdrSentinelProbeNoImpl__";
+const ERROR_STRING_DEMO_REVERT_RAW =
+  "0x08c379a0" +
+  "0000000000000000000000000000000000000000000000000000000000000020" +
+  "0000000000000000000000000000000000000000000000000000000000000004" +
+  "64656d6f00000000000000000000000000000000000000000000000000000000";
+
 /**
  * Minimal Observer stub for Uploader unit tests. Uploader consults Observer
  * for `maxEncryptedDataSize` (the size-validation gate in `write`) and for
@@ -69,11 +76,16 @@ function mockClients() {
     readContract: vi.fn(),
     waitForTransactionReceipt: vi.fn(),
     getTransactionReceipt: vi.fn(),
-    // Default: simulateContract succeeds, modelling a valid condition
-    // contract whose checkRead/Write function returned a bool. Tests
-    // exercising the rejection paths override this with explicit
-    // mockRejectedValue / mockImplementation.
-    simulateContract: vi.fn().mockResolvedValue({ result: true, request: {} }),
+    // Default validation path: real selector returns, sentinel selector misses.
+    simulateContract: vi
+      .fn()
+      .mockImplementation(({ functionName }: { functionName: string }) =>
+        functionName === SENTINEL_CONDITION_FUNCTION
+          ? Promise.reject({
+              cause: { name: "ContractFunctionRevertedError", raw: "0x" },
+            })
+          : Promise.resolve({ result: true, request: {} }),
+      ),
   } as any;
   const walletClient = {
     writeContract: vi.fn(),
@@ -147,9 +159,6 @@ describe("Uploader", () => {
   });
 
   it("allocate rejects when condition contract does not implement the check function", async () => {
-    // Empty revert payload from a `ContractFunctionRevertedError` is the EVM
-    // dispatcher's fallback signal — the function selector was not routed.
-    // This is the case the previous (buggy) preflight silently accepted.
     const { publicClient, walletClient } = mockClients();
     publicClient.simulateContract.mockRejectedValue({
       cause: { name: "ContractFunctionRevertedError", raw: "0x" },
@@ -172,14 +181,10 @@ describe("Uploader", () => {
       }),
     ).rejects.toThrow(InvalidConditionContractError);
 
-    // Short-circuits before allocate would have been broadcast.
     expect(walletClient.writeContract).not.toHaveBeenCalled();
   });
 
   it("allocate rejects condition revert whose cause has no raw field (#95)", async () => {
-    // Regression for #95: the original guard `cause.raw !== "0x"` was
-    // silently true when `raw` was undefined, passing the contract as
-    // valid. The typeof tightening now routes this to selector-miss.
     const { publicClient, walletClient } = mockClients();
     publicClient.simulateContract.mockRejectedValue({
       cause: { name: "ContractFunctionRevertedError" }, // no `raw`
@@ -208,10 +213,6 @@ describe("Uploader", () => {
   });
 
   it("allocate rejects when condition call surfaces ContractFunctionZeroDataError (EOA / no code)", async () => {
-    // viem returns this when the call returns `0x` with no revert —
-    // what an EOA, or a contract whose dispatcher returns nothing,
-    // looks like. Distinct shape from ContractFunctionRevertedError;
-    // also maps to selector-miss.
     const { publicClient, walletClient } = mockClients();
     publicClient.simulateContract.mockRejectedValue({
       cause: { name: "ContractFunctionZeroDataError" },
@@ -240,20 +241,11 @@ describe("Uploader", () => {
   });
 
   it("allocate accepts when condition function body reverts with non-empty data", async () => {
-    // Function exists and reverted with an Error(string) payload —
-    // selector 0x08c379a0 + abi-encoded "demo". The preflight treats a
-    // non-empty revert payload as "selector found, body ran" only when
-    // the sentinel probe confirms the contract doesn't have a catch-all
-    // fallback that would produce the same shape.
     const { publicClient, walletClient } = mockClients();
     const realRevert = {
       cause: {
         name: "ContractFunctionRevertedError",
-        raw:
-          "0x08c379a0" +
-          "0000000000000000000000000000000000000000000000000000000000000020" +
-          "0000000000000000000000000000000000000000000000000000000000000004" +
-          "64656d6f00000000000000000000000000000000000000000000000000000000",
+        raw: ERROR_STRING_DEMO_REVERT_RAW,
       },
     };
     const sentinelRevert = {
@@ -262,7 +254,7 @@ describe("Uploader", () => {
     publicClient.simulateContract.mockImplementation(
       ({ functionName }: { functionName: string }) =>
         Promise.reject(
-          functionName === "__cdrSentinelProbeNoImpl__"
+          functionName === SENTINEL_CONDITION_FUNCTION
             ? sentinelRevert
             : realRevert,
         ),
@@ -292,20 +284,11 @@ describe("Uploader", () => {
   });
 
   it("allocate rejects when contract has a payload-reverting fallback (ambiguous)", async () => {
-    // Both the real-selector and sentinel-selector calls revert with the
-    // same Error(string) payload — modelling a contract whose fallback
-    // reverts with a non-empty payload. We cannot tell whether the real
-    // call's payload came from the function body or the fallback, so the
-    // preflight rejects conservatively with reason="ambiguous-fallback".
     const { publicClient, walletClient } = mockClients();
     const payloadRevert = {
       cause: {
         name: "ContractFunctionRevertedError",
-        raw:
-          "0x08c379a0" +
-          "0000000000000000000000000000000000000000000000000000000000000020" +
-          "0000000000000000000000000000000000000000000000000000000000000004" +
-          "64656d6f00000000000000000000000000000000000000000000000000000000",
+        raw: ERROR_STRING_DEMO_REVERT_RAW,
       },
     };
     publicClient.simulateContract.mockRejectedValue(payloadRevert);
@@ -334,11 +317,6 @@ describe("Uploader", () => {
   });
 
   it("allocate rejects when sentinel probe returns OK (swallow-all fallback)", async () => {
-    // Real-selector call reverts with a payload (looks like a body
-    // revert), but the sentinel call returns successfully — the
-    // contract has a fallback that accepts any selector, so we cannot
-    // trust the original payload-revert came from the real function.
-    // Conservative reject.
     const { publicClient, walletClient } = mockClients();
     const realRevert = {
       cause: {
@@ -348,7 +326,7 @@ describe("Uploader", () => {
     };
     publicClient.simulateContract.mockImplementation(
       ({ functionName }: { functionName: string }) =>
-        functionName === "__cdrSentinelProbeNoImpl__"
+        functionName === SENTINEL_CONDITION_FUNCTION
           ? Promise.resolve({ result: true, request: {} })
           : Promise.reject(realRevert),
     );
@@ -375,6 +353,83 @@ describe("Uploader", () => {
     expect(walletClient.writeContract).not.toHaveBeenCalled();
   });
 
+  it("allocate rejects when the real selector itself returns OK via a swallow-all fallback", async () => {
+    const { publicClient, walletClient } = mockClients();
+    publicClient.simulateContract.mockResolvedValue({ result: true, request: {} });
+
+    const uploader = new Uploader({
+      network: "testnet",
+      publicClient,
+      walletClient,
+      observer: fakeObserver(),
+    });
+
+    await expect(
+      uploader.allocate({
+        updatable: false,
+        writeConditionAddr: "0x1111111111111111111111111111111111111111",
+        readConditionAddr: "0x2222222222222222222222222222222222222222",
+        writeConditionData: "0x",
+        readConditionData: "0x",
+      }),
+    ).rejects.toMatchObject({
+      code: "INVALID_CONDITION_CONTRACT",
+      reason: "ambiguous-fallback",
+    });
+    expect(walletClient.writeContract).not.toHaveBeenCalled();
+  });
+
+  it("allocate surfaces a transport error from the sentinel probe instead of masking it as ambiguous", async () => {
+    const { publicClient, walletClient } = mockClients();
+    publicClient.simulateContract.mockImplementation(
+      ({ functionName }: { functionName: string }) =>
+        functionName === SENTINEL_CONDITION_FUNCTION
+          ? Promise.reject(new Error("HTTP request failed"))
+          : Promise.resolve({ result: true, request: {} }),
+    );
+
+    const uploader = new Uploader({
+      network: "testnet",
+      publicClient,
+      walletClient,
+      observer: fakeObserver(),
+    });
+
+    await expect(
+      uploader.allocate({
+        updatable: false,
+        writeConditionAddr: "0x1111111111111111111111111111111111111111",
+        readConditionAddr: "0x2222222222222222222222222222222222222222",
+        writeConditionData: "0x",
+        readConditionData: "0x",
+      }),
+    ).rejects.toThrow("HTTP request failed");
+    expect(walletClient.writeContract).not.toHaveBeenCalled();
+  });
+
+  it("allocate surfaces a transport error from the real probe instead of masking it as invalid", async () => {
+    const { publicClient, walletClient } = mockClients();
+    publicClient.simulateContract.mockRejectedValue(new Error("RPC timeout"));
+
+    const uploader = new Uploader({
+      network: "testnet",
+      publicClient,
+      walletClient,
+      observer: fakeObserver(),
+    });
+
+    await expect(
+      uploader.allocate({
+        updatable: false,
+        writeConditionAddr: "0x1111111111111111111111111111111111111111",
+        readConditionAddr: "0x2222222222222222222222222222222222222222",
+        writeConditionData: "0x",
+        readConditionData: "0x",
+      }),
+    ).rejects.toThrow("RPC timeout");
+    expect(walletClient.writeContract).not.toHaveBeenCalled();
+  });
+
   it("allocate preflight probes condition contracts with the 4-arg signature", async () => {
     const { publicClient, walletClient } = mockClients();
     publicClient.readContract.mockResolvedValueOnce(1000n);
@@ -398,12 +453,19 @@ describe("Uploader", () => {
       readConditionData: "0x",
     });
 
-    // Once per side. The exact signature matters: regressing to the 3-arg
-    // form would silently misalign with deployed condition contracts.
-    expect(publicClient.simulateContract).toHaveBeenCalledTimes(2);
-    for (const call of publicClient.simulateContract.mock.calls) {
-      const { abi, functionName, args } = call[0];
-      expect(["checkWriteCondition", "checkReadCondition"]).toContain(functionName);
+    const calls = publicClient.simulateContract.mock.calls.map((c: any[]) => c[0]);
+    const realCalls = calls.filter(
+      (c: any) => c.functionName !== SENTINEL_CONDITION_FUNCTION,
+    );
+    const sentinelCalls = calls.filter(
+      (c: any) => c.functionName === SENTINEL_CONDITION_FUNCTION,
+    );
+    expect(realCalls).toHaveLength(2);
+    expect(realCalls.map((c: any) => c.functionName).sort()).toEqual([
+      "checkReadCondition",
+      "checkWriteCondition",
+    ]);
+    for (const { abi, args } of realCalls) {
       expect(abi[0].inputs).toEqual([
         { name: "uuid", type: "uint32" },
         { name: "accessAuxData", type: "bytes" },
@@ -412,6 +474,7 @@ describe("Uploader", () => {
       ]);
       expect(args).toHaveLength(4);
     }
+    expect(sentinelCalls).toHaveLength(2);
   });
 
   it("write sends tx with correct fee", async () => {

--- a/packages/sdk/__tests__/uploader.test.ts
+++ b/packages/sdk/__tests__/uploader.test.ts
@@ -9,7 +9,7 @@ vi.mock("@piplabs/cdr-crypto", () => ({
 
 import { Uploader } from "../src/uploader.js";
 import { tdh2Encrypt } from "@piplabs/cdr-crypto";
-import { ContentSizeExceededError } from "../src/errors.js";
+import { ContentSizeExceededError, InvalidConditionContractError } from "../src/errors.js";
 import type { Observer } from "../src/observer.js";
 
 /**
@@ -140,6 +140,114 @@ describe("Uploader", () => {
     expect(callArgs.value).toBe(500n);
     expect(publicClient.readContract).not.toHaveBeenCalled();
     expect(result.uuid).toBe(7);
+  });
+
+  it("allocate rejects when condition contract does not implement the check function", async () => {
+    // Empty revert payload from a `ContractFunctionRevertedError` is the EVM
+    // dispatcher's fallback signal — the function selector was not routed.
+    // This is the case the previous (buggy) preflight silently accepted.
+    const { publicClient, walletClient } = mockClients();
+    publicClient.simulateContract.mockRejectedValue({
+      cause: { name: "ContractFunctionRevertedError", raw: "0x" },
+    });
+
+    const uploader = new Uploader({
+      network: "testnet",
+      publicClient,
+      walletClient,
+      observer: fakeObserver(),
+    });
+
+    await expect(
+      uploader.allocate({
+        updatable: false,
+        writeConditionAddr: "0x1111111111111111111111111111111111111111",
+        readConditionAddr: "0x2222222222222222222222222222222222222222",
+        writeConditionData: "0x",
+        readConditionData: "0x",
+      }),
+    ).rejects.toThrow(InvalidConditionContractError);
+
+    // Short-circuits before allocate would have been broadcast.
+    expect(walletClient.writeContract).not.toHaveBeenCalled();
+  });
+
+  it("allocate accepts when condition function body reverts with non-empty data", async () => {
+    // Function exists and reverted with an Error(string) payload —
+    // selector 0x08c379a0 + abi-encoded "demo". The preflight treats any
+    // non-empty revert payload as "selector found, body ran."
+    const { publicClient, walletClient } = mockClients();
+    publicClient.simulateContract.mockRejectedValue({
+      cause: {
+        name: "ContractFunctionRevertedError",
+        raw:
+          "0x08c379a0" +
+          "0000000000000000000000000000000000000000000000000000000000000020" +
+          "0000000000000000000000000000000000000000000000000000000000000004" +
+          "64656d6f00000000000000000000000000000000000000000000000000000000",
+      },
+    });
+    publicClient.readContract.mockResolvedValueOnce(1000n);
+    walletClient.writeContract.mockResolvedValueOnce("0xtxhash" as `0x${string}`);
+    publicClient.waitForTransactionReceipt.mockResolvedValueOnce({
+      logs: [makeVaultAllocatedLog(99)],
+    });
+
+    const uploader = new Uploader({
+      network: "testnet",
+      publicClient,
+      walletClient,
+      observer: fakeObserver(),
+    });
+
+    const result = await uploader.allocate({
+      updatable: false,
+      writeConditionAddr: "0x1111111111111111111111111111111111111111",
+      readConditionAddr: "0x2222222222222222222222222222222222222222",
+      writeConditionData: "0x",
+      readConditionData: "0x",
+    });
+
+    expect(result.uuid).toBe(99);
+  });
+
+  it("allocate preflight probes condition contracts with the 4-arg signature", async () => {
+    const { publicClient, walletClient } = mockClients();
+    publicClient.readContract.mockResolvedValueOnce(1000n);
+    walletClient.writeContract.mockResolvedValueOnce("0xtxhash" as `0x${string}`);
+    publicClient.waitForTransactionReceipt.mockResolvedValueOnce({
+      logs: [makeVaultAllocatedLog(1)],
+    });
+
+    const uploader = new Uploader({
+      network: "testnet",
+      publicClient,
+      walletClient,
+      observer: fakeObserver(),
+    });
+
+    await uploader.allocate({
+      updatable: false,
+      writeConditionAddr: "0x1111111111111111111111111111111111111111",
+      readConditionAddr: "0x2222222222222222222222222222222222222222",
+      writeConditionData: "0x",
+      readConditionData: "0x",
+    });
+
+    // Once per side. The exact signature matters: regressing to the 3-arg
+    // form would silently misalign with deployed condition contracts.
+    expect(publicClient.simulateContract).toHaveBeenCalledTimes(2);
+    for (const call of publicClient.simulateContract.mock.calls) {
+      const { abi, functionName, args } = call[0];
+      expect(["checkWriteCondition", "checkReadCondition"]).toContain(functionName);
+      expect(abi[0].inputs).toEqual([
+        { name: "uuid", type: "uint32" },
+        { name: "accessAuxData", type: "bytes" },
+        { name: "conditionData", type: "bytes" },
+        { name: "caller", type: "address" },
+      ]);
+      expect(args).toHaveLength(4);
+    }
   });
 
   it("write sends tx with correct fee", async () => {

--- a/packages/sdk/src/errors.ts
+++ b/packages/sdk/src/errors.ts
@@ -73,7 +73,7 @@ export class InvalidConditionContractError extends CDRError {
   ) {
     const detail =
       reason === "ambiguous-fallback"
-        ? "preflight conservatively rejected: contract has a non-empty-revert fallback that shadows the selector check. If the contract is correct, pass `skipConditionValidation: true` to bypass this preflight"
+        ? "preflight conservatively rejected: a catch-all fallback answered an unknown selector by returning a value or reverting with data. If the contract is correct, pass `skipConditionValidation: true` to bypass this preflight"
         : "does not implement the required interface";
     super(
       `${type} condition contract at ${address} ${detail}`,

--- a/packages/sdk/src/errors.ts
+++ b/packages/sdk/src/errors.ts
@@ -60,12 +60,26 @@ export class RpcConsensusError extends CDRError {
   }
 }
 
+export type InvalidConditionContractReason =
+  | "selector-miss"
+  | "ambiguous-fallback";
+
 export class InvalidConditionContractError extends CDRError {
-  constructor(address: string, type: "write" | "read") {
+  readonly reason: InvalidConditionContractReason;
+  constructor(
+    address: string,
+    type: "write" | "read",
+    reason: InvalidConditionContractReason = "selector-miss",
+  ) {
+    const detail =
+      reason === "ambiguous-fallback"
+        ? "preflight conservatively rejected: contract has a non-empty-revert fallback that shadows the selector check. If the contract is correct, pass `skipConditionValidation: true` to bypass this preflight"
+        : "does not implement the required interface";
     super(
-      `${type} condition contract at ${address} does not implement the required interface`,
+      `${type} condition contract at ${address} ${detail}`,
       "INVALID_CONDITION_CONTRACT",
     );
+    this.reason = reason;
   }
 }
 

--- a/packages/sdk/src/uploader.ts
+++ b/packages/sdk/src/uploader.ts
@@ -393,6 +393,7 @@ export class Uploader {
         functionName,
         args: [0, dummyBytes, dummyBytes, zeroAddr],
       });
+      return;
     } catch (e: any) {
       // Function exists iff the call reverted with a non-empty revert payload
       // (Error string, custom error, Panic, etc.). An empty `0x` revert is
@@ -400,10 +401,68 @@ export class Uploader {
       // ContractFunctionZeroDataError (EOA / no code at all) and any other
       // error surface as invalid too.
       const cause = e?.cause;
-      if (cause?.name === "ContractFunctionRevertedError" && cause.raw !== "0x") {
-        return;
+      const realRevertedWithPayload =
+        cause?.name === "ContractFunctionRevertedError" &&
+        typeof cause.raw === "string" &&
+        cause.raw !== "0x";
+      if (!realRevertedWithPayload) {
+        throw new InvalidConditionContractError(address, type);
       }
-      throw new InvalidConditionContractError(address, type);
+    }
+
+    // Real selector reverted with payload — could be the function body OR a
+    // payload-reverting fallback (e.g. EIP-2535 Diamond's
+    // `Diamond_FunctionDoesNotExist()`). Probe a sentinel selector that no
+    // real condition contract implements; if it ALSO reverts non-empty, we
+    // cannot tell the payload came from our function rather than the
+    // fallback, and conservatively reject. Users with this code shape can
+    // opt out via `skipConditionValidation: true`.
+    const sentinelClean = await this.sentinelProbeIsEmpty(address);
+    if (!sentinelClean) {
+      throw new InvalidConditionContractError(
+        address,
+        type,
+        "ambiguous-fallback",
+      );
+    }
+  }
+
+  private async sentinelProbeIsEmpty(
+    address: `0x${string}`,
+  ): Promise<boolean> {
+    // A fake function name no condition contract would implement; its
+    // selector (keccak256("__cdrSentinelProbeNoImpl__()")[:4]) is
+    // effectively random over the 4-byte space, so collision with a real
+    // selector is astronomically unlikely.
+    const sentinelAbi = [
+      {
+        type: "function" as const,
+        name: "__cdrSentinelProbeNoImpl__",
+        inputs: [],
+        outputs: [{ name: "", type: "bool" }],
+        stateMutability: "view" as const,
+      },
+    ];
+    try {
+      await this.publicClient.simulateContract({
+        address,
+        abi: sentinelAbi,
+        functionName: "__cdrSentinelProbeNoImpl__",
+      });
+      // Returned OK on a fabricated selector → swallow-all fallback. Treat
+      // as not-empty so the caller rejects conservatively.
+      return false;
+    } catch (sErr: any) {
+      const sCause = sErr?.cause;
+      if (sCause?.name === "ContractFunctionZeroDataError") return true;
+      if (
+        sCause?.name === "ContractFunctionRevertedError" &&
+        typeof sCause.raw === "string" &&
+        sCause.raw === "0x"
+      ) {
+        return true;
+      }
+      return false;
     }
   }
 

--- a/packages/sdk/src/uploader.ts
+++ b/packages/sdk/src/uploader.ts
@@ -369,30 +369,39 @@ export class Uploader {
       type: "function" as const,
       name: functionName,
       inputs: [
-        { name: "caller", type: "address" },
-        { name: "conditionData", type: "bytes" },
+        { name: "uuid", type: "uint32" },
         { name: "accessAuxData", type: "bytes" },
+        { name: "conditionData", type: "bytes" },
+        { name: "caller", type: "address" },
       ],
       outputs: [{ name: "", type: "bool" }],
       stateMutability: "view" as const,
     }];
+
+    // Zero-padded dummy bytes (256 bytes each) so well-formed conditions can
+    // run their body to completion under abi.decode of common shapes and
+    // return a value, rather than reverting on truncated input. That keeps
+    // the empty-revert-data signal specific to "selector not found on this
+    // contract" (dispatcher fallback path).
+    const dummyBytes = `0x${"00".repeat(256)}` as `0x${string}`;
+    const zeroAddr = "0x0000000000000000000000000000000000000000" as `0x${string}`;
 
     try {
       await this.publicClient.simulateContract({
         address,
         abi: conditionAbi,
         functionName,
-        args: [
-          "0x0000000000000000000000000000000000000000",
-          "0x",
-          "0x",
-        ],
+        args: [0, dummyBytes, dummyBytes, zeroAddr],
       });
     } catch (e: any) {
-      // A revert inside the function body means the function exists — contract is valid.
-      // Only throw if the function selector itself is missing (zero data / execution error).
-      if (e?.cause?.name === "ContractFunctionRevertedError") {
-        return; // Function exists but reverted with dummy args — expected
+      // Function exists iff the call reverted with a non-empty revert payload
+      // (Error string, custom error, Panic, etc.). An empty `0x` revert is
+      // the EVM dispatcher fallback path — the selector isn't routed.
+      // ContractFunctionZeroDataError (EOA / no code at all) and any other
+      // error surface as invalid too.
+      const cause = e?.cause;
+      if (cause?.name === "ContractFunctionRevertedError" && cause.raw !== "0x") {
+        return;
       }
       throw new InvalidConditionContractError(address, type);
     }

--- a/packages/sdk/src/uploader.ts
+++ b/packages/sdk/src/uploader.ts
@@ -6,6 +6,8 @@ import { ContentSizeExceededError, LabelMismatchError, InvalidConditionContractE
 import type { StorageProvider } from "./storage/types.js";
 import { Observer } from "./observer.js";
 
+const SENTINEL_CONDITION_FUNCTION = "__cdrSentinelProbeNoImpl__";
+
 export class Uploader {
   private publicClient: PublicClient;
   private walletClient: WalletClient;
@@ -378,11 +380,7 @@ export class Uploader {
       stateMutability: "view" as const,
     }];
 
-    // Zero-padded dummy bytes (256 bytes each) so well-formed conditions can
-    // run their body to completion under abi.decode of common shapes and
-    // return a value, rather than reverting on truncated input. That keeps
-    // the empty-revert-data signal specific to "selector not found on this
-    // contract" (dispatcher fallback path).
+    // Keep dummy bytes ABI-decodable so empty reverts remain a selector-miss signal.
     const dummyBytes = `0x${"00".repeat(256)}` as `0x${string}`;
     const zeroAddr = "0x0000000000000000000000000000000000000000" as `0x${string}`;
 
@@ -393,31 +391,28 @@ export class Uploader {
         functionName,
         args: [0, dummyBytes, dummyBytes, zeroAddr],
       });
-      return;
     } catch (e: any) {
-      // Function exists iff the call reverted with a non-empty revert payload
-      // (Error string, custom error, Panic, etc.). An empty `0x` revert is
-      // the EVM dispatcher fallback path — the selector isn't routed.
-      // ContractFunctionZeroDataError (EOA / no code at all) and any other
-      // error surface as invalid too.
       const cause = e?.cause;
       const realRevertedWithPayload =
         cause?.name === "ContractFunctionRevertedError" &&
         typeof cause.raw === "string" &&
         cause.raw !== "0x";
+      // Payload reverts are still ambiguous until the sentinel proves unknown
+      // selectors miss cleanly.
       if (!realRevertedWithPayload) {
-        throw new InvalidConditionContractError(address, type);
+        if (
+          cause?.name === "ContractFunctionRevertedError" ||
+          cause?.name === "ContractFunctionZeroDataError"
+        ) {
+          throw new InvalidConditionContractError(address, type);
+        }
+        throw e;
       }
     }
 
-    // Real selector reverted with payload — could be the function body OR a
-    // payload-reverting fallback (e.g. EIP-2535 Diamond's
-    // `Diamond_FunctionDoesNotExist()`). Probe a sentinel selector that no
-    // real condition contract implements; if it ALSO reverts non-empty, we
-    // cannot tell the payload came from our function rather than the
-    // fallback, and conservatively reject. Users with this code shape can
-    // opt out via `skipConditionValidation: true`.
-    const sentinelClean = await this.sentinelProbeIsEmpty(address);
+    // Success and payload reverts can both come from catch-all fallbacks.
+    // Trust the real selector only after an unknown selector cleanly misses.
+    const sentinelClean = await this.sentinelProbeCleanlyMisses(address);
     if (!sentinelClean) {
       throw new InvalidConditionContractError(
         address,
@@ -427,17 +422,14 @@ export class Uploader {
     }
   }
 
-  private async sentinelProbeIsEmpty(
+  private async sentinelProbeCleanlyMisses(
     address: `0x${string}`,
   ): Promise<boolean> {
-    // A fake function name no condition contract would implement; its
-    // selector (keccak256("__cdrSentinelProbeNoImpl__()")[:4]) is
-    // effectively random over the 4-byte space, so collision with a real
-    // selector is astronomically unlikely.
+    // True means the unknown selector missed cleanly; false means a fallback answered it.
     const sentinelAbi = [
       {
         type: "function" as const,
-        name: "__cdrSentinelProbeNoImpl__",
+        name: SENTINEL_CONDITION_FUNCTION,
         inputs: [],
         outputs: [{ name: "", type: "bool" }],
         stateMutability: "view" as const,
@@ -447,10 +439,8 @@ export class Uploader {
       await this.publicClient.simulateContract({
         address,
         abi: sentinelAbi,
-        functionName: "__cdrSentinelProbeNoImpl__",
+        functionName: SENTINEL_CONDITION_FUNCTION,
       });
-      // Returned OK on a fabricated selector → swallow-all fallback. Treat
-      // as not-empty so the caller rejects conservatively.
       return false;
     } catch (sErr: any) {
       const sCause = sErr?.cause;
@@ -462,7 +452,14 @@ export class Uploader {
       ) {
         return true;
       }
-      return false;
+      if (
+        sCause?.name === "ContractFunctionRevertedError" &&
+        typeof sCause.raw === "string" &&
+        sCause.raw !== "0x"
+      ) {
+        return false;
+      }
+      throw sErr;
     }
   }
 


### PR DESCRIPTION
Closes #95.

Fixes the two related bugs in #95: stale 3-arg condition signature in `docs/CONDITIONS.md`, and a `validateConditionContract` preflight that silently accepts any contract with bytecode (including ones that don't implement the function).

## Summary of Changes

- **`docs/CONDITIONS.md`** — every signature (Expected Interface block, parameter table, narrative, and all four example contracts: `OpenCondition`, `OwnerCondition`, `TokenGateCondition`, `MerkleCondition`) now uses the canonical 4-arg form `(uint32 uuid, bytes accessAuxData, bytes conditionData, address caller)`. Matches the `ICDRReadCondition` / `ICDRWriteCondition` interfaces in `piplabs/story` and the deployed `LicenseReadCondition` / `OwnerWriteCondition` on Aeneid.
- **`packages/sdk/src/uploader.ts`** — `validateConditionContract` now:
  - probes with the 4-arg ABI (correct selector — `0x8db3eb17` for read, `0x5645dbbf` for write);
  - tightens the catch to require `cause.raw !== "0x"` on `ContractFunctionRevertedError`, so an empty-data dispatcher fallback revert (selector miss) is correctly classified invalid.

## Notes on the implementation vs. the snippet in #95

Two empirical findings during implementation that the issue snippet doesn't account for — flagging here:

1. **Dummy `args` need non-empty bytes, not `"0x"`.** The issue suggests `args: [0, "0x", "0x", zeroAddr]`. Probed against the canonical `LicenseReadCondition` on Aeneid, that produces a `ContractFunctionRevertedError` with `cause.raw === "0x"` — because the body's `abi.decode(conditionData, (address, address))` reverts on truncated input via a low-level `revert(0,0)`. That's indistinguishable from a selector miss. This PR passes 256-byte zero buffers for each `bytes` arg so the body decodes successfully and either returns a value or reverts with non-empty payload, keeping the empty-`raw` signal specific to dispatcher fallback. The issue's "known caveat" about bare `revert()` applies more broadly than written.

2. **`cause.raw` is the populated field; `cause.data` is `undefined`.** The issue's snippet uses `cause.raw ?? cause.data`. On the viem version in this repo, `cause.data` is undefined for `ContractFunctionRevertedError` — `cause.raw` is the only relevant field. Implementation just keys off `cause.raw`.

## Test coverage

Three unit tests added in `packages/sdk/__tests__/uploader.test.ts`:

- `allocate rejects when condition contract does not implement the check function` — mocks `cause.raw === "0x"` (the dispatcher-fallback signal). This is the case the buggy preflight silently let through.
- `allocate accepts when condition function body reverts with non-empty data` — mocks a real `Error("demo")` revert payload (`0x08c379a0...`). Function exists → preflight passes.
- `allocate preflight probes condition contracts with the 4-arg signature` — deep-equals the ABI inputs to pin the canonical 4-arg shape and order. Catches any drift back to a 3-arg ABI or a permuted 4-arg form that would yield a different selector.

**Existing tests preserved:**
- All 9 prior `__tests__/uploader.test.ts` tests still pass (the file is now 12 tests).
- Integration tests asserting EOA rejection by default (`uploader.test.ts` "default policy rejects EOA…", `security.test.ts` SEC-06) continue to behave identically: the EOA path produces `ContractFunctionZeroDataError`, which falls through the new catch's `name` check to `throw InvalidConditionContractError`.
- Integration tests for the `skipConditionValidation: true` escape hatch are upstream of the preflight and unaffected.
- Suite total: 186 passed, 23 skipped (was 183 / 23).

## Known limitation

A condition contract whose function body uses a bare `revert()` (no message, no custom error) produces empty revert data and would still be mis-classified as selector miss. Real contracts virtually always use `require("...")` or a custom error; flagging here per #95's note.