### PR TITLE
test(integration): split 100w-fresh into devnet + aeneid variants, lock 1000w-perf to devnet

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -20,12 +20,12 @@ on:
         options:
           # default                 — functional (SDK/CLI/Examples) + 100w ephemeral
           # all                     — default + 1000w perf + 60min stress
-          # 1000-wallet-performance — ONLY ephemeral-1000w-perf.test.ts (strict isolation:
+          # 1000-wallet-performance-devnet-only — ONLY ephemeral-1000w-perf.test.ts (strict isolation:
           #                           no functional, no CLI, no Examples — clean perf signal)
           # 1H-stress-devnet-only   — ONLY ephemeral-60min-stress.test.ts (DevNet only)
           - default
           - all
-          - 1000-wallet-performance
+          - 1000-wallet-performance-devnet-only
           - 1H-stress-devnet-only
         default: default
   pull_request:
@@ -73,7 +73,7 @@ jobs:
           # `run_integration` / `run_stress` flags steer which step blocks
           # inside it run. There is no separate `stress` job anymore.
           case "$SUITE" in
-            default|1000-wallet-performance)
+            default|1000-wallet-performance-devnet-only)
               RUN_INTEGRATION=true
               RUN_STRESS=false ;;
             all)
@@ -95,15 +95,6 @@ jobs:
         if: ${{ steps.resolve.outputs.run_stress == 'true' && steps.resolve.outputs.network != 'devnet' }}
         run: |
           echo "::error::test_suite=${{ steps.resolve.outputs.test_suite }} requires network=devnet (got ${{ steps.resolve.outputs.network }})"
-          exit 1
-
-      - name: Validate (1000-wallet-performance is DevNet-only)
-        # 1000-way burst saturates any public RPC; the test gate inside the
-        # file also enforces this, but failing fast in `prepare` is friendlier
-        # than letting `integration` schedule a job that ends up all-skipped.
-        if: ${{ steps.resolve.outputs.test_suite == '1000-wallet-performance' && steps.resolve.outputs.network != 'devnet' }}
-        run: |
-          echo "::error::test_suite=1000-wallet-performance requires network=devnet (got ${{ steps.resolve.outputs.network }})"
           exit 1
 
       - name: Write run summary
@@ -139,9 +130,9 @@ jobs:
     runs-on: ubuntu-latest
     # Timeout sized to the heaviest suite in play. Stress alone is 60 min
     # wall time + ~15 min setup/teardown; `all` adds another 30-50 min
-    # for the 1000-wallet perf suite. `1000-wallet-performance` is 90 min
+    # for the 1000-wallet perf suite. `1000-wallet-performance-devnet-only` is 90 min
     # without stress.
-    timeout-minutes: ${{ needs.prepare.outputs.test_suite == 'all' && 180 || (needs.prepare.outputs.test_suite == '1H-stress-devnet-only' && 120 || (needs.prepare.outputs.test_suite == '1000-wallet-performance' && 90 || 60)) }}
+    timeout-minutes: ${{ needs.prepare.outputs.test_suite == 'all' && 180 || (needs.prepare.outputs.test_suite == '1H-stress-devnet-only' && 120 || (needs.prepare.outputs.test_suite == '1000-wallet-performance-devnet-only' && 90 || 60)) }}
     env:
       NETWORK: ${{ needs.prepare.outputs.network }}
       TEST_SUITE: ${{ needs.prepare.outputs.test_suite }}
@@ -213,7 +204,7 @@ jobs:
       # treats it as end-of-options and the `--outputFile.json=…` flag is
       # silently dropped.
       # Strict isolation for the perf-only suites:
-      #   - 1000-wallet-performance → SDK step runs ONLY the 1000w-perf file,
+      #   - 1000-wallet-performance-devnet-only → SDK step runs ONLY the 1000w-perf file,
       #     CLI + Examples steps skip entirely. Goal: clean perf signal
       #     without ~10 min of functional-test noise on the funder wallet.
       #   - default / all → SDK step runs everything (vitest's default glob),
@@ -228,7 +219,7 @@ jobs:
         run: |
           set -o pipefail
           INCLUDE_ARGS=()
-          if [ "$TEST_SUITE" = "1000-wallet-performance" ]; then
+          if [ "$TEST_SUITE" = "1000-wallet-performance-devnet-only" ]; then
             INCLUDE_ARGS=('__integration__/ephemeral-1000w-perf.test.ts')
           fi
           npx vitest run --no-file-parallelism \
@@ -242,7 +233,7 @@ jobs:
 
       - name: CLI integration
         id: cli
-        if: ${{ env.RUN_INTEGRATION == 'true' && env.TEST_SUITE != '1000-wallet-performance' }}
+        if: ${{ env.RUN_INTEGRATION == 'true' && env.TEST_SUITE != '1000-wallet-performance-devnet-only' }}
         working-directory: apps/cli
         run: |
           set -o pipefail
@@ -256,7 +247,7 @@ jobs:
 
       - name: Examples integration
         id: examples
-        if: ${{ env.RUN_INTEGRATION == 'true' && env.TEST_SUITE != '1000-wallet-performance' }}
+        if: ${{ env.RUN_INTEGRATION == 'true' && env.TEST_SUITE != '1000-wallet-performance-devnet-only' }}
         working-directory: apps/examples
         run: |
           set -o pipefail

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -97,6 +97,15 @@ jobs:
           echo "::error::test_suite=${{ steps.resolve.outputs.test_suite }} requires network=devnet (got ${{ steps.resolve.outputs.network }})"
           exit 1
 
+      - name: Validate (1000-wallet-performance is DevNet-only)
+        # 1000-way burst saturates any public RPC; the test gate inside the
+        # file also enforces this, but failing fast in `prepare` is friendlier
+        # than letting `integration` schedule a job that ends up all-skipped.
+        if: ${{ steps.resolve.outputs.test_suite == '1000-wallet-performance' && steps.resolve.outputs.network != 'devnet' }}
+        run: |
+          echo "::error::test_suite=1000-wallet-performance requires network=devnet (got ${{ steps.resolve.outputs.network }})"
+          exit 1
+
       - name: Write run summary
         if: always()
         # head_ref is attacker-controlled (any PR opener picks the

--- a/packages/sdk/__integration__/_ephemeral-wallets.ts
+++ b/packages/sdk/__integration__/_ephemeral-wallets.ts
@@ -24,6 +24,7 @@ import {
   type Chain,
   type Hex,
   type PublicClient,
+  type Transport,
   type WalletClient,
   createWalletClient,
   http,
@@ -173,6 +174,13 @@ export interface RefundResult {
  * the failure and continues. The reasoning: a single ephemeral wallet
  * being un-refundable (e.g. it ran out of gas mid-workload, or its
  * nonce is wedged) should not mask the test's primary outcome.
+ *
+ * `transportFactory` defaults to viem's bare `http`; on rate-limited
+ * public endpoints (e.g. Aeneid) callers may pass `resilientHttp` so
+ * a 429 storm during the refund pass doesn't silently inflate the
+ * `failedRefunds` count (which would in turn overstate the cost-model
+ * `burned_wei` derived from refund totals). DevNet callers omit the
+ * arg and behavior is byte-identical to the pre-arg version.
  */
 export async function refundWallets(
   publicClient: PublicClient,
@@ -180,6 +188,7 @@ export async function refundWallets(
   recipient: Address,
   rpcUrl: string,
   gasReserveWei: bigint = parseEther("0.001"),
+  transportFactory: (url: string) => Transport = http,
 ): Promise<RefundResult> {
   const chain = publicClient.chain as Chain;
 
@@ -193,7 +202,7 @@ export async function refundWallets(
         const wc = createWalletClient({
           account: w.account,
           chain,
-          transport: http(rpcUrl),
+          transport: transportFactory(rpcUrl),
         });
         const hash = await wc.sendTransaction({
           to: recipient,

--- a/packages/sdk/__integration__/_rpc-resilience.ts
+++ b/packages/sdk/__integration__/_rpc-resilience.ts
@@ -1,0 +1,60 @@
+/**
+ * RPC resilience helpers for integration tests that target rate-limited
+ * public endpoints (e.g. `https://aeneid.storyrpc.io`).
+ *
+ * **Scope of use**: ONLY the `*-aeneid.test.ts` files. The DevNet-targeted
+ * suites import `http` directly from viem and run at full concurrency —
+ * adding retry / throttling there would mask real validator-side issues.
+ */
+
+import { http } from "viem";
+
+/**
+ * `http()` with retry budget tuned for public-RPC throttling.
+ *
+ * viem already retries on HTTP 429 / 408 / 413 / 500 / 502 / 503 / 504 with
+ * exponential backoff (`~~(1 << count) * retryDelay`) and honors any
+ * `Retry-After` header (viem `buildRequest.js`). The defaults
+ * (`retryCount: 3`, `retryDelay: 150`) exhaust in ~1s — too fast for a
+ * 100-way burst against a public endpoint. The values below give a
+ * ~31s envelope (500ms, 1s, 2s, 4s, 8s, 16s) across 5 retries.
+ */
+export function resilientHttp(rpcUrl: string, opts?: {
+  retryCount?: number;
+  retryDelay?: number;
+}) {
+  return http(rpcUrl, {
+    retryCount: opts?.retryCount ?? 5,
+    retryDelay: opts?.retryDelay ?? 500,
+  });
+}
+
+/**
+ * Tiny in-process semaphore. Returns a `run` function that gates `fn`
+ * to at most `maxConcurrency` in-flight executions; surplus callers
+ * wait FIFO.
+ *
+ * Used to cap burst pressure on a public RPC: the test still launches
+ * N logical workers, but the RPC sees at most `maxConcurrency`
+ * outstanding requests at a time.
+ */
+export function pLimit(maxConcurrency: number) {
+  if (!Number.isInteger(maxConcurrency) || maxConcurrency < 1) {
+    throw new Error(`pLimit: maxConcurrency must be a positive integer, got ${maxConcurrency}`);
+  }
+  const queue: Array<() => void> = [];
+  let active = 0;
+  return async function run<T>(fn: () => Promise<T>): Promise<T> {
+    if (active >= maxConcurrency) {
+      await new Promise<void>((resolve) => queue.push(resolve));
+    }
+    active++;
+    try {
+      return await fn();
+    } finally {
+      active--;
+      const next = queue.shift();
+      if (next) next();
+    }
+  };
+}

--- a/packages/sdk/__integration__/_rpc-resilience.ts
+++ b/packages/sdk/__integration__/_rpc-resilience.ts
@@ -37,6 +37,22 @@ export function resilientHttp(rpcUrl: string, opts?: {
  * Used to cap burst pressure on a public RPC: the test still launches
  * N logical workers, but the RPC sees at most `maxConcurrency`
  * outstanding requests at a time.
+ *
+ * **Usage contract (closed-system)**: every caller of `run()` must
+ * enter inside a single synchronous tick (e.g. `wallets.map(w =>
+ * run(...))`). No new `run()` calls may interleave with already-running
+ * or already-queued workers' completions. In this mode, the first
+ * `maxConcurrency` callers admit immediately and the rest queue;
+ * thereafter the system is closed and each completion admits exactly
+ * one waiter — `active` is provably bounded by `maxConcurrency`.
+ *
+ * The `active++` after the await deliberately omits a re-check (jinn
+ * #L54). A streaming/open-system caller arriving between a releaser's
+ * `next()` and the awaiting waiter's resume could read a stale `active`
+ * and admit itself, leaving the resumed waiter to over-increment past
+ * `maxConcurrency`. If this helper is ever reused in a streaming
+ * pattern, replace this with a pre-increment-on-admit design (releaser
+ * does `active++` before `next()`, waiter skips the post-await `active++`).
  */
 export function pLimit(maxConcurrency: number) {
   if (!Number.isInteger(maxConcurrency) || maxConcurrency < 1) {

--- a/packages/sdk/__integration__/_suite.ts
+++ b/packages/sdk/__integration__/_suite.ts
@@ -4,11 +4,11 @@
  * The workflow dispatches with one of:
  *   default                   — basic integration + 100-wallet ephemeral tests
  *   all                       — everything including 1000w perf + 60min stress
- *   1000-wallet-performance   — only the 1000-wallet perf suite
+ *   1000-wallet-performance-devnet-only   — only the 1000-wallet perf suite
  *   1H-stress-devnet-only     — only the 60-min combined stress (DevNet only)
  *
  * Test files gate their `describe` block via:
- *   describe.skipIf(skipUnlessSuite("1000-wallet-performance"))(...)
+ *   describe.skipIf(skipUnlessSuite("1000-wallet-performance-devnet-only"))(...)
  *
  * `all` always runs every gated suite.
  */
@@ -16,7 +16,7 @@
 export type TestSuite =
   | "default"
   | "all"
-  | "1000-wallet-performance"
+  | "1000-wallet-performance-devnet-only"
   | "1H-stress-devnet-only";
 
 export type Network = "devnet" | "aeneid";

--- a/packages/sdk/__integration__/ephemeral-1000w-perf.test.ts
+++ b/packages/sdk/__integration__/ephemeral-1000w-perf.test.ts
@@ -4,7 +4,7 @@
  * same shape, 10x the fan-out, plus a final summary block that breaks
  * out the cost model and latency distribution.
  *
- * Suite gating: `1000-wallet-performance` (and `all`). DevNet + Aeneid.
+ * Suite gating: `1000-wallet-performance-devnet-only` (and `all`), DevNet only.
  *
  * Why batch the funding:
  *   Multicall3.aggregate3Value with 1000 inner calls costs ~50M gas — past
@@ -155,7 +155,7 @@ async function fundInBatches(
   return totalFunded;
 }
 
-describe.skipIf(skipUnlessSuite("1000-wallet-performance") || NETWORK !== "devnet")(
+describe.skipIf(skipUnlessSuite("1000-wallet-performance-devnet-only") || NETWORK !== "devnet")(
   `1000 ephemeral wallets → shared vault read perf (network=${NETWORK})`,
   () => {
     let funderPublic: PublicClient;
@@ -332,7 +332,7 @@ describe.skipIf(skipUnlessSuite("1000-wallet-performance") || NETWORK !== "devne
       // 1000 concurrent reads against the validator partial path can stretch
       // well past the per-call timeout if the chain or DKG nodes throttle.
       // 75 min outer bound matches the workflow's 90-min timeout-minutes for
-      // the 1000-wallet-performance suite with slack for setup + teardown.
+      // the 1000-wallet-performance-devnet-only suite with slack for setup + teardown.
       75 * 60 * 1000,
     );
   },

--- a/packages/sdk/__integration__/ephemeral-1000w-perf.test.ts
+++ b/packages/sdk/__integration__/ephemeral-1000w-perf.test.ts
@@ -155,7 +155,7 @@ async function fundInBatches(
   return totalFunded;
 }
 
-describe.skipIf(skipUnlessSuite("1000-wallet-performance"))(
+describe.skipIf(skipUnlessSuite("1000-wallet-performance") || NETWORK !== "devnet")(
   `1000 ephemeral wallets → shared vault read perf (network=${NETWORK})`,
   () => {
     let funderPublic: PublicClient;

--- a/packages/sdk/__integration__/ephemeral-100w-fresh-aeneid.test.ts
+++ b/packages/sdk/__integration__/ephemeral-100w-fresh-aeneid.test.ts
@@ -1,31 +1,29 @@
 /**
  * 100 ephemeral wallets, each doing their own allocate + write + read
- * against fresh vaults.
+ * against fresh vaults — Aeneid-flavored variant.
  *
- * Suite gating: `default` (and `all`). Runs on both DevNet + Aeneid.
+ * Suite gating: `default` (and `all`), Aeneid ONLY (the DevNet counterpart
+ * lives in `ephemeral-100w-fresh.test.ts` and runs at full concurrency).
  *
- * Pattern:
- *   1. Funder deploys one open-condition contract (shared across wallets
- *      — the contract is stateless, just an "always allow" check).
- *   2. Generate 100 ephemeral wallets, Multicall3 batch-fund them.
- *   3. Each wallet runs PER-WALLET SEQUENTIAL:
- *        uploadCDR(ownDataKey) → accessCDR(ownVaultUuid)
- *      The two txs go in series so the wallet's nonce stream stays
- *      monotonic (no two concurrent txs from the same account).
- *   4. CROSS-WALLET PARALLEL: all 100 wallets fire their sequential
- *      flow simultaneously via Promise.allSettled. Cross-wallet there
- *      are no nonce dependencies, so this exercises 100-way concurrent
- *      load on the chain + DKG validators.
- *   5. Refund pass.
+ * What's different from the DevNet version:
+ *   - Transport goes through `resilientHttp()` instead of bare `http()` —
+ *     bumps viem's retry envelope from ~1s to ~31s so HTTP 429 / 408 /
+ *     5xx from `aeneid.storyrpc.io` get absorbed (viem already retries
+ *     these status codes; we only widen the budget).
+ *   - Cross-wallet parallelism gated by `pLimit(25)` so the public RPC
+ *     sees at most 25 in-flight requests at a time. The test still
+ *     launches all 100 wallets logically; only the burst pressure is
+ *     capped. WALLET_COUNT, per-wallet sequential semantics, assertion
+ *     bar (`failed.length === 0`), and the recovered-dataKey checks
+ *     are byte-identical to the DevNet version.
+ *   - Timeout 60 min (vs 45 min DevNet) — public RPC tail latencies
+ *     stretch p99 well beyond the private validator.
+ *   - `writePerfStats` label is `"100w-fresh-aeneid"` so the aggregate
+ *     perf-stats JSON doesn't collide with the DevNet run's slot.
  *
- * What this proves (different from `ephemeral-100w-shared.test.ts`):
- *   - 100 INDEPENDENT vault lifecycles concurrently — the validator
- *     partial path must handle distinct (uuid, requesterPubKey) buckets
- *     in parallel without cross-talk.
- *   - The uploader's chain interaction (alloc + write txs) scales to
- *     100 distinct senders without nonce-collision failure modes.
- *   - Each wallet recovers the SAME dataKey it wrote — proves the
- *     keeper indexes vaults by uuid correctly under load.
+ * What's the same:
+ *   - 100 fresh wallets, Multicall3 batch fund, per-wallet sequential
+ *     upload→read, cross-wallet parallel, refund pass, same assertions.
  */
 
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
@@ -34,7 +32,6 @@ import {
   type WalletClient,
   createPublicClient,
   createWalletClient,
-  http,
   parseEther,
 } from "viem";
 import { privateKeyToAccount } from "viem/accounts";
@@ -47,10 +44,12 @@ import {
   refundWallets,
 } from "./_ephemeral-wallets.js";
 import { formatMs, logCase, mean, p50, p95, statsOf, writePerfStats } from "./_helpers.js";
+import { pLimit, resilientHttp } from "./_rpc-resilience.js";
 
 const WALLET_COUNT = 100;
 const PER_WALLET_FUND = parseEther("0.1");
 const ACCESS_TIMEOUT_MS = 180_000;
+const MAX_INFLIGHT = 25;
 
 const API_URL = process.env.CDR_API_URL;
 const RPC_URL = process.env.CDR_RPC_URL;
@@ -69,11 +68,11 @@ function makeFunderClient(): {
 } {
   const account = privateKeyToAccount(FUNDER_KEY!);
   const publicClient = createPublicClient({
-    transport: http(RPC_URL),
+    transport: resilientHttp(RPC_URL!),
   }) as unknown as PublicClient;
   const walletClient = createWalletClient({
     account,
-    transport: http(RPC_URL),
+    transport: resilientHttp(RPC_URL!),
   }) as unknown as WalletClient;
   const client = new CDRClient({
     network: "testnet",
@@ -86,11 +85,11 @@ function makeFunderClient(): {
 
 function makeWalletClient(wallet: EphemeralWallet): CDRClient {
   const publicClient = createPublicClient({
-    transport: http(RPC_URL),
+    transport: resilientHttp(RPC_URL!),
   }) as unknown as PublicClient;
   const walletClient = createWalletClient({
     account: wallet.account,
-    transport: http(RPC_URL),
+    transport: resilientHttp(RPC_URL!),
   }) as unknown as WalletClient;
   return new CDRClient({
     network: "testnet",
@@ -118,8 +117,8 @@ async function deployOpenCondition(
   return receipt.contractAddress;
 }
 
-describe.skipIf(skipUnlessSuite("default") || NETWORK !== "devnet")(
-  `100 ephemeral wallets → fresh vault per wallet (network=${NETWORK})`,
+describe.skipIf(skipUnlessSuite("default") || NETWORK !== "aeneid")(
+  `100 ephemeral wallets → fresh vault per wallet, throttled (network=${NETWORK})`,
   () => {
     let funderPublic: PublicClient;
     let funderWallet: WalletClient;
@@ -176,7 +175,7 @@ describe.skipIf(skipUnlessSuite("default") || NETWORK !== "devnet")(
       });
       if (perfBuffer) {
         writePerfStats({
-          label: "100w-fresh",
+          label: "100w-fresh-aeneid",
           network: NETWORK,
           wallets: WALLET_COUNT,
           fulfilled: perfBuffer.fulfilled,
@@ -191,53 +190,56 @@ describe.skipIf(skipUnlessSuite("default") || NETWORK !== "devnet")(
             burned_wei: (totalFundedWei - refund.totalRefundedWei).toString(),
             failed_sweeps: refund.failedRefunds,
           },
-          extra: null,
+          extra: { maxInflight: MAX_INFLIGHT },
         });
       }
     }, 5 * 60 * 1000);
 
     it(
-      `${WALLET_COUNT} wallets each do upload→read on their own vault, in parallel`,
+      `${WALLET_COUNT} wallets each do upload→read on their own vault, capped at ${MAX_INFLIGHT} in-flight`,
       async () => {
+        const limit = pLimit(MAX_INFLIGHT);
         const start = Date.now();
         const results = await Promise.allSettled(
-          wallets.map(async (w) => {
-            const client = makeWalletClient(w);
+          wallets.map((w) =>
+            limit(async () => {
+              const client = makeWalletClient(w);
 
-            // ----- per-wallet sequential: upload, then read -----
-            const dataKey = crypto.getRandomValues(new Uint8Array(32));
-            const globalPubKey = await client.observer.getGlobalPubKey();
+              // ----- per-wallet sequential: upload, then read -----
+              const dataKey = crypto.getRandomValues(new Uint8Array(32));
+              const globalPubKey = await client.observer.getGlobalPubKey();
 
-            const tUploadStart = Date.now();
-            const upload = await client.uploader.uploadCDR({
-              dataKey,
-              globalPubKey,
-              updatable: false,
-              writeConditionAddr: openCondition,
-              readConditionAddr: openCondition,
-              writeConditionData: "0x",
-              readConditionData: "0x",
-              accessAuxData: "0x",
-            });
-            const uploadMs = Date.now() - tUploadStart;
+              const tUploadStart = Date.now();
+              const upload = await client.uploader.uploadCDR({
+                dataKey,
+                globalPubKey,
+                updatable: false,
+                writeConditionAddr: openCondition,
+                readConditionAddr: openCondition,
+                writeConditionData: "0x",
+                readConditionData: "0x",
+                accessAuxData: "0x",
+              });
+              const uploadMs = Date.now() - tUploadStart;
 
-            const tAccessStart = Date.now();
-            const access = await client.consumer.accessCDR({
-              uuid: upload.uuid,
-              accessAuxData: "0x",
-              timeoutMs: ACCESS_TIMEOUT_MS,
-            });
-            const accessMs = Date.now() - tAccessStart;
+              const tAccessStart = Date.now();
+              const access = await client.consumer.accessCDR({
+                uuid: upload.uuid,
+                accessAuxData: "0x",
+                timeoutMs: ACCESS_TIMEOUT_MS,
+              });
+              const accessMs = Date.now() - tAccessStart;
 
-            return {
-              address: w.address,
-              uuid: upload.uuid,
-              uploadMs,
-              accessMs,
-              expected: dataKey,
-              recovered: access.dataKey,
-            };
-          }),
+              return {
+                address: w.address,
+                uuid: upload.uuid,
+                uploadMs,
+                accessMs,
+                expected: dataKey,
+                recovered: access.dataKey,
+              };
+            }),
+          ),
         );
 
         const fulfilled = results.flatMap((r) =>
@@ -259,10 +261,11 @@ describe.skipIf(skipUnlessSuite("default") || NETWORK !== "devnet")(
         const totalMs = Date.now() - start;
         const uploadLats = fulfilled.map((r) => r.uploadMs);
         const accessLats = fulfilled.map((r) => r.accessMs);
-        logCase("100-fresh summary", {
+        logCase("100-fresh-aeneid summary", {
           fulfilled: fulfilled.length,
           failed: failed.length,
           totalMs: formatMs(totalMs),
+          maxInflight: MAX_INFLIGHT,
           uploadMs: {
             p50: formatMs(p50(uploadLats)),
             p95: formatMs(p95(uploadLats)),
@@ -290,10 +293,10 @@ describe.skipIf(skipUnlessSuite("default") || NETWORK !== "devnet")(
           expect(Array.from(r.recovered)).toEqual(Array.from(r.expected));
         }
       },
-      // Two sequential txs per wallet (upload + read) under 100-way
-      // contention can stretch the tail well past a single-vault test.
-      // Allow 45 min worst-case.
-      45 * 60 * 1000,
+      // Public RPC tail latencies stretch p99 well beyond the private
+      // validator's; 100 wallets × (upload + read) under pLimit(25)
+      // contention easily reach the 30-40 min mark on a busy Aeneid.
+      60 * 60 * 1000,
     );
   },
 );

--- a/packages/sdk/__integration__/ephemeral-100w-fresh-aeneid.test.ts
+++ b/packages/sdk/__integration__/ephemeral-100w-fresh-aeneid.test.ts
@@ -163,11 +163,15 @@ describe.skipIf(skipUnlessSuite("default") || NETWORK !== "aeneid")(
 
     afterAll(async () => {
       if (!wallets || wallets.length === 0) return;
+      // Public-RPC sweep also benefits from the retry envelope —
+      // otherwise refund 429s silently inflate `failedRefunds`.
       const refund = await refundWallets(
         funderPublic,
         wallets,
         funderAddress,
         RPC_URL!,
+        undefined,
+        resilientHttp,
       );
       logCase("refund summary", {
         totalRefundedWei: refund.totalRefundedWei.toString(),


### PR DESCRIPTION
## Why

`workflow_dispatch` run [25930638842](https://github.com/piplabs/cdr-sdk/actions/runs/25930638842) on Aeneid failed `ephemeral-100w-fresh` with `13/100 wallets failed`. All visible failure reasons (the test caps printed reasons at 5) were `HTTP 429` from `https://aeneid.storyrpc.io/` on `eth_sendRawTransaction` — public-RPC rate-limit, not an SDK bug. Same test passes every run on DevNet (private validator2 RPC).

viem 2.47.6 already retries `429` by default (`buildRequest.js:141-180`), but the default `retryCount: 3, retryDelay: 150ms` exhausts in ~1s — too tight for a 100-way concurrent burst. And the test had no in-flight cap, so the entire burst hit the rate limiter at once.

## What

Surface split: don't paper over the public-RPC reality on DevNet, don't relax the assertion on Aeneid.

- **`ephemeral-100w-fresh.test.ts`** (existing): gate tightened from `skipUnlessSuite("default")` to also require `NETWORK === "devnet"`. On DevNet the new boolean is `false`, so the effective gate reduces to the original — byte-identical assertion path.

- **`ephemeral-100w-fresh-aeneid.test.ts`** (new): Aeneid-only counterpart, ~290 LOC mirroring the DevNet version. Three narrow differences:
  - Transport via `resilientHttp()` → viem retry envelope widened to `retryCount: 5, retryDelay: 500ms` (~31s budget with exponential backoff). Just tuning viem's existing 429 retry, no custom `shouldRetry`.
  - `pLimit(25)` caps in-flight requests. 100 wallets still launch logically; only burst pressure is capped.
  - `refundWallets` called with `resilientHttp` as transport factory (added as an optional param) so 429s during the refund sweep don't inflate `failedRefunds` and overstate `burned_wei` in the cost model.
  - Assertion stays strict (`failed.length === 0`), timeout extended to 60 min for public-RPC tail.

- **`ephemeral-1000w-perf.test.ts`** + **`_suite.ts`** + workflow dropdown: suite renamed from `1000-wallet-performance` → `1000-wallet-performance-devnet-only` to match the existing `1H-stress-devnet-only` convention. Operators see the constraint in the dropdown itself. Combined with the test-file gate `NETWORK !== "devnet"`, an Aeneid-misconfigured run lands as `1 file | 1 skipped` (green) rather than a hard fail.

- **`_rpc-resilience.ts`** (new, ~60 LOC, no new deps): houses `resilientHttp()` + `pLimit()`. Imported only by the new Aeneid test — every existing DevNet-targeted test still imports `http` from viem directly. Includes a usage-contract docblock for `pLimit` documenting the closed-system invariant (all `run()` callers in a single sync tick; no streaming admit).

- **`_ephemeral-wallets.ts`** (modified): `refundWallets` gains an optional `transportFactory` parameter, default `http`. Existing callers omit the arg and get byte-identical behavior. The new Aeneid test passes `resilientHttp` so the refund sweep absorbs the same 429s the workload does.

- **`.github/workflows/integration.yml`**: dropdown option renamed (`1000-wallet-performance` → `1000-wallet-performance-devnet-only`); workflow case-statement updated to match.

## DevNet non-regression

| Path | DevNet behavior |
|---|---|
| `100w-fresh.test.ts` gate | `skipUnlessSuite("default") \|\| false` → original |
| `1000w-perf.test.ts` gate | `skipUnlessSuite("1000-wallet-performance-devnet-only") \|\| false` → original |
| New Aeneid file | gate `NETWORK !== "aeneid"` is `true` → entire describe skipped, no code executes |
| `refundWallets` new param | default `http` → byte-identical for every existing caller (100w-shared / 100w-fresh / 1000w-perf / 60min-stress) |
| `_rpc-resilience.ts` | Not imported by any DevNet-targeted test |

PR-trigger DevNet+default run on commit `ebf8b39` passed (`25932559200`), confirming zero behavioral regression on the DevNet path.

## Test plan

- [x] PR auto-trigger (DevNet, default suite) on `ebf8b39` — passed
- [ ] PR auto-trigger (DevNet, default suite) on latest HEAD — confirm still green after the rename + refund fix
- [ ] Manual `workflow_dispatch` with `network=aeneid, test_suite=default` — confirms the new Aeneid case runs (100w-fresh-aeneid with retry+limit) and the original DevNet case skips
- [ ] Manual `workflow_dispatch` with `network=aeneid, test_suite=1000-wallet-performance-devnet-only` — confirms the file-level gate skips cleanly (`1 file | 1 skipped`, run goes green)