### PR TITLE
feat(stress): per-wallet 3-op pipeline + 3-row perf-stats for 21-node plan

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -511,9 +511,14 @@ jobs:
                   end;
                 # Ordered list of (op_name, stats) pairs for this suite,
                 # filtered to only those present. Upload first if present.
+                # Stress emits separate accessShared + accessFresh rows
+                # (no accessMs); other suites emit a single access row
+                # from accessMs.
                 [
-                  (if .uploadMs != null then {op: "upload", lat: .uploadMs} else empty end),
-                  (if .accessMs != null then {op: "access", lat: .accessMs} else empty end)
+                  (if .uploadMs       != null then {op: "upload",          lat: .uploadMs}       else empty end),
+                  (if .accessMs       != null then {op: "access",          lat: .accessMs}       else empty end),
+                  (if .accessSharedMs != null then {op: "access (shared)", lat: .accessSharedMs} else empty end),
+                  (if .accessFreshMs  != null then {op: "access (fresh)",  lat: .accessFreshMs}  else empty end)
                 ] as $ops |
                 # Suite-level summary columns are emitted on row 0 only.
                 ([$ops | length] | add) as $n_ops |

--- a/packages/sdk/__integration__/_helpers.ts
+++ b/packages/sdk/__integration__/_helpers.ts
@@ -130,9 +130,15 @@ export interface LatencyStats {
   max_ms: number;
 }
 
-export function statsOf(samples: number[]): LatencyStats {
+export function statsOf(samples: number[]): LatencyStats | null {
+  // Empty samples → null, not zero-valued stats. Returning a "0ms across
+  // the board" object would let the workflow's perf-table jq (which
+  // gates on `!= null`) render rows reading "0ms" for every percentile,
+  // which a casual reader can misinterpret as a real (and suspiciously
+  // fast) latency rather than "no data". Forcing null here makes the
+  // zero-sample case skipped in the table, which is the truthful signal.
   if (samples.length === 0) {
-    return { count: 0, min_ms: 0, p50_ms: 0, mean_ms: 0, p95_ms: 0, p99_ms: 0, max_ms: 0 };
+    return null;
   }
   const sorted = [...samples].sort((a, b) => a - b);
   return {

--- a/packages/sdk/__integration__/_helpers.ts
+++ b/packages/sdk/__integration__/_helpers.ts
@@ -152,9 +152,11 @@ export function statsOf(samples: number[]): LatencyStats {
  * these files and renders one table row per file in the Step Summary, so
  * a single CI run lists every suite's latency distribution side by side.
  *
- * `accessMs` is always present; `uploadMs` is null for read-only suites
- * (e.g. 100w-shared, 1000w-perf). `refund` is null for suites that don't
- * sweep wallets (none today, but reserved).
+ * `accessMs` is present for suites that read a single uuid (100w-shared,
+ * 100w-fresh, 1000w-perf). `uploadMs` is null for read-only suites.
+ * The stress suite uses `accessSharedMs` + `accessFreshMs` instead of
+ * `accessMs` to separate same-uuid vs fresh-uuid read latency in one
+ * cycle. `refund` is null for suites that don't sweep wallets.
  */
 export interface PerfStatsFile {
   label: string;
@@ -166,6 +168,10 @@ export interface PerfStatsFile {
   accessMs: LatencyStats | null;
   uploadMs: LatencyStats | null;
   tickMs: LatencyStats | null;
+  /** Stress suite only: same-uuid read latency (validator cache benefit). */
+  accessSharedMs: LatencyStats | null;
+  /** Stress suite only: fresh-uuid read latency (no caching). */
+  accessFreshMs: LatencyStats | null;
   refund: {
     funded_wei: string;
     refunded_wei: string;

--- a/packages/sdk/__integration__/ephemeral-60min-stress.test.ts
+++ b/packages/sdk/__integration__/ephemeral-60min-stress.test.ts
@@ -400,6 +400,18 @@ describe.skipIf(skipUnlessSuite("1H-stress-devnet-only") || skipUnlessDevnet())(
                 }
 
                 // ----- PHASE 3: ACCESS own fresh vault (fresh-uuid read) -----
+                // The settlement window between Phase 1's write tx and
+                // this read is implicit — whatever Phase 2's shared
+                // read happened to take (typically 10-120s). When Phase
+                // 2 hits a hot validator cache it can return in just a
+                // few seconds, in which case `upload.uuid` may still be
+                // propagating across validators when this call fires.
+                // `ACCESS_TIMEOUT_MS` (120s) is LOAD-BEARING here: it's
+                // not a generic safety margin but the actual headroom
+                // accessCDR uses to poll until the new uuid lands. Do
+                // not shrink it without explicit fresh-uuid propagation
+                // benchmarks — a "fast" timeout would turn occasional
+                // hot-cache cycles into spurious failures.
                 const tFresh = Date.now();
                 const freshAccess = await w.client.consumer.accessCDR({
                   uuid: upload.uuid,

--- a/packages/sdk/__integration__/ephemeral-60min-stress.test.ts
+++ b/packages/sdk/__integration__/ephemeral-60min-stress.test.ts
@@ -7,14 +7,22 @@
  *
  * Pattern (1 hour total, **no artificial pacing**):
  *   1. Funder deploys an open-condition contract + uploads 1 shared CDR
- *      vault with a random dataKey.
+ *      vault with a random dataKey (the "old shared uuid" all wallets
+ *      will read every cycle).
  *   2. 10 ephemeral wallets, Multicall3 batch-funded with 1000 IP each
  *      (deliberately oversized — pipeline mode does hundreds of cycles
  *      per wallet over the hour).
- *   3. **Pipeline mode:** each wallet runs an independent async loop —
- *      `while (elapsed < 60min) { uploadCDR(fresh vault); accessCDR(shared); }` —
+ *   3. **Pipeline mode (3 ops per cycle):** each wallet runs an
+ *      independent async loop covering both read patterns —
+ *      `while (elapsed < 60min) {
+ *         uploadCDR(fresh vault);          // write fresh-uuid
+ *         accessCDR(sharedVault);          // read same-uuid (validator cache benefit)
+ *         accessCDR(ownFreshVault);        // read fresh-uuid (no caching)
+ *       }`
  *      with no sleep between cycles. 10 wallet loops in parallel via
- *      `Promise.all`. The chain + DKG path see steady back-to-back load.
+ *      `Promise.all`. Replaces the deleted Workflow A
+ *      (cdr-sdk-stress-test.yml) from the e2e repo — same-uuid +
+ *      fresh-uuid coverage in a single 1h run.
  *   4. **Soft failures:** a single cycle that throws (or recovers a
  *      mismatched dataKey on the shared vault) is recorded in a failure
  *      counter, but does NOT abort the wallet — the loop moves on to the
@@ -38,9 +46,11 @@
  * (`cdr-stress-log-<run_id>`).
  *
  * Perf-stats JSON: `/tmp/perf-stats-stress.json` is written in afterAll
- * with the `PerfStatsFile` shape (uploadMs, accessMs, refund summary,
- * extra.total_cycles / extra.failed_cycles), so the workflow's summary
- * step renders the same per-suite perf row as the 100w/1000w suites.
+ * with the `PerfStatsFile` shape (uploadMs, accessSharedMs, accessFreshMs,
+ * refund summary, extra.total_cycles / extra.failed_cycles). The
+ * workflow's summary step renders 3 perf rows for stress (upload +
+ * access (shared) + access (fresh)) so the latency gap between
+ * cached same-uuid reads and uncached fresh-uuid reads is visible.
  *
  * Run locally (DevNet only):
  *   pnpm test:stress
@@ -183,7 +193,7 @@ function logLine(line: string): void {
 }
 
 describe.skipIf(skipUnlessSuite("1H-stress-devnet-only") || skipUnlessDevnet())(
-  `60-min pipelined stress: ${CONCURRENCY} wallets upload+access loop on DevNet`,
+  `60-min pipelined stress: ${CONCURRENCY} wallets 3-op (upload + read shared + read fresh) loop on DevNet`,
   () => {
     let funderPublic: PublicClient;
     let funderWallet: WalletClient;
@@ -200,7 +210,8 @@ describe.skipIf(skipUnlessSuite("1H-stress-devnet-only") || skipUnlessDevnet())(
     // before reaching the workload).
     let perfBuffer: {
       uploadLats: number[];
-      accessLats: number[];
+      accessSharedLats: number[];
+      accessFreshLats: number[];
       totalCycles: number;
       failedCycles: number;
       wallClockMs: number;
@@ -303,7 +314,12 @@ describe.skipIf(skipUnlessSuite("1H-stress-devnet-only") || skipUnlessDevnet())(
           failed: perfBuffer.failedCycles,
           wall_clock_ms: perfBuffer.wallClockMs,
           uploadMs: statsOf(perfBuffer.uploadLats),
-          accessMs: statsOf(perfBuffer.accessLats),
+          // Stress emits 2 access rows (shared + fresh); accessMs is
+          // left null so the workflow's perf-table jq skips the
+          // unified single-access row branch for this suite.
+          accessMs: null,
+          accessSharedMs: statsOf(perfBuffer.accessSharedLats),
+          accessFreshMs: statsOf(perfBuffer.accessFreshLats),
           tickMs: null,
           refund: {
             funded_wei: totalFundedWei.toString(),
@@ -326,25 +342,27 @@ describe.skipIf(skipUnlessSuite("1H-stress-devnet-only") || skipUnlessDevnet())(
     }, 10 * 60 * 1000);
 
     it(
-      `${CONCURRENCY} wallets pipeline upload+access for 1h, no inter-cycle delay`,
+      `${CONCURRENCY} wallets pipeline upload + read(shared) + read(fresh) for 1h, no inter-cycle delay`,
       async () => {
         const startTime = Date.now();
         const uploadLats: number[] = [];
-        const accessLats: number[] = [];
+        const accessSharedLats: number[] = [];
+        const accessFreshLats: number[] = [];
         let totalCycles = 0;
         let failedCycles = 0;
 
         // Each wallet's loop is independent — Promise.all runs all 10 in
-        // parallel. Within a wallet the cycle is sequential (upload then
-        // access) so the wallet's nonce stream stays monotonic; across
-        // wallets there's no synchronization (no tick boundary).
+        // parallel. Within a wallet the cycle is strictly sequential
+        // (upload → read shared → read own fresh) so the wallet's nonce
+        // stream stays monotonic; across wallets there's no
+        // synchronization (no tick boundary, no phase barrier).
         await Promise.all(
           stressWallets.map(async (w, idx) => {
             let cycleIdx = 0;
             while (Date.now() - startTime < DURATION_MS) {
               cycleIdx++;
               try {
-                // ----- UPLOAD (own fresh vault) -----
+                // ----- PHASE 1: UPLOAD (own fresh vault) -----
                 const dataKey = crypto.getRandomValues(new Uint8Array(32));
                 const globalPubKey = await w.client.observer.getGlobalPubKey();
                 const tUpload = Date.now();
@@ -363,30 +381,51 @@ describe.skipIf(skipUnlessSuite("1H-stress-devnet-only") || skipUnlessDevnet())(
                   `[w[${idx}] cycle=${cycleIdx} UPLOAD ok] uuid=${upload.uuid} ${uploadDur}ms`,
                 );
 
-                // ----- ACCESS shared vault -----
-                const tAccess = Date.now();
-                const access = await w.client.consumer.accessCDR({
+                // ----- PHASE 2: ACCESS shared vault (same-uuid read) -----
+                const tShared = Date.now();
+                const sharedAccess = await w.client.consumer.accessCDR({
                   uuid: sharedVaultUuid,
                   accessAuxData: "0x",
                   timeoutMs: ACCESS_TIMEOUT_MS,
                 });
-                const accessDur = Date.now() - tAccess;
-                const ok = bytesEqual(access.dataKey, sharedDataKey);
+                const sharedDur = Date.now() - tShared;
+                const sharedOk = bytesEqual(sharedAccess.dataKey, sharedDataKey);
                 logLine(
-                  `[w[${idx}] cycle=${cycleIdx} ACCESS ${ok ? "ok" : "MISMATCH"}] uuid=${sharedVaultUuid} tx=${access.txHash} ${accessDur}ms`,
+                  `[w[${idx}] cycle=${cycleIdx} ACCESS_SHARED ${sharedOk ? "ok" : "MISMATCH"}] uuid=${sharedVaultUuid} tx=${sharedAccess.txHash} ${sharedDur}ms`,
                 );
-                if (!ok) {
+                if (!sharedOk) {
                   throw new Error(
                     `w[${idx}] cycle=${cycleIdx} dataKey mismatch on shared uuid=${sharedVaultUuid}`,
                   );
                 }
-                // Push BOTH latencies together — only when the full cycle
-                // succeeded end-to-end. Pushing uploadDur eagerly above
-                // would let partially-failed cycles' upload times bias
-                // the upload p50/p95, decoupling the two arrays from
-                // `totalCycles`. Reviewer caught this on PR #83.
+
+                // ----- PHASE 3: ACCESS own fresh vault (fresh-uuid read) -----
+                const tFresh = Date.now();
+                const freshAccess = await w.client.consumer.accessCDR({
+                  uuid: upload.uuid,
+                  accessAuxData: "0x",
+                  timeoutMs: ACCESS_TIMEOUT_MS,
+                });
+                const freshDur = Date.now() - tFresh;
+                const freshOk = bytesEqual(freshAccess.dataKey, dataKey);
+                logLine(
+                  `[w[${idx}] cycle=${cycleIdx} ACCESS_FRESH ${freshOk ? "ok" : "MISMATCH"}] uuid=${upload.uuid} tx=${freshAccess.txHash} ${freshDur}ms`,
+                );
+                if (!freshOk) {
+                  throw new Error(
+                    `w[${idx}] cycle=${cycleIdx} dataKey mismatch on fresh uuid=${upload.uuid}`,
+                  );
+                }
+
+                // Push ALL THREE latencies in lockstep — only when the
+                // full cycle (upload + read shared + read own fresh)
+                // succeeded end-to-end. Pushing eagerly per-phase would
+                // let partially-failed cycles bias one array's p50/p95
+                // and decouple lengths from `totalCycles`. Same fix as
+                // PR #83's 1b9a80d, extended to 3 arrays.
                 uploadLats.push(uploadDur);
-                accessLats.push(accessDur);
+                accessSharedLats.push(sharedDur);
+                accessFreshLats.push(freshDur);
                 totalCycles++;
               } catch (e) {
                 failedCycles++;
@@ -418,12 +457,14 @@ describe.skipIf(skipUnlessSuite("1H-stress-devnet-only") || skipUnlessDevnet())(
             100
           ).toFixed(2),
           upload: statsOf(uploadLats),
-          access: statsOf(accessLats),
+          access_shared: statsOf(accessSharedLats),
+          access_fresh: statsOf(accessFreshLats),
         };
         logLine(`[stress summary] ${JSON.stringify(stats)}`);
         perfBuffer = {
           uploadLats,
-          accessLats,
+          accessSharedLats,
+          accessFreshLats,
           totalCycles,
           failedCycles,
           wallClockMs,


### PR DESCRIPTION
## Summary

For the [21-Node DKG Expansion Test Plan](https://www.notion.so/storyprotocol/21-Node-DKG-Expansion-Test-Plan-35e051299a5481d18426d15cb642b3d6), the 60-min stress test is expanded to cover both read patterns in a single 1h run — replacing the deleted Workflow A (`story-cdr-e2e/cdr-sdk-stress-test.yml`).

## Locked decisions (Notion §7)

| | Decision |
|---|---|
| Cycle shape (Q1) | **Per-wallet pipeline** — each wallet runs its own `write → read shared → read fresh` loop independently; no synchronized phases across wallets |
| Perf-stats schema (Q2) | **3 rows per stress run** — `PerfStatsFile` gains `accessSharedMs` + `accessFreshMs` alongside the existing `uploadMs` |
| Stress duration | Unchanged 60 min |

## Files changed

- `packages/sdk/__integration__/ephemeral-60min-stress.test.ts` — per-cycle adds 3rd op (read own fresh uuid); 3 latency arrays tracked + pushed in lockstep
- `packages/sdk/__integration__/_helpers.ts` — `PerfStatsFile` interface extended with `accessSharedMs` + `accessFreshMs`; backward compatible (legacy `accessMs` retained for read-only suites)
- `.github/workflows/integration.yml` — `render_perf_table` jq emits 2 extra rows for stress (`access (shared)` + `access (fresh)`); other suites unaffected

## Verification done locally

- [x] `pnpm tsc --noEmit` passes for `packages/sdk`
- [x] `pnpm lint` passes
- [x] No stale `accessLats` references in the stress test
- [ ] Workflow not yet dispatched — **per request, holding for maintainer review before running**

## Network scope

**DevNet-only by design.** The stress suite gates on `skipUnlessDevnet()` (test side) and the workflow's prepare step hard-rejects `network != devnet` with `exit 1`. Reason: the test requires anvil-0 as funder for the 10 ephemeral wallets, which exists only on DevNet.

Aeneid coverage of the 21-node expansion comes from §5.0 perf snapshots (`batch-flood-perf.test.ts`) at each N, not from this stress test.

## How to dispatch when ready

```bash
gh workflow run integration.yml --repo piplabs/cdr-sdk \
  -f network=devnet \
  -f test_suite=1H-stress-devnet-only
```