### PR TITLE
fix(sdk): expose skipConditionValidation on uploadCDR and uploadFile

### DIFF
--- a/docs/CONDITIONS.md
+++ b/docs/CONDITIONS.md
@@ -76,6 +76,23 @@ When someone calls `write()` or `read()` on the CDR contract, the contract:
 
 This happens at the protocol level — the SDK does not enforce conditions locally. Your transaction will revert on-chain if conditions aren't met.
 
+### Bypassing Validation for EOA / Wallet-Address Conditions
+
+The CDR contract supports a short-circuit when `msg.sender == conditionAddr` — in that case, the on-chain `write()` / `read()` skips the condition `staticcall` entirely. This lets you use a plain wallet (EOA) address as the condition address for the simplest "only this wallet" access pattern, with no condition contract to deploy.
+
+Because the SDK validates the condition contract interface at allocation time (it simulates `checkWriteCondition` / `checkReadCondition`), an EOA address would fail that check. Pass `skipConditionValidation: true` to bypass it. `allocate()`, `uploadCDR()`, and `uploadFile()` all accept this flag:
+
+```typescript
+await client.uploader.uploadCDR({
+  // ...
+  writeConditionAddr: walletAddress,
+  readConditionAddr: walletAddress,
+  writeConditionData: "0x",
+  readConditionData: "0x",
+  skipConditionValidation: true,
+});
+```
+
 ## Expected Interface
 
 Condition contracts must implement these functions:

--- a/packages/sdk/__tests__/upload-file.test.ts
+++ b/packages/sdk/__tests__/upload-file.test.ts
@@ -9,7 +9,7 @@ vi.mock("@piplabs/cdr-crypto", () => ({
 
 import { Uploader } from "../src/uploader.js";
 import { tdh2Encrypt, encryptFile } from "@piplabs/cdr-crypto";
-import { ContentSizeExceededError } from "../src/errors.js";
+import { ContentSizeExceededError, InvalidConditionContractError } from "../src/errors.js";
 import type { StorageProvider } from "../src/storage/types.js";
 import type { Observer } from "../src/observer.js";
 
@@ -179,5 +179,83 @@ describe("Uploader.uploadFile", () => {
 
     // Allocate happened (size check is in `write`, after allocate); write was NOT.
     expect(walletClient.writeContract).toHaveBeenCalledOnce(); // allocate only
+  });
+
+  it("uploadFile with skipConditionValidation does not call simulateContract and completes", async () => {
+    const { publicClient, walletClient } = mockClients();
+    const storageProvider = mockStorageProvider();
+
+    const fakeKey = new Uint8Array(32).fill(0xaa);
+    const fakeFileCt = new Uint8Array([1, 2, 3]);
+    vi.mocked(encryptFile).mockReturnValue({ ciphertext: fakeFileCt, key: fakeKey });
+    vi.mocked(tdh2Encrypt).mockResolvedValue({
+      raw: new Uint8Array([10, 20, 30]),
+      label: new Uint8Array([4, 5]),
+    });
+
+    // allocateFee → allocate tx → allocate receipt → writeFee → write tx → write receipt
+    publicClient.readContract.mockResolvedValueOnce(1000n);
+    walletClient.writeContract.mockResolvedValueOnce("0xalloctx" as `0x${string}`);
+    publicClient.waitForTransactionReceipt.mockResolvedValueOnce({
+      logs: [makeVaultAllocatedLog(77)],
+    });
+    publicClient.readContract.mockResolvedValueOnce(200n);
+    walletClient.writeContract.mockResolvedValueOnce("0xwritetx" as `0x${string}`);
+    publicClient.waitForTransactionReceipt.mockResolvedValueOnce({});
+
+    const uploader = new Uploader({
+      network: "testnet",
+      publicClient,
+      walletClient,
+      observer: fakeObserver(),
+    });
+
+    const result = await uploader.uploadFile({
+      ...baseParams,
+      // EOA addresses — would fail interface validation if it ran.
+      writeConditionAddr: "0xeeee000000000000000000000000000000000001",
+      readConditionAddr: "0xeeee000000000000000000000000000000000002",
+      content: new TextEncoder().encode("hello"),
+      storageProvider,
+      skipConditionValidation: true,
+    });
+
+    expect(publicClient.simulateContract).not.toHaveBeenCalled();
+    // Pipeline ran through encrypt → storage upload → allocate → write.
+    expect(encryptFile).toHaveBeenCalledOnce();
+    expect(storageProvider.upload).toHaveBeenCalledOnce();
+    expect(result.uuid).toBe(77);
+    expect(result.txHashes.allocate).toBe("0xalloctx");
+    expect(result.txHashes.write).toBe("0xwritetx");
+  });
+
+  it("uploadFile without skipConditionValidation rejects EOA condition addresses with InvalidConditionContractError", async () => {
+    const { publicClient, walletClient } = mockClients();
+    const storageProvider = mockStorageProvider();
+    // Non-`ContractFunctionRevertedError` cause → validator treats this as a missing selector.
+    publicClient.simulateContract.mockReset();
+    publicClient.simulateContract.mockRejectedValue(new Error("returned no data"));
+
+    const fakeKey = new Uint8Array(32).fill(0xaa);
+    vi.mocked(encryptFile).mockReturnValue({ ciphertext: new Uint8Array([1]), key: fakeKey });
+
+    const uploader = new Uploader({
+      network: "testnet",
+      publicClient,
+      walletClient,
+      observer: fakeObserver(),
+    });
+
+    await expect(
+      uploader.uploadFile({
+        ...baseParams,
+        writeConditionAddr: "0xeeee000000000000000000000000000000000001",
+        readConditionAddr: "0xeeee000000000000000000000000000000000002",
+        content: new TextEncoder().encode("hello"),
+        storageProvider,
+      }),
+    ).rejects.toThrow(InvalidConditionContractError);
+
+    expect(walletClient.writeContract).not.toHaveBeenCalled();
   });
 });

--- a/packages/sdk/__tests__/uploader.test.ts
+++ b/packages/sdk/__tests__/uploader.test.ts
@@ -9,7 +9,7 @@ vi.mock("@piplabs/cdr-crypto", () => ({
 
 import { Uploader } from "../src/uploader.js";
 import { tdh2Encrypt } from "@piplabs/cdr-crypto";
-import { ContentSizeExceededError } from "../src/errors.js";
+import { ContentSizeExceededError, InvalidConditionContractError } from "../src/errors.js";
 import type { Observer } from "../src/observer.js";
 
 /**
@@ -290,6 +290,79 @@ describe("Uploader", () => {
     // No tx ever submitted — fail-fast before writeContract.
     expect(walletClient.writeContract).not.toHaveBeenCalled();
     expect(observer.getMaxEncryptedDataSize).toHaveBeenCalledOnce();
+  });
+
+  it("uploadCDR with skipConditionValidation does not call simulateContract and completes", async () => {
+    const { publicClient, walletClient } = mockClients();
+    // allocateFee
+    publicClient.readContract.mockResolvedValueOnce(1000n);
+    walletClient.writeContract.mockResolvedValueOnce("0xalloctx" as `0x${string}`);
+    publicClient.waitForTransactionReceipt.mockResolvedValueOnce({
+      logs: [makeVaultAllocatedLog(99)],
+    });
+    // writeFee
+    publicClient.readContract.mockResolvedValueOnce(200n);
+    walletClient.writeContract.mockResolvedValueOnce("0xwritetx" as `0x${string}`);
+    publicClient.waitForTransactionReceipt.mockResolvedValueOnce({});
+
+    vi.mocked(tdh2Encrypt).mockResolvedValueOnce({
+      raw: new Uint8Array([1, 2, 3]),
+      label: new Uint8Array([4, 5]),
+    });
+
+    const uploader = new Uploader({
+      network: "testnet",
+      publicClient,
+      walletClient,
+      observer: fakeObserver(),
+    });
+
+    // EOA addresses — would fail interface validation if it ran.
+    const result = await uploader.uploadCDR({
+      dataKey: new Uint8Array([0x11]),
+      globalPubKey: new Uint8Array([0xaa]),
+      updatable: false,
+      writeConditionAddr: "0xeeee000000000000000000000000000000000001",
+      readConditionAddr: "0xeeee000000000000000000000000000000000002",
+      writeConditionData: "0x",
+      readConditionData: "0x",
+      accessAuxData: "0x",
+      skipConditionValidation: true,
+    });
+
+    expect(publicClient.simulateContract).not.toHaveBeenCalled();
+    expect(result.uuid).toBe(99);
+    expect(result.txHashes.allocate).toBe("0xalloctx");
+    expect(result.txHashes.write).toBe("0xwritetx");
+  });
+
+  it("uploadCDR without skipConditionValidation rejects EOA condition addresses with InvalidConditionContractError", async () => {
+    const { publicClient, walletClient } = mockClients();
+    // No `cause` → validator treats this as a missing selector / non-contract address.
+    publicClient.simulateContract.mockReset();
+    publicClient.simulateContract.mockRejectedValue(new Error("returned no data"));
+
+    const uploader = new Uploader({
+      network: "testnet",
+      publicClient,
+      walletClient,
+      observer: fakeObserver(),
+    });
+
+    await expect(
+      uploader.uploadCDR({
+        dataKey: new Uint8Array([0x11]),
+        globalPubKey: new Uint8Array([0xaa]),
+        updatable: false,
+        writeConditionAddr: "0xeeee000000000000000000000000000000000001",
+        readConditionAddr: "0xeeee000000000000000000000000000000000002",
+        writeConditionData: "0x",
+        readConditionData: "0x",
+        accessAuxData: "0x",
+      }),
+    ).rejects.toThrow(InvalidConditionContractError);
+
+    expect(walletClient.writeContract).not.toHaveBeenCalled();
   });
 
   it("write passes when encryptedData is within maxEncryptedDataSize", async () => {

--- a/packages/sdk/src/uploader.ts
+++ b/packages/sdk/src/uploader.ts
@@ -233,6 +233,8 @@ export class Uploader {
     allocateFeeOverride?: bigint;
     /** See {@link write}'s `feeOverride` — same strict-equality semantics. */
     writeFeeOverride?: bigint;
+    /** Skip condition contract interface validation (default: false). */
+    skipConditionValidation?: boolean;
   }): Promise<{
     uuid: number;
     ciphertext: TDH2Ciphertext;
@@ -246,6 +248,7 @@ export class Uploader {
       writeConditionData: params.writeConditionData,
       readConditionData: params.readConditionData,
       feeOverride: params.allocateFeeOverride,
+      skipConditionValidation: params.skipConditionValidation,
     });
 
     // Step 2: Encrypt using UUID-derived label (matches validator's uuidToLabel)
@@ -305,6 +308,8 @@ export class Uploader {
     allocateFeeOverride?: bigint;
     /** See {@link write}'s `feeOverride` — same strict-equality semantics. */
     writeFeeOverride?: bigint;
+    /** Skip condition contract interface validation (default: false). */
+    skipConditionValidation?: boolean;
   }): Promise<{
     uuid: number;
     cid: string;
@@ -331,6 +336,7 @@ export class Uploader {
       writeConditionData: params.writeConditionData,
       readConditionData: params.readConditionData,
       feeOverride: params.allocateFeeOverride,
+      skipConditionValidation: params.skipConditionValidation,
     });
 
     // Step 5: TDH2-encrypt the payload with UUID-derived label


### PR DESCRIPTION
## Why
Closes #50.

`uploadCDR()` and `uploadFile()` both call `allocate()` internally, which validates that the configured condition addresses implement `checkWriteCondition` / `checkReadCondition`. `allocate()` already exposes `skipConditionValidation` to bypass that check — needed for the CDR contract's `msg.sender == conditionAddr` short-circuit (CDR.sol `write()` line 174, `read()` line 217) when callers use a plain EOA / wallet address as the condition. The high-level wrappers didn't forward the flag, so the EOA-as-condition pattern wasn't reachable through them and would always throw `InvalidConditionContractError`.

## Change
- `packages/sdk/src/uploader.ts` — add optional `skipConditionValidation?: boolean` to `uploadCDR()` and `uploadFile()` param types; forward to the internal `allocate()` call. JSDoc matches the existing comment on `allocate()`.
- `packages/sdk/__tests__/uploader.test.ts` — two new tests for `uploadCDR`: pass-through with EOA addresses asserts `simulateContract` is **not** called and the run completes; default path with a non-`ContractFunctionRevertedError` cause throws `InvalidConditionContractError` and no tx is sent.
- `packages/sdk/__tests__/upload-file.test.ts` — mirror tests for `uploadFile`, exercising the full `encryptFile → storage.upload → allocate → tdh2Encrypt → write` pipeline so the skip assertion runs against a fully-completed call.
- `docs/CONDITIONS.md` — new \"Bypassing Validation for EOA / Wallet-Address Conditions\" subsection under \"How Conditions Work\", explaining the bypass and showing the flag on `uploadCDR`.

No behavior change when the flag is omitted (default `false`).

## Test plan
- [x] \`pnpm --filter @piplabs/cdr-sdk test\` — 187 passed (+4 new), 0 failures
- [x] \`pnpm --filter @piplabs/cdr-sdk lint\` — clean
- [ ] PR CI green