### PR TITLE
fix(sdk): improve typed read error surface

### DIFF
--- a/packages/sdk/__tests__/consumer.test.ts
+++ b/packages/sdk/__tests__/consumer.test.ts
@@ -38,6 +38,7 @@ import {
   PartialCollectionTimeoutError,
   InvalidParamsError,
   EmptyVaultError,
+  ReadTransactionRevertedError,
 } from "../src/errors.js";
 import { toHex } from "viem";
 import type { Observer } from "../src/observer.js";
@@ -144,6 +145,8 @@ function mockClients(opts: { vaultEncryptedData?: `0x${string}` } = {}) {
   const publicClient = {
     readContract,
     getBlockNumber: vi.fn().mockResolvedValue(1000n),
+    waitForTransactionReceipt: vi.fn().mockResolvedValue({ status: "success" }),
+    simulateContract: vi.fn().mockResolvedValue({ result: undefined }),
   };
   const walletClient = {
     writeContract: vi.fn().mockResolvedValue("0xtxhash" as `0x${string}`),
@@ -223,6 +226,161 @@ describe("Consumer", () => {
       expect(walletClient.writeContract).toHaveBeenCalledWith(
         expect.objectContaining({ value: 99n }),
       );
+    });
+
+    it("read awaits the tx receipt with the submitted tx hash", async () => {
+      const { consumer, publicClient } = makeConsumer();
+      await consumer.read({
+        uuid: 42,
+        accessAuxData: "0x",
+        requesterPubKey: "0x04" as `0x${string}`,
+        feeOverride: 1n,
+      });
+      expect(publicClient.waitForTransactionReceipt).toHaveBeenCalledWith({
+        hash: "0xtxhash",
+      });
+    });
+
+    it("read returns txHash when receipt status is success", async () => {
+      const { consumer, publicClient } = makeConsumer();
+      publicClient.waitForTransactionReceipt.mockResolvedValueOnce({ status: "success" });
+      const result = await consumer.read({
+        uuid: 42,
+        accessAuxData: "0x",
+        requesterPubKey: "0x04" as `0x${string}`,
+        feeOverride: 1n,
+      });
+      expect(result.txHash).toBe("0xtxhash");
+    });
+
+    it("read throws ReadTransactionRevertedError with txHash when receipt status is reverted", async () => {
+      const { consumer, publicClient } = makeConsumer();
+      publicClient.waitForTransactionReceipt.mockResolvedValueOnce({ status: "reverted" });
+      try {
+        await consumer.read({
+          uuid: 42,
+          accessAuxData: "0x",
+          requesterPubKey: "0x04" as `0x${string}`,
+          feeOverride: 1n,
+        });
+        expect.fail("expected ReadTransactionRevertedError");
+      } catch (err) {
+        expect(err).toBeInstanceOf(ReadTransactionRevertedError);
+        expect((err as ReadTransactionRevertedError).txHash).toBe("0xtxhash");
+        expect((err as ReadTransactionRevertedError).code).toBe("READ_TX_REVERTED");
+      }
+    });
+
+    it("read populates reason from viem revert error when simulate fails", async () => {
+      const { consumer, publicClient } = makeConsumer();
+      publicClient.waitForTransactionReceipt.mockResolvedValueOnce({
+        status: "reverted",
+        blockNumber: 123n,
+      });
+      const simulateErr: any = new Error("execution reverted");
+      simulateErr.shortMessage = "execution reverted";
+      simulateErr.cause = { reason: "Invalid fee amount" };
+      publicClient.simulateContract.mockRejectedValueOnce(simulateErr);
+
+      try {
+        await consumer.read({
+          uuid: 42,
+          accessAuxData: "0x",
+          requesterPubKey: "0x04" as `0x${string}`,
+          feeOverride: 1n,
+        });
+        expect.fail("expected ReadTransactionRevertedError");
+      } catch (err) {
+        expect(err).toBeInstanceOf(ReadTransactionRevertedError);
+        expect((err as ReadTransactionRevertedError).reason).toBe("Invalid fee amount");
+        expect((err as ReadTransactionRevertedError).message).toContain("Invalid fee amount");
+      }
+      expect(publicClient.simulateContract).toHaveBeenCalledWith(
+        expect.objectContaining({
+          functionName: "read",
+          args: [42, "0x", "0x04"],
+          value: 1n,
+          blockNumber: 123n,
+        }),
+      );
+    });
+
+    it("read still throws ReadTransactionRevertedError when reason decoding fails", async () => {
+      const { consumer, publicClient } = makeConsumer();
+      publicClient.waitForTransactionReceipt.mockResolvedValueOnce({
+        status: "reverted",
+        blockNumber: 123n,
+      });
+      // Opaque error from simulate — no recognizable viem fields.
+      publicClient.simulateContract.mockRejectedValueOnce(new Error("network is hard"));
+
+      try {
+        await consumer.read({
+          uuid: 42,
+          accessAuxData: "0x",
+          requesterPubKey: "0x04" as `0x${string}`,
+          feeOverride: 1n,
+        });
+        expect.fail("expected ReadTransactionRevertedError");
+      } catch (err) {
+        expect(err).toBeInstanceOf(ReadTransactionRevertedError);
+        expect((err as ReadTransactionRevertedError).reason).toBeUndefined();
+      }
+    });
+
+    it("read ignores shortMessage from non-contract errors (transport/RPC)", async () => {
+      const { consumer, publicClient } = makeConsumer();
+      publicClient.waitForTransactionReceipt.mockResolvedValueOnce({
+        status: "reverted",
+        blockNumber: 123n,
+      });
+      // Simulate throws a transport-shaped error — has shortMessage/details
+      // but is NOT a ContractFunction(Execution|Reverted)Error. The decoder
+      // must not surface "HTTP request failed" as a contract revert reason.
+      const transportErr: any = new Error("transport");
+      transportErr.name = "HttpRequestError";
+      transportErr.shortMessage = "HTTP request failed";
+      transportErr.details = "fetch failed: ECONNREFUSED";
+      publicClient.simulateContract.mockRejectedValueOnce(transportErr);
+
+      try {
+        await consumer.read({
+          uuid: 42,
+          accessAuxData: "0x",
+          requesterPubKey: "0x04" as `0x${string}`,
+          feeOverride: 1n,
+        });
+        expect.fail("expected ReadTransactionRevertedError");
+      } catch (err) {
+        expect(err).toBeInstanceOf(ReadTransactionRevertedError);
+        expect((err as ReadTransactionRevertedError).reason).toBeUndefined();
+      }
+    });
+
+    it("read uses top-level shortMessage when chain contains a contract error but no decoded fields", async () => {
+      const { consumer, publicClient } = makeConsumer();
+      publicClient.waitForTransactionReceipt.mockResolvedValueOnce({
+        status: "reverted",
+        blockNumber: 123n,
+      });
+      const cfeErr: any = new Error("execution reverted");
+      cfeErr.name = "ContractFunctionExecutionError";
+      cfeErr.shortMessage = "The contract function \"read\" reverted.";
+      publicClient.simulateContract.mockRejectedValueOnce(cfeErr);
+
+      try {
+        await consumer.read({
+          uuid: 42,
+          accessAuxData: "0x",
+          requesterPubKey: "0x04" as `0x${string}`,
+          feeOverride: 1n,
+        });
+        expect.fail("expected ReadTransactionRevertedError");
+      } catch (err) {
+        expect((err as ReadTransactionRevertedError).reason).toBe(
+          "The contract function \"read\" reverted.",
+        );
+      }
     });
   });
 
@@ -775,6 +933,23 @@ describe("Consumer", () => {
       // reads would mean accessCDR + collectPartials each loaded the
       // vault separately, and the filter would pin C2 instead of C1.
       expect(vaultReadCount).toBe(1);
+    });
+
+    it("does not enter collectPartials when read tx reverts", async () => {
+      const { consumer, publicClient } = makeConsumer(
+        makeFakeObserver({ globalPubKey: new Uint8Array(34).fill(0xaa) }),
+      );
+      vi.mocked(generateEphemeralKeyPair).mockReturnValue({
+        privateKey: new Uint8Array(32).fill(1),
+        publicKey: new Uint8Array(65).fill(2),
+      });
+      publicClient.waitForTransactionReceipt.mockResolvedValueOnce({ status: "reverted" });
+
+      await expect(
+        consumer.accessCDR({ uuid: 42, accessAuxData: "0x", timeoutMs: 1000 }),
+      ).rejects.toBeInstanceOf(ReadTransactionRevertedError);
+
+      expect(queryCDRPartials).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/sdk/__tests__/consumer.test.ts
+++ b/packages/sdk/__tests__/consumer.test.ts
@@ -621,20 +621,43 @@ describe("Consumer", () => {
       ]);
 
       const onInvalidPartial = vi.fn();
-      await expect(
-        consumer.collectPartials({
+      let timeoutErr: PartialCollectionTimeoutError | undefined;
+      try {
+        await consumer.collectPartials({
           uuid: 1,
           requesterPubKey: "0x04" as `0x${string}`,
           timeoutMs: 50,
           pollIntervalMs: 5,
           attestationConfig: { minSecurityVersion: 1 },
           onInvalidPartial,
-        }),
-      ).rejects.toThrow(PartialCollectionTimeoutError);
+        });
+        expect.fail("expected PartialCollectionTimeoutError");
+      } catch (err) {
+        expect(err).toBeInstanceOf(PartialCollectionTimeoutError);
+        timeoutErr = err as PartialCollectionTimeoutError;
+      }
+
+      // `collected` reflects the trusted/accepted count (1: only A), NOT
+      // the raw bucket size (3). Critical when the typed field is consumed
+      // for telemetry / UX.
+      expect(timeoutErr!.collected).toBe(1);
+      expect(timeoutErr!.needed).toBe(2);
 
       // Both un-trusted validators reported.
       const reported = onInvalidPartial.mock.calls.map((c) => c[0].validator);
       expect(new Set(reported)).toEqual(new Set([VALIDATOR_B, VALIDATOR_C]));
+
+      // Each call passes a typed `attestation-rejected` reason as the 2nd
+      // argument, with stable fields callers can switch on without parsing
+      // text. The legacy Error is still passed as the 3rd argument.
+      for (const call of onInvalidPartial.mock.calls) {
+        const [event, reason, error] = call;
+        expect(reason.kind).toBe("attestation-rejected");
+        expect(reason.validator).toBe(event.validator);
+        expect(reason.pid).toBe(event.pid);
+        expect(reason.round).toBe(event.round);
+        expect(error).toBeInstanceOf(Error);
+      }
     });
 
     it("attestation cache: verifyAttestation called once per validator per round", async () => {

--- a/packages/sdk/__tests__/consumer.test.ts
+++ b/packages/sdk/__tests__/consumer.test.ts
@@ -237,9 +237,9 @@ describe("Consumer", () => {
         requesterPubKey: "0x04" as `0x${string}`,
         feeOverride: 1n,
       });
-      expect(publicClient.waitForTransactionReceipt).toHaveBeenCalledWith({
-        hash: "0xtxhash",
-      });
+      expect(publicClient.waitForTransactionReceipt).toHaveBeenCalledWith(
+        expect.objectContaining({ hash: "0xtxhash" }),
+      );
     });
 
     it("read returns txHash when receipt status is success", async () => {

--- a/packages/sdk/__tests__/consumer.test.ts
+++ b/packages/sdk/__tests__/consumer.test.ts
@@ -500,21 +500,52 @@ describe("Consumer", () => {
     });
 
     it("times out when threshold never reached", async () => {
-      const { consumer } = makeConsumer(makeFakeObserver({ threshold: 5 }));
+      const { consumer } = makeConsumer(
+        makeFakeObserver({ threshold: 5, thresholdAt: 5 }),
+      );
       vi.mocked(queryCDRPartials).mockResolvedValue([
         makeGroup({
           submissions: [makeSubmission({ validator: VALIDATOR_A, pid: 1 })],
           thresholdMet: false,
         }),
       ]);
-      await expect(
-        consumer.collectPartials({
+      try {
+        await consumer.collectPartials({
           uuid: 1,
           requesterPubKey: "0x04" as `0x${string}`,
           timeoutMs: 50,
           pollIntervalMs: 5,
-        }),
-      ).rejects.toThrow(PartialCollectionTimeoutError);
+        });
+        expect.fail("expected PartialCollectionTimeoutError");
+      } catch (err) {
+        expect(err).toBeInstanceOf(PartialCollectionTimeoutError);
+        const e = err as PartialCollectionTimeoutError;
+        expect(e.collected).toBe(1);
+        expect(e.needed).toBe(5);
+        expect(e.timeoutMs).toBe(50);
+        expect(e.code).toBe("PARTIAL_COLLECTION_TIMEOUT");
+      }
+    });
+
+    it("timeout fields reflect active-round threshold when no matching bucket ever appears", async () => {
+      const { consumer } = makeConsumer(makeFakeObserver({ threshold: 3 }));
+      // No groups returned across all polls — bucket-aware getThresholdAt
+      // never runs; `needed` should come from the seeded getThreshold().
+      vi.mocked(queryCDRPartials).mockResolvedValue([]);
+      try {
+        await consumer.collectPartials({
+          uuid: 1,
+          requesterPubKey: "0x04" as `0x${string}`,
+          timeoutMs: 30,
+          pollIntervalMs: 5,
+        });
+        expect.fail("expected PartialCollectionTimeoutError");
+      } catch (err) {
+        const e = err as PartialCollectionTimeoutError;
+        expect(e.collected).toBe(0);
+        expect(e.needed).toBe(3);
+        expect(e.timeoutMs).toBe(30);
+      }
     });
 
     it("treats empty groups as 'wait, may arrive later'", async () => {
@@ -808,9 +839,8 @@ describe("Consumer", () => {
 
     it("uses provided globalPubKey: skips observer.getGlobalPubKey", async () => {
       // observer.getThresholdAt is called once from collectPartials (it
-      // derives the bucket-round threshold). observer.getThreshold (the
-      // active-round variant) must NOT be called from collectPartials —
-      // those are now distinct methods.
+      // derives the bucket-round threshold). observer.getThreshold is
+      // called once at loop start to seed `needed` on the timeout error.
       vi.mocked(generateEphemeralKeyPair).mockReturnValue({
         privateKey: new Uint8Array(32).fill(1),
         publicKey: new Uint8Array(65).fill(2),
@@ -838,7 +868,7 @@ describe("Consumer", () => {
       expect(observer.getGlobalPubKey).not.toHaveBeenCalled();
       expect(observer.getThresholdAt).toHaveBeenCalledTimes(1);
       expect(observer.getThresholdAt).toHaveBeenCalledWith(4);
-      expect(observer.getThreshold).not.toHaveBeenCalled();
+      expect(observer.getThreshold).toHaveBeenCalledTimes(1);
     });
 
     it("throws EmptyVaultError BEFORE submitting any tx — no fee paid for empty vault (#78)", async () => {
@@ -1155,8 +1185,9 @@ describe("Consumer", () => {
 
       expect(result).toHaveLength(2);
       expect(observer.getThresholdAt).toHaveBeenCalledWith(10);
-      // getThreshold (active-round) must not be called from collectPartials.
-      expect(observer.getThreshold).not.toHaveBeenCalled();
+      // getThresholdAt drives the bucket-aware threshold; getThreshold is
+      // only called once to seed `needed` on the timeout error.
+      expect(observer.getThresholdAt).toHaveBeenCalledTimes(1);
     });
 
     it("throws EmptyVaultError when vault has no encryptedData", async () => {

--- a/packages/sdk/__tests__/errors.test.ts
+++ b/packages/sdk/__tests__/errors.test.ts
@@ -42,6 +42,13 @@ describe("errors", () => {
       expect(err.message).toContain("5");
       expect(err).toBeInstanceOf(CDRError);
     });
+
+    it("exposes collected, needed, and timeoutMs as public fields", () => {
+      const err = new PartialCollectionTimeoutError(3, 5, 30000);
+      expect(err.collected).toBe(3);
+      expect(err.needed).toBe(5);
+      expect(err.timeoutMs).toBe(30000);
+    });
   });
 
   describe("ContractRevertError", () => {

--- a/packages/sdk/src/consumer.ts
+++ b/packages/sdk/src/consumer.ts
@@ -15,7 +15,7 @@ import {
   EmptyVaultError,
   ReadTransactionRevertedError,
 } from "./errors.js";
-import type { PartialDecryptionEvent } from "./types.js";
+import type { PartialDecryptionEvent, InvalidPartialReason } from "./types.js";
 import { uuidToLabel } from "./label.js";
 import type { StorageProvider } from "./storage/types.js";
 import { Observer } from "./observer.js";
@@ -243,7 +243,11 @@ export class Consumer {
     requesterPubKey: `0x${string}`;
     timeoutMs?: number;
     pollIntervalMs?: number;
-    onInvalidPartial?: (event: PartialDecryptionEvent, error: Error) => void;
+    onInvalidPartial?: (
+      event: PartialDecryptionEvent,
+      reason: InvalidPartialReason,
+      error?: Error,
+    ) => void;
     attestationConfig?: AttestationConfig;
     /**
      * @internal Pre-loaded vault ciphertext from a containing call (e.g.
@@ -344,6 +348,12 @@ export class Consumer {
                 reported.add(dedupeKey);
                 onInvalidPartial?.(
                   event,
+                  {
+                    kind: "attestation-rejected",
+                    validator: sub.validator,
+                    pid: sub.pid,
+                    round: group.round,
+                  },
                   new Error(`attestation rejected for validator ${sub.validator}`),
                 );
               }
@@ -355,6 +365,10 @@ export class Consumer {
           if (accepted.length >= sdkThreshold) {
             return accepted.slice(0, sdkThreshold);
           }
+          // Below threshold after trust filtering: surface the
+          // trusted/accepted count (not the raw bucket size) on a future
+          // timeout, so callers see what was actually usable.
+          lastSeen = accepted.length;
           // Not enough trusted partials this poll — keep waiting; more
           // validators may still submit, and the trust set is fixed for
           // this round so newly-arrived partials reuse the same checks.
@@ -495,7 +509,11 @@ export class Consumer {
     timeoutMs?: number;
     /** See {@link read}'s `feeOverride` — same strict-equality semantics. */
     feeOverride?: bigint;
-    onInvalidPartial?: (event: PartialDecryptionEvent, error: Error) => void;
+    onInvalidPartial?: (
+      event: PartialDecryptionEvent,
+      reason: InvalidPartialReason,
+      error?: Error,
+    ) => void;
     attestationConfig?: AttestationConfig;
   }): Promise<{ dataKey: Uint8Array; txHash: `0x${string}` }> {
     if (
@@ -585,7 +603,11 @@ export class Consumer {
     timeoutMs?: number;
     /** See {@link read}'s `feeOverride` — same strict-equality semantics. */
     feeOverride?: bigint;
-    onInvalidPartial?: (event: PartialDecryptionEvent, error: Error) => void;
+    onInvalidPartial?: (
+      event: PartialDecryptionEvent,
+      reason: InvalidPartialReason,
+      error?: Error,
+    ) => void;
     attestationConfig?: AttestationConfig;
     /** Skip CID integrity verification of downloaded file (default: false). */
     skipCidVerification?: boolean;

--- a/packages/sdk/src/consumer.ts
+++ b/packages/sdk/src/consumer.ts
@@ -13,6 +13,7 @@ import {
   InvalidParamsError,
   CidIntegrityError,
   EmptyVaultError,
+  ReadTransactionRevertedError,
 } from "./errors.js";
 import type { PartialDecryptionEvent } from "./types.js";
 import { uuidToLabel } from "./label.js";
@@ -146,7 +147,43 @@ export class Consumer {
       value: fee,
     });
 
+    const receipt = await this.publicClient.waitForTransactionReceipt({ hash: txHash });
+
+    if (receipt.status === "reverted") {
+      const reason = await this.decodeReadRevertReason({
+        uuid: params.uuid,
+        accessAuxData: params.accessAuxData,
+        requesterPubKey: params.requesterPubKey,
+        fee,
+        blockNumber: receipt.blockNumber,
+      });
+      throw new ReadTransactionRevertedError(txHash, reason);
+    }
+
     return { txHash };
+  }
+
+  private async decodeReadRevertReason(params: {
+    uuid: number;
+    accessAuxData: `0x${string}`;
+    requesterPubKey: `0x${string}`;
+    fee: bigint;
+    blockNumber?: bigint;
+  }): Promise<string | undefined> {
+    try {
+      await this.publicClient.simulateContract({
+        account: this.walletClient.account ?? undefined,
+        address: contractAddresses[this.network].cdr,
+        abi: cdrAbi,
+        functionName: "read",
+        args: [params.uuid, params.accessAuxData, params.requesterPubKey],
+        value: params.fee,
+        blockNumber: params.blockNumber,
+      });
+    } catch (err) {
+      return extractViemRevertReason(err);
+    }
+    return undefined;
   }
 
   /**
@@ -622,4 +659,56 @@ function bytesEqual(a: Uint8Array, b: Uint8Array): boolean {
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Best-effort revert-reason extractor for viem errors. Walks the `cause`
+ * chain looking for stable fields — `reason` (Solidity `revert("msg")`),
+ * decoded custom error name, or signature. Falls back to top-level
+ * `shortMessage` / `details` ONLY when the chain contains a
+ * `ContractFunctionExecutionError` / `ContractFunctionRevertedError` —
+ * otherwise transport/RPC errors (e.g. `HttpRequestError`) would surface
+ * misleading reasons like "HTTP request failed". Returns undefined for
+ * unrecognized shapes.
+ */
+function extractViemRevertReason(err: unknown): string | undefined {
+  if (!err || typeof err !== "object") return undefined;
+
+  let current: any = err;
+  let sawContractError = false;
+  for (let i = 0; i < 5 && current; i++) {
+    if (
+      current.name === "ContractFunctionExecutionError" ||
+      current.name === "ContractFunctionRevertedError"
+    ) {
+      sawContractError = true;
+    }
+    if (typeof current.reason === "string" && current.reason.length > 0) {
+      return current.reason;
+    }
+    const decoded = current.data;
+    if (
+      decoded &&
+      typeof decoded === "object" &&
+      typeof decoded.errorName === "string" &&
+      decoded.errorName.length > 0
+    ) {
+      return decoded.errorName;
+    }
+    if (typeof current.signature === "string" && current.signature.length > 0) {
+      return current.signature;
+    }
+    current = current.cause;
+  }
+
+  if (!sawContractError) return undefined;
+
+  const top: any = err;
+  if (typeof top.shortMessage === "string" && top.shortMessage.length > 0) {
+    return top.shortMessage;
+  }
+  if (typeof top.details === "string" && top.details.length > 0) {
+    return top.details;
+  }
+  return undefined;
 }

--- a/packages/sdk/src/consumer.ts
+++ b/packages/sdk/src/consumer.ts
@@ -23,6 +23,7 @@ import { verifyAttestation, type AttestationConfig } from "./attestation.js";
 import { queryCDRPartials } from "./story-api/client.js";
 import type { DKGPartialDecryptionSubmission } from "./story-api/types.js";
 import { safeWriteContract } from "./_tx-submit.js";
+import { waitForReceiptResilient } from "./_rpc-resilience.js";
 
 /**
  * Consumer reads encrypted vault data from the CDR contract and recovers the
@@ -146,7 +147,7 @@ export class Consumer {
       value: fee,
     });
 
-    const receipt = await this.publicClient.waitForTransactionReceipt({ hash: txHash });
+    const receipt = await waitForReceiptResilient(this.publicClient, txHash);
 
     if (receipt.status === "reverted") {
       const reason = await this.decodeReadRevertReason({

--- a/packages/sdk/src/consumer.ts
+++ b/packages/sdk/src/consumer.ts
@@ -290,8 +290,14 @@ export class Consumer {
     const reported = new Set<string>();
     /** Last-known submission count (within the matching bucket), for the timeout error. */
     let lastSeen = 0;
-    /** Last-known round threshold, for the timeout error. */
-    let lastNeeded = 0;
+    /**
+     * Last-known round threshold, for the timeout error. Seeded from the
+     * active-round threshold so a complete no-show timeout still surfaces a
+     * meaningful `needed` value (e.g. `got 0/3`) rather than `got 0/0`.
+     * Overridden by `getThresholdAt(group.round)` once a matching bucket
+     * appears.
+     */
+    let lastNeeded = await this.observer.getThreshold().catch(() => 0);
 
     while (Date.now() < deadline) {
       let groups: Awaited<ReturnType<typeof queryCDRPartials>> = [];

--- a/packages/sdk/src/errors.ts
+++ b/packages/sdk/src/errors.ts
@@ -101,3 +101,18 @@ export class EmptyVaultError extends CDRError {
     this.uuid = uuid;
   }
 }
+
+export class ReadTransactionRevertedError extends CDRError {
+  txHash: `0x${string}`;
+  reason?: string;
+  constructor(txHash: `0x${string}`, reason?: string) {
+    super(
+      reason
+        ? `Read transaction ${txHash} reverted: ${reason}`
+        : `Read transaction ${txHash} reverted`,
+      "READ_TX_REVERTED",
+    );
+    this.txHash = txHash;
+    this.reason = reason;
+  }
+}

--- a/packages/sdk/src/errors.ts
+++ b/packages/sdk/src/errors.ts
@@ -14,11 +14,17 @@ export class WalletClientRequiredError extends CDRError {
 }
 
 export class PartialCollectionTimeoutError extends CDRError {
+  collected: number;
+  needed: number;
+  timeoutMs: number;
   constructor(collected: number, needed: number, timeoutMs: number) {
     super(
       `Timed out collecting partials after ${timeoutMs}ms: got ${collected}/${needed}`,
       "PARTIAL_COLLECTION_TIMEOUT",
     );
+    this.collected = collected;
+    this.needed = needed;
+    this.timeoutMs = timeoutMs;
   }
 }
 

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -30,6 +30,22 @@ export interface PartialDecryptionEvent {
   ciphertext: `0x${string}`;
 }
 
+/**
+ * Tagged reason passed to `onInvalidPartial` callbacks when `collectPartials`
+ * drops a validator's submission. Discriminate on `kind` for telemetry /
+ * UI / fallback logic instead of regex-matching error messages.
+ *
+ * Currently only `attestation-rejected` is emitted; the union is open to
+ * extension as future failure paths (e.g. stale registry, signature
+ * mismatch) are surfaced from the SDK.
+ */
+export type InvalidPartialReason = {
+  kind: "attestation-rejected";
+  validator: `0x${string}`;
+  pid: number;
+  round: number;
+};
+
 /** CDR Vault as stored on-chain */
 export interface Vault {
   uuid: number;


### PR DESCRIPTION
## Summary

- Surface reverted read transactions immediately with a typed `ReadTransactionRevertedError`, including tx hash and best-effort revert reason.
- Expose `collected`, `needed`, and `timeoutMs` on `PartialCollectionTimeoutError`, including meaningful no-bucket and attestation-filtered timeout counts.
- Replace string-based `onInvalidPartial` handling with typed `InvalidPartialReason` values for rejected partials.

## Issue

Closes #55.

## Why

Today, integrators have to regex-match error messages to tell unrelated failure modes apart, and a deterministic on-chain revert from `consumer.read()` surfaces ~60–120 s later as a `PartialCollectionTimeoutError: got 0/N` — misdiagnosed as a validator/network problem. The three sub-fixes in #55 share one concern: make SDK failures programmatically dispatchable without parsing English.

## What changed

### 1.1 `ReadTransactionRevertedError` (issue #55.1.1)

`Consumer.read()` now awaits the receipt and throws a typed error on `status === "reverted"`:

```ts
export class ReadTransactionRevertedError extends CDRError {
  txHash: `0x${string}`;
  reason?: string; // best-effort
}
```

`reason` is decoded best-effort by re-simulating the same call at `receipt.blockNumber` via `simulateContract` and walking viem's `cause` chain for `reason` / decoded `errorName` / `signature`. The `shortMessage` / `details` fallback is **gated** on having seen a `ContractFunctionExecutionError` or `ContractFunctionRevertedError` in the chain — otherwise transport-shaped errors (e.g. `HttpRequestError`) could surface misleading reasons like "HTTP request failed". On any simulation oddity, `reason` is left undefined and the typed error still throws.

Net result: an app-level revert (bad `accessAuxData`, expired license, fee mismatch) is now distinguishable from a partial-collection timeout within one block instead of two minutes.

### 1.2 Typed fields on `PartialCollectionTimeoutError` (issue #55.1.2)

```ts
export class PartialCollectionTimeoutError extends CDRError {
  collected: number;
  needed: number;
  timeoutMs: number;
}
```

Message string is unchanged → backward compatible for anyone matching `.message` / `.code`.

Two semantics improvements in `collectPartials`:

- `lastNeeded` is **seeded** from `observer.getThreshold()` before the poll loop (with `.catch(() => 0)`), so a complete no-show timeout reports `got 0/3` instead of the previous `got 0/0`. `getThresholdAt(group.round)` still overrides per matching bucket.
- Under `attestationConfig`, `lastSeen` is **updated to `accepted.length`** after the trust filter runs on the keep-polling branch. Previously a timeout could report `collected = raw bucket size` while only a smaller trusted subset was actually usable — the public field would have lied.

### 1.3 `InvalidPartialReason` (issue #55.1.3) — **breaking**

New discriminated union in `types.ts`:

```ts
export type InvalidPartialReason = {
  kind: "attestation-rejected";
  validator: `0x${string}`;
  pid: number;
  round: number;
};
```

`onInvalidPartial` now receives the typed reason as arg 2, with the legacy descriptive `Error` retained as optional arg 3.

## Breaking change

`onInvalidPartial` signature changed across `collectPartials`, `accessCDR`, and `downloadFile`.

Before:

```ts
onInvalidPartial: (event, error) => log(error.message)
```

After:

```ts
onInvalidPartial: (event, reason, error) => log(reason.kind, reason.validator)
```

## Test plan

- [x] `pnpm --filter @piplabs/cdr-sdk test` — 193 passing, 23 integration skipped (no live env)
- [x] `pnpm --filter @piplabs/cdr-sdk lint` (tsc --noEmit)
- [ ] Changeset added (minor bump) before merge
- [ ] Integration suite dispatched on merge if required by release process