### PR TITLE
docs: reshape root README for SDK consumers — install matrix, slim Development, Quick start apiUrl

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,19 @@ when a quorum of validators provide partial decryptions.
 
 ## Install
 
+Each package is published to npm and can be installed independently:
+
+| Package | Install | Description |
+|---|---|---|
+| [`@piplabs/cdr-sdk`](./packages/sdk) | `npm i @piplabs/cdr-sdk` | Main SDK — `CDRClient`, `Observer`, `Uploader`, `Consumer` |
+| [`@piplabs/cdr-contracts`](./packages/contracts) | `npm i @piplabs/cdr-contracts` | Contract ABIs and network addresses |
+| [`@piplabs/cdr-crypto`](./packages/crypto) | `npm i @piplabs/cdr-crypto` | TDH2 encryption, ECIES decryption, WASM loader |
+| [`@piplabs/cdr-cli`](./apps/cli) | `npm i -g @piplabs/cdr-cli` | Command-line interface |
+
+Most consumers only need `@piplabs/cdr-sdk` — it re-exports everything
+relevant from `cdr-crypto` and `cdr-contracts`. Install `viem` as a peer
+dependency:
+
 ```bash
 pnpm add @piplabs/cdr-sdk viem
 # Optional storage adapters (only the one you'll use):
@@ -136,16 +149,6 @@ Two condition contracts are deployed on Aeneid testnet:
 | LicenseReadCondition | `0xC0640AD4CF2CaA9914C8e5C44234359a9102f7a3` | Only Story Protocol license holders can read |
 
 See [Condition Contracts](./docs/CONDITIONS.md) for the interface spec, more examples, and usage details.
-
-## Packages
-
-| Package | Description |
-|---------|-------------|
-| [`@piplabs/cdr-sdk`](./packages/sdk) | Main SDK — `CDRClient`, `Observer`, `Uploader`, `Consumer` |
-| [`@piplabs/cdr-contracts`](./packages/contracts) | Contract ABIs and network addresses |
-| [`@piplabs/cdr-crypto`](./packages/crypto) | TDH2 encryption, ECIES decryption, WASM loader |
-| [`@piplabs/cdr-cli`](./apps/cli) | Command-line interface |
-| [`@piplabs/cdr-examples`](./apps/examples) | Example scripts |
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -160,99 +160,14 @@ pnpm build
 pnpm test
 ```
 
-### Unit Tests
-
-`pnpm test` runs all unit tests (excludes `__integration__/`). For filtering:
-
-```bash
-# filters require running from packages/sdk (turbo doesn't forward args at the root)
-cd packages/sdk
-
-pnpm test story-api                  # file path substring
-pnpm test story-api -t "round-trip"  # also by `it` name
-
-pnpm exec vitest                     # watch mode (all)
-pnpm exec vitest story-api           # watch + path filter
-```
-
-`pnpm test:coverage` produces a coverage report.
-
-### Integration Tests
-
-Integration tests in `packages/sdk/__integration__/` exercise the Story-API REST client (`packages/sdk/src/story-api/`) against a live endpoint. They are excluded from the default `pnpm test` and run via a separate command.
-
-Setup (one-time, after cloning):
-
-```bash
-cp .env.local.example .env.local
-$EDITOR .env.local
-# Required for the full suite:
-#   CDR_API_URL           Story-API REST URL (port 1317)
-#   CDR_RPC_URL           EVM JSON-RPC URL on the same chain (port 8545)
-#   CDR_TEST_PRIVATE_KEY  Funded test-wallet private key (0x-prefixed hex)
-# Only `story-api.test.ts` can run with `CDR_API_URL` alone; every other
-# test file throws at module-load time if any of the three is missing.
-```
-
-Run:
-
-```bash
-# all integration tests (from monorepo root or packages/sdk)
-pnpm test:integration
-
-# only one test file — substring match against test paths (from packages/sdk)
-cd packages/sdk
-pnpm test:integration story-api
-
-# only one test case within a file (from packages/sdk)
-pnpm test:integration story-api -t "queryCDRPartials"
-
-# temporarily override the endpoint without editing .env.local
-CDR_API_URL=<your-story-api-url> pnpm test:integration
-```
-
-Path / `-t` filters only work when running from `packages/sdk` directly (`turbo` doesn't forward extra args at the monorepo root).
-
-`.env.local` is gitignored; `.env.local.example` documents the variables. Missing any of `CDR_API_URL` / `CDR_RPC_URL` / `CDR_TEST_PRIVATE_KEY` hard-fails the suite at module-load time with a clear error.
-
-| Endpoint | Aeneid (testnet) |
-|---|---|
-| Story-API REST | `http://172.192.41.96:1317` |
-| EVM RPC | `https://aeneid.storyrpc.io` |
-
-### Running Examples
-
-All examples read `CDR_API_URL` + `CDR_RPC_URL` from env. Tx-sending
-examples (`upload` / `access` / `e2e`) additionally need
-`CDR_TEST_PRIVATE_KEY`. Easiest is to export them once, then each
-command line only has to spell out what's specific to that script:
-
-```bash
-export CDR_API_URL=http://172.192.41.96:1317           # Story-API REST
-export CDR_RPC_URL=https://aeneid.storyrpc.io          # EVM JSON-RPC
-export CDR_TEST_PRIVATE_KEY=0xYOUR_KEY                 # required for upload/access/e2e
-
-# Query DKG state (no wallet needed)
-pnpm --filter @piplabs/cdr-examples query
-
-# Upload encrypted data
-WRITE_CONDITION=0x... READ_CONDITION=0x... \
-  pnpm --filter @piplabs/cdr-examples upload
-
-# Access and decrypt a vault (replace with a uuid the wallet can read)
-VAULT_UUID=1 \
-  pnpm --filter @piplabs/cdr-examples access
-
-# Full end-to-end demo (upload + access in one script)
-WRITE_CONDITION=0x... READ_CONDITION=0x... \
-  pnpm --filter @piplabs/cdr-examples e2e
-```
+For unit + integration test setup and the workspace examples runner, see [`docs/DEVELOPMENT.md`](./docs/DEVELOPMENT.md).
 
 ## Documentation
 
 - **[User Guide](./USER_GUIDE.md)** — Network configuration, API reference, examples, and error handling
 - **[Architecture](./docs/ARCHITECTURE.md)** — How CDR works end-to-end: DKG, threshold encryption, on-chain flow
 - **[Condition Contracts](./docs/CONDITIONS.md)** — Write and read access control: interface spec, deployed contracts, debugging
+- **[Development](./docs/DEVELOPMENT.md)** — Workspace setup, running unit + integration tests, executing example scripts
 - **[Changelog](./CHANGELOG.md)** — Release history
 
 ## License

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -1,0 +1,104 @@
+# Development
+
+Workspace setup, tests, and example scripts for `cdr-sdk` contributors.
+
+## Prerequisites
+
+- [pnpm](https://pnpm.io/) v9+
+- Node.js 18+
+
+## Setup
+
+```bash
+pnpm install
+pnpm build
+pnpm test
+```
+
+## Unit Tests
+
+`pnpm test` runs all unit tests (excludes `__integration__/`). For filtering:
+
+```bash
+# filters require running from packages/sdk (turbo doesn't forward args at the root)
+cd packages/sdk
+
+pnpm test story-api                  # file path substring
+pnpm test story-api -t "round-trip"  # also by `it` name
+
+pnpm exec vitest                     # watch mode (all)
+pnpm exec vitest story-api           # watch + path filter
+```
+
+`pnpm test:coverage` produces a coverage report.
+
+## Integration Tests
+
+Integration tests in `packages/sdk/__integration__/` exercise the Story-API REST client (`packages/sdk/src/story-api/`) against a live endpoint. They are excluded from the default `pnpm test` and run via a separate command.
+
+Setup (one-time, after cloning):
+
+```bash
+cp .env.local.example .env.local
+$EDITOR .env.local
+# Required for the full suite:
+#   CDR_API_URL           Story-API REST URL (port 1317)
+#   CDR_RPC_URL           EVM JSON-RPC URL on the same chain (port 8545)
+#   CDR_TEST_PRIVATE_KEY  Funded test-wallet private key (0x-prefixed hex)
+# Only `story-api.test.ts` can run with `CDR_API_URL` alone; every other
+# test file throws at module-load time if any of the three is missing.
+```
+
+Run:
+
+```bash
+# all integration tests (from monorepo root or packages/sdk)
+pnpm test:integration
+
+# only one test file — substring match against test paths (from packages/sdk)
+cd packages/sdk
+pnpm test:integration story-api
+
+# only one test case within a file (from packages/sdk)
+pnpm test:integration story-api -t "queryCDRPartials"
+
+# temporarily override the endpoint without editing .env.local
+CDR_API_URL=<your-story-api-url> pnpm test:integration
+```
+
+Path / `-t` filters only work when running from `packages/sdk` directly (`turbo` doesn't forward extra args at the monorepo root).
+
+`.env.local` is gitignored; `.env.local.example` documents the variables. Missing any of `CDR_API_URL` / `CDR_RPC_URL` / `CDR_TEST_PRIVATE_KEY` hard-fails the suite at module-load time with a clear error.
+
+| Endpoint | Aeneid (testnet) |
+|---|---|
+| Story-API REST | `http://172.192.41.96:1317` |
+| EVM RPC | `https://aeneid.storyrpc.io` |
+
+## Running Examples
+
+All examples read `CDR_API_URL` + `CDR_RPC_URL` from env. Tx-sending
+examples (`upload` / `access` / `e2e`) additionally need
+`CDR_TEST_PRIVATE_KEY`. Easiest is to export them once, then each
+command line only has to spell out what's specific to that script:
+
+```bash
+export CDR_API_URL=http://172.192.41.96:1317           # Story-API REST
+export CDR_RPC_URL=https://aeneid.storyrpc.io          # EVM JSON-RPC
+export CDR_TEST_PRIVATE_KEY=0xYOUR_KEY                 # required for upload/access/e2e
+
+# Query DKG state (no wallet needed)
+pnpm --filter @piplabs/cdr-examples query
+
+# Upload encrypted data
+WRITE_CONDITION=0x... READ_CONDITION=0x... \
+  pnpm --filter @piplabs/cdr-examples upload
+
+# Access and decrypt a vault (replace with a uuid the wallet can read)
+VAULT_UUID=1 \
+  pnpm --filter @piplabs/cdr-examples access
+
+# Full end-to-end demo (upload + access in one script)
+WRITE_CONDITION=0x... READ_CONDITION=0x... \
+  pnpm --filter @piplabs/cdr-examples e2e
+```

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -18,6 +18,21 @@ npm install @storacha/client                     # Storacha
 npm install @filoz/synapse-sdk                   # Filecoin via Synapse
 ```
 
+## Compatibility & known issues
+
+### Requirements
+
+- **Node.js ≥ 20.19** — transitive dependencies (`@noble/ciphers`, `@noble/hashes`) require this. Older Node versions install with `EBADENGINE` warnings; the SDK functions but the warning will be raised in the future. Tracked in [#98](https://github.com/piplabs/cdr-sdk/issues/98).
+- **ESM-only** — all `@piplabs/*` packages are `"type": "module"`. CommonJS consumers must use dynamic `import()`; plain `require()` returns `ERR_REQUIRE_ESM`. CJS dual-publish is under discussion in [#97](https://github.com/piplabs/cdr-sdk/issues/97).
+
+### Known issues queued for v0.2.2
+
+- `@piplabs/cdr-cli --version` reports a stale `0.1.2` — the CLI binary itself works correctly. See [#96](https://github.com/piplabs/cdr-sdk/issues/96).
+- `engines` field is not yet declared on any package — see [#98](https://github.com/piplabs/cdr-sdk/issues/98).
+- ESM-only packaging without an explicit `"exports"` field — see [#97](https://github.com/piplabs/cdr-sdk/issues/97).
+
+None of these affect SDK or CLI functionality. v0.2.1 was validated end-to-end on Aeneid (upload + access round-trip) prior to release.
+
 ## Quick start
 
 ```ts
@@ -32,6 +47,7 @@ const client = new CDRClient({
   network: "testnet",
   publicClient: createPublicClient({ transport: http("https://aeneid.storyrpc.io") }),
   walletClient: createWalletClient({ account, transport: http("https://aeneid.storyrpc.io") }),
+  apiUrl: "http://172.192.41.96:1317", // Story-API REST endpoint — see Networks table in repo README
 });
 
 const globalPubKey = await client.observer.getGlobalPubKey();

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -18,21 +18,6 @@ npm install @storacha/client                     # Storacha
 npm install @filoz/synapse-sdk                   # Filecoin via Synapse
 ```
 
-## Compatibility & known issues
-
-### Requirements
-
-- **Node.js ≥ 20.19** — transitive dependencies (`@noble/ciphers`, `@noble/hashes`) require this. Older Node versions install with `EBADENGINE` warnings; the SDK functions but the warning will be raised in the future. Tracked in [#98](https://github.com/piplabs/cdr-sdk/issues/98).
-- **ESM-only** — all `@piplabs/*` packages are `"type": "module"`. CommonJS consumers must use dynamic `import()`; plain `require()` returns `ERR_REQUIRE_ESM`. CJS dual-publish is under discussion in [#97](https://github.com/piplabs/cdr-sdk/issues/97).
-
-### Known issues queued for v0.2.2
-
-- `@piplabs/cdr-cli --version` reports a stale `0.1.2` — the CLI binary itself works correctly. See [#96](https://github.com/piplabs/cdr-sdk/issues/96).
-- `engines` field is not yet declared on any package — see [#98](https://github.com/piplabs/cdr-sdk/issues/98).
-- ESM-only packaging without an explicit `"exports"` field — see [#97](https://github.com/piplabs/cdr-sdk/issues/97).
-
-None of these affect SDK or CLI functionality. v0.2.1 was validated end-to-end on Aeneid (upload + access round-trip) prior to release.
-
 ## Quick start
 
 ```ts


### PR DESCRIPTION
## Summary

README cleanup pass after v0.2.1 ship. The root README had grown to mix consumer-facing material (Install, Quick Start, Networks, File Operations) with maintainer-facing material (full Unit + Integration test setup, per-example pnpm filter commands). This PR rebalances it toward SDK consumers and moves contributor detail into a dedicated doc.

## Changes

### 1. `README.md` — Install gains per-package install matrix

Folds the old `## Packages` table into `## Install` as a four-row matrix, one row per published package with its own `npm i` command, followed by the existing `pnpm add @piplabs/cdr-sdk viem` quick path for the common case. `@piplabs/cdr-examples` removed from the matrix since it is workspace-only and not published; it remains referenced in Development → Running Examples (now under `docs/DEVELOPMENT.md`).

### 2. `README.md` — Development section slimmed; full content moved to `docs/DEVELOPMENT.md`

`## Development` previously included ~90 lines covering `vitest` filter syntax, `.env.local` setup for integration tests, integration-test env-var requirements, the Aeneid endpoint table, and per-example pnpm filter commands. All contributor-facing.

Now it keeps only:
- Prerequisites (pnpm v9+, Node 18+)
- The three baseline commands (`pnpm install / build / test`)
- A pointer to `docs/DEVELOPMENT.md`

Full content moved verbatim into the new `docs/DEVELOPMENT.md` (zero information lost). Documentation index updated to link it next to ARCHITECTURE / CONDITIONS / RELEASING / CHANGELOG.

### 3. `packages/sdk/README.md` — restore `apiUrl` in Quick start

PR #73 made `apiUrl` a required `CDRClient` constructor field when the SDK moved to Story-API REST. PR #84 added it to the root README but missed the package-level one. Wording matches the root README's Networks-table reference.

## History

An earlier commit on this branch also added a "Compatibility & known issues" section to `packages/sdk/README.md` linking the three v0.2.1 polish issues (#96 / #97 / #98). Per maintainer review that block does not belong in the package README; those issues will be addressed directly in v0.2.2. The section was removed in 9500b1d.

## Net effect

| File | Change |
|---|---|
| `README.md` | -84 lines (257 → 173); install matrix added; Development slimmed |
| `docs/DEVELOPMENT.md` | new file, +104 lines (moved from README) |
| `packages/sdk/README.md` | +1 line (apiUrl in Quick start) |

## Test plan

- [x] v0.2.1 validated end-to-end on Aeneid using `@piplabs/cdr-sdk@0.2.1` from npm (uploadCDR + accessCDR vault round-trip succeeds)
- [x] Each `npm i @piplabs/...` command in the new Install matrix resolves on the public npm registry today
- [x] `@piplabs/cdr-examples` confirmed not published (workspace-only)
- [x] No content lost in the Development → docs/DEVELOPMENT.md move (verbatim copy)
- [x] Documentation index linked the new doc