### PR TITLE
test(ephemeral): size per-wallet fund from live CDR fees + render fee table in summary

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -559,6 +559,51 @@ jobs:
             done
           }
 
+          # ─── Fee table: glob /tmp/fee-stats-*.json ────────────────────────────
+          # Each ephemeral suite queries baseFee / writeFee / readFee /
+          # allocateFee off the live CDR contract at setup time and writes
+          # them to /tmp/fee-stats-{label}.json alongside the per-cycle cost
+          # it actually used + the computed per-wallet fund. We render that
+          # here so any "100 wallets failed with insufficient funds" failure
+          # mode is one table-row away from being diagnosed — you can see
+          # at a glance whether the chain raised a fee since the last run
+          # and whether the suite's fund covers it.
+          render_fee_table() {
+            shopt -s nullglob
+            local files=(/tmp/fee-stats-*.json)
+            shopt -u nullglob
+            [ "${#files[@]}" -gt 0 ] || { echo "_(no fee-stats output produced — no ephemeral suite ran)_"; echo ""; return; }
+            echo "**One row per ephemeral suite.** Fees are queried live off the CDR contract at suite setup."
+            echo "\`Per-cycle\` = the payable value the suite expects per (upload + access) iteration —"
+            echo "read-only suites (100w-shared, 1000w-perf) bill only \`readFee\`; full-cycle suites add \`baseFee + writeFee + allocateFee\`; stress adds an extra \`readFee\` for the second access per cycle."
+            echo "\`Per-wallet fund\` = \`per-cycle × cycles × safety_multiplier + gas_reserve × cycles\`."
+            echo ""
+            echo "| Suite | baseFee | writeFee | readFee | allocateFee | Per-cycle | Cycles/wallet | Safety× | Per-wallet fund |"
+            echo "|---|---|---|---|---|---|---|---|---|"
+            for f in "${files[@]}"; do
+              jq -r '
+                def fmtIp:
+                  ((. | tonumber) / 1e18) as $ip |
+                  ($ip * 10000 | floor) as $n |
+                  ($n / 10000 | floor | tostring) as $whole |
+                  ($n % 10000 | tostring) as $fracraw |
+                  ("0000" + $fracraw)[-4:] as $frac |
+                  $whole + "." + $frac + " IP";
+                "| " + .label
+                + " | " + (.baseFee_wei         | fmtIp)
+                + " | " + (.writeFee_wei        | fmtIp)
+                + " | " + (.readFee_wei         | fmtIp)
+                + " | " + (.allocateFee_wei     | fmtIp)
+                + " | " + (.per_cycle_wei       | fmtIp)
+                + " | " + (.cycles_per_wallet   | tostring)
+                + " | " + (.safety_multiplier   | tostring)
+                + " | " + (.per_wallet_fund_wei | fmtIp)
+                + " |"
+              ' "$f"
+            done
+            echo ""
+          }
+
           # ─── Now write everything to GITHUB_STEP_SUMMARY in the new order ─────
           {
             echo "## ${HEADLINE_EMOJI} Overall — ${TOTAL_PASSED} passed | ${TOTAL_FAILED} failed | ${TOTAL_SKIPPED} skipped — wall ${ELAPSED_S}s"
@@ -598,6 +643,10 @@ jobs:
             echo ""
             echo "_DKG stage codes: 1 = Registration, 2 = Dealing, 3 = Finalization, 4 = Active._"
             echo ""
+
+            echo "### Live CDR fees + ephemeral fund sizing"
+            echo ""
+            render_fee_table
 
             echo "### Performance metrics"
             echo ""

--- a/packages/sdk/__integration__/_helpers.ts
+++ b/packages/sdk/__integration__/_helpers.ts
@@ -7,6 +7,8 @@
  */
 
 import { expect, vi } from "vitest";
+import type { PublicClient } from "viem";
+import { cdrAbi, contractAddresses, type Network } from "@piplabs/cdr-contracts";
 import { bytesToHex } from "../src/story-api/index.js";
 
 /**
@@ -210,5 +212,159 @@ export function writePerfStats(file: PerfStatsFile): void {
   } catch (e) {
     // eslint-disable-next-line no-console
     console.warn(`[perf-stats] failed to write ${path}: ${(e as Error).message}`);
+  }
+}
+
+/**
+ * The four fee getters on the CDR contract, all denominated in wei.
+ * Per-tx payable composition (current contract behavior on aeneid + devnet):
+ *
+ *   uploadCDR.value = baseFee + writeFee + allocateFee
+ *   accessCDR.value = readFee                       (NO baseFee)
+ *
+ * `baseFee` is only charged on the upload path. Read-only suites
+ * (100w-shared, 1000w-perf) pay readFee only.
+ */
+export interface CDRFees {
+  baseFee: bigint;
+  writeFee: bigint;
+  readFee: bigint;
+  allocateFee: bigint;
+}
+
+/**
+ * Query all four fees off the live CDR proxy at
+ * `contractAddresses[network].cdr`. One RPC roundtrip per getter (4 total).
+ * Each ephemeral suite calls this once at setup so the per-wallet fund
+ * tracks whatever fees are live on the target chain — avoids the
+ * hard-coded `parseEther("0.1")` shortfall that broke 100w-fresh-aeneid
+ * once aeneid raised all four fees from 0.01 IP → 0.03 IP.
+ */
+export async function queryCDRFees(
+  publicClient: PublicClient,
+  network: Network,
+): Promise<CDRFees> {
+  const cdrAddress = contractAddresses[network].cdr;
+  const [baseFee, writeFee, readFee, allocateFee] = await Promise.all([
+    publicClient.readContract({
+      address: cdrAddress,
+      abi: cdrAbi,
+      functionName: "baseFee",
+    }) as Promise<bigint>,
+    publicClient.readContract({
+      address: cdrAddress,
+      abi: cdrAbi,
+      functionName: "writeFee",
+    }) as Promise<bigint>,
+    publicClient.readContract({
+      address: cdrAddress,
+      abi: cdrAbi,
+      functionName: "readFee",
+    }) as Promise<bigint>,
+    publicClient.readContract({
+      address: cdrAddress,
+      abi: cdrAbi,
+      functionName: "allocateFee",
+    }) as Promise<bigint>,
+  ]);
+  return { baseFee, writeFee, readFee, allocateFee };
+}
+
+/**
+ * Required `payable` value for one uploadCDR call, EXCLUDING gas.
+ * Mirrors the contract's `require(msg.value == baseFee + writeFee +
+ * allocateFee)` on the write path.
+ */
+export function uploadFeeCost(fees: CDRFees): bigint {
+  return fees.baseFee + fees.writeFee + fees.allocateFee;
+}
+
+/**
+ * Required `payable` value for one accessCDR call, EXCLUDING gas.
+ * Mirrors `require(msg.value == readFee)` on the read path. `baseFee`
+ * is NOT charged on access — read-only suites (100w-shared, 1000w-perf)
+ * pay only this.
+ */
+export function accessFeeCost(fees: CDRFees): bigint {
+  return fees.readFee;
+}
+
+/**
+ * Required `payable` value for one (upload + access) cycle. Suites that
+ * exercise both paths per wallet (100w-fresh*, 60min-stress) use this.
+ */
+export function cycleFeeCost(fees: CDRFees): bigint {
+  return uploadFeeCost(fees) + accessFeeCost(fees);
+}
+
+/**
+ * Compute per-wallet fund for an ephemeral suite. Callers pass the
+ * per-cycle cost they expect (`cycleFeeCost`/`uploadFeeCost`/
+ * `accessFeeCost`) so this helper stays agnostic to which contract
+ * paths the suite exercises.
+ *
+ *   funded = perCycleWei × cyclesPerWallet × safetyMultiplier
+ *          + gasReserveWei × cyclesPerWallet
+ *
+ * `safetyMultiplier` covers fee bumps mid-run + per-tx gas variance;
+ * default 3× tracks the historical funded/needed ratio on devnet
+ * (PER_WALLET_FUND=0.1 IP vs single-cycle fee cost ≈ 0.04 IP).
+ * `gasReserveWei` defaults to 0.005 IP per tx, matching the same
+ * conservative gas reserve used by `_ephemeral-wallets.ts::refundWallets`.
+ *
+ * Returns a bigint suitable for passing straight into `fundWallets`.
+ */
+export function computePerWalletFund(opts: {
+  perCycleWei: bigint;
+  cyclesPerWallet: number;
+  safetyMultiplier?: number;
+  gasReserveWei?: bigint;
+}): bigint {
+  const cycles = BigInt(opts.cyclesPerWallet);
+  const multiplier = BigInt(Math.round((opts.safetyMultiplier ?? 3) * 100));
+  // Multiply by safetyMultiplier × 100 then divide by 100 to keep bigint
+  // math integral when callers pass a fractional multiplier like 2.5.
+  const padded = (opts.perCycleWei * cycles * multiplier) / 100n;
+  const gas = opts.gasReserveWei ?? 5_000_000_000_000_000n; // 0.005 IP
+  return padded + gas * cycles;
+}
+
+/**
+ * Per-suite fee snapshot written to `/tmp/fee-stats-{label}.json` at the
+ * end of each ephemeral suite setup. The integration workflow's summary
+ * step globs these files and renders one table row per file in the Step
+ * Summary, surfacing live fee values + actual per-wallet fund used
+ * alongside the perf table.
+ */
+export interface FeeStatsFile {
+  label: string;
+  network: string;
+  baseFee_wei: string;
+  writeFee_wei: string;
+  readFee_wei: string;
+  allocateFee_wei: string;
+  /**
+   * The per-cycle fee cost the suite used to compute its fund — either
+   * `cycleFeeCost` (full upload+access), `uploadFeeCost`, or `accessFeeCost`
+   * depending on which contract path the suite exercises.
+   */
+  per_cycle_wei: string;
+  cycles_per_wallet: number;
+  safety_multiplier: number;
+  per_wallet_fund_wei: string;
+}
+
+export function writeFeeStats(file: FeeStatsFile): void {
+  // Lazy fs import — see writePerfStats above for the rationale.
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const fs = require("node:fs") as typeof import("node:fs");
+  const path = `/tmp/fee-stats-${file.label}.json`;
+  try {
+    fs.writeFileSync(path, JSON.stringify(file, null, 2));
+    // eslint-disable-next-line no-console
+    console.log(`[fee-stats] wrote ${path}`);
+  } catch (e) {
+    // eslint-disable-next-line no-console
+    console.warn(`[fee-stats] failed to write ${path}: ${(e as Error).message}`);
   }
 }

--- a/packages/sdk/__integration__/_helpers.ts
+++ b/packages/sdk/__integration__/_helpers.ts
@@ -304,13 +304,14 @@ export function cycleFeeCost(fees: CDRFees): bigint {
  * paths the suite exercises.
  *
  *   funded = perCycleWei × cyclesPerWallet × safetyMultiplier
- *          + gasReserveWei × cyclesPerWallet
+ *          + gasReservePerCycleWei × cyclesPerWallet
  *
  * `safetyMultiplier` covers fee bumps mid-run + per-tx gas variance;
  * default 3× tracks the historical funded/needed ratio on devnet
  * (PER_WALLET_FUND=0.1 IP vs single-cycle fee cost ≈ 0.04 IP).
- * `gasReserveWei` defaults to 0.005 IP per tx, matching the same
- * conservative gas reserve used by `_ephemeral-wallets.ts::refundWallets`.
+ * `gasReservePerCycleWei` defaults to 0.005 IP per cycle, which covers
+ * 1-3 txs of typical gas (~0.001-0.002 IP per tx). Same order of
+ * magnitude as the `refundWallets` end-of-suite reserve.
  *
  * Returns a bigint suitable for passing straight into `fundWallets`.
  */
@@ -318,14 +319,14 @@ export function computePerWalletFund(opts: {
   perCycleWei: bigint;
   cyclesPerWallet: number;
   safetyMultiplier?: number;
-  gasReserveWei?: bigint;
+  gasReservePerCycleWei?: bigint;
 }): bigint {
   const cycles = BigInt(opts.cyclesPerWallet);
   const multiplier = BigInt(Math.round((opts.safetyMultiplier ?? 3) * 100));
   // Multiply by safetyMultiplier × 100 then divide by 100 to keep bigint
   // math integral when callers pass a fractional multiplier like 2.5.
   const padded = (opts.perCycleWei * cycles * multiplier) / 100n;
-  const gas = opts.gasReserveWei ?? 5_000_000_000_000_000n; // 0.005 IP
+  const gas = opts.gasReservePerCycleWei ?? 5_000_000_000_000_000n; // 0.005 IP
   return padded + gas * cycles;
 }
 
@@ -367,4 +368,69 @@ export function writeFeeStats(file: FeeStatsFile): void {
     // eslint-disable-next-line no-console
     console.warn(`[fee-stats] failed to write ${path}: ${(e as Error).message}`);
   }
+}
+
+/**
+ * Suite-side convenience wrapper: query live fees, compute per-wallet
+ * fund, persist the fee-stats snapshot for the workflow summary, and
+ * return the fund. Folds the boilerplate that all five ephemeral suites
+ * share into a single call. The `perCycleCost` selector lets each suite
+ * pick the cost shape it actually exercises without the helper having
+ * to know which contract paths it touches.
+ *
+ *   const perWalletFund = await sizeFundAndReport({
+ *     label: "100w-fresh-aeneid",
+ *     network: NETWORK,
+ *     publicClient: funderPublic,
+ *     perCycleCost: cycleFeeCost,            // or accessFeeCost / uploadFeeCost
+ *     cyclesPerWallet: 1,
+ *     safetyMultiplier: 3,
+ *   });
+ *
+ * Logs the fee snapshot via `console.log` so the suite's CI output
+ * preserves the same one-line trace that the previous bespoke logCase
+ * calls produced.
+ */
+export async function sizeFundAndReport(opts: {
+  label: string;
+  network: string;
+  publicClient: PublicClient;
+  contractNetwork?: Network;
+  perCycleCost: (fees: CDRFees) => bigint;
+  cyclesPerWallet: number;
+  safetyMultiplier?: number;
+  gasReservePerCycleWei?: bigint;
+}): Promise<bigint> {
+  const fees = await queryCDRFees(
+    opts.publicClient,
+    opts.contractNetwork ?? "testnet",
+  );
+  const perCycleWei = opts.perCycleCost(fees);
+  const safetyMultiplier = opts.safetyMultiplier ?? 3;
+  const perWalletFund = computePerWalletFund({
+    perCycleWei,
+    cyclesPerWallet: opts.cyclesPerWallet,
+    safetyMultiplier,
+    gasReservePerCycleWei: opts.gasReservePerCycleWei,
+  });
+  writeFeeStats({
+    label: opts.label,
+    network: opts.network,
+    baseFee_wei: fees.baseFee.toString(),
+    writeFee_wei: fees.writeFee.toString(),
+    readFee_wei: fees.readFee.toString(),
+    allocateFee_wei: fees.allocateFee.toString(),
+    per_cycle_wei: perCycleWei.toString(),
+    cycles_per_wallet: opts.cyclesPerWallet,
+    safety_multiplier: safetyMultiplier,
+    per_wallet_fund_wei: perWalletFund.toString(),
+  });
+  // eslint-disable-next-line no-console
+  console.log(
+    `[fee-sizing][${opts.label}] base=${fees.baseFee} write=${fees.writeFee} ` +
+      `read=${fees.readFee} allocate=${fees.allocateFee} perCycle=${perCycleWei} ` +
+      `cycles=${opts.cyclesPerWallet} safety=${safetyMultiplier} ` +
+      `perWalletFund=${perWalletFund}`,
+  );
+  return perWalletFund;
 }

--- a/packages/sdk/__integration__/ephemeral-1000w-perf.test.ts
+++ b/packages/sdk/__integration__/ephemeral-1000w-perf.test.ts
@@ -46,7 +46,6 @@ import {
 } from "./_ephemeral-wallets.js";
 import {
   accessFeeCost,
-  computePerWalletFund,
   formatMs,
   logCase,
   max as arrMax,
@@ -54,9 +53,8 @@ import {
   p50,
   p95,
   p99,
-  queryCDRFees,
+  sizeFundAndReport,
   statsOf,
-  writeFeeStats,
   writePerfStats,
 } from "./_helpers.js";
 
@@ -190,31 +188,13 @@ describe.skipIf(skipUnlessSuite("1000-wallet-performance-devnet-only") || NETWOR
       // Read-only suite: each wallet pays readFee only. Size fund from
       // live readFee so we don't have to rotate this hard-coded number
       // every time chain fees move.
-      const fees = await queryCDRFees(funderPublic, "testnet");
-      const perCycleWei = accessFeeCost(fees);
-      perWalletFund = computePerWalletFund({
-        perCycleWei,
-        cyclesPerWallet: CYCLES_PER_WALLET,
-        safetyMultiplier: FUND_SAFETY_MULTIPLIER,
-      });
-      writeFeeStats({
+      perWalletFund = await sizeFundAndReport({
         label: "1000w-perf",
         network: NETWORK,
-        baseFee_wei: fees.baseFee.toString(),
-        writeFee_wei: fees.writeFee.toString(),
-        readFee_wei: fees.readFee.toString(),
-        allocateFee_wei: fees.allocateFee.toString(),
-        per_cycle_wei: perCycleWei.toString(),
-        cycles_per_wallet: CYCLES_PER_WALLET,
-        safety_multiplier: FUND_SAFETY_MULTIPLIER,
-        per_wallet_fund_wei: perWalletFund.toString(),
-      });
-      logCase("fees + fund sizing", {
-        readFee: fees.readFee.toString(),
-        perCycleWei: perCycleWei.toString(),
+        publicClient: funderPublic,
+        perCycleCost: accessFeeCost,
         cyclesPerWallet: CYCLES_PER_WALLET,
         safetyMultiplier: FUND_SAFETY_MULTIPLIER,
-        perWalletFund: perWalletFund.toString(),
       });
 
       openCondition = await deployOpenCondition(funderPublic, funderWallet);

--- a/packages/sdk/__integration__/ephemeral-1000w-perf.test.ts
+++ b/packages/sdk/__integration__/ephemeral-1000w-perf.test.ts
@@ -34,7 +34,6 @@ import {
   createWalletClient,
   formatEther,
   http,
-  parseEther,
 } from "viem";
 import { privateKeyToAccount } from "viem/accounts";
 import { CDRClient, initWasm } from "../src/index.js";
@@ -46,6 +45,8 @@ import {
   refundWallets,
 } from "./_ephemeral-wallets.js";
 import {
+  accessFeeCost,
+  computePerWalletFund,
   formatMs,
   logCase,
   max as arrMax,
@@ -53,7 +54,9 @@ import {
   p50,
   p95,
   p99,
+  queryCDRFees,
   statsOf,
+  writeFeeStats,
   writePerfStats,
 } from "./_helpers.js";
 
@@ -61,7 +64,8 @@ const WALLET_COUNT = 1000;
 // 200-wallet batch keeps Multicall3.aggregate3Value tx-gas ≲ 12M, well
 // under Story's ~30M block gas limit on both DevNet + Aeneid.
 const FUND_BATCH_SIZE = 200;
-const PER_WALLET_FUND = parseEther("0.05");
+const CYCLES_PER_WALLET = 1; // 1 accessCDR per wallet, no upload
+const FUND_SAFETY_MULTIPLIER = 3;
 const ACCESS_TIMEOUT_MS = 300_000;
 
 const API_URL = process.env.CDR_API_URL;
@@ -166,6 +170,7 @@ describe.skipIf(skipUnlessSuite("1000-wallet-performance-devnet-only") || NETWOR
     let sharedVaultUuid: number;
     let sharedDataKey: Uint8Array;
     let wallets: EphemeralWallet[];
+    let perWalletFund = 0n;
     let totalFundedWei = 0n;
     let perfBuffer: {
       fulfilled: number;
@@ -181,6 +186,36 @@ describe.skipIf(skipUnlessSuite("1000-wallet-performance-devnet-only") || NETWOR
       funderWallet = f.walletClient;
       funderClient = f.client;
       funderAddress = privateKeyToAccount(FUNDER_KEY!).address;
+
+      // Read-only suite: each wallet pays readFee only. Size fund from
+      // live readFee so we don't have to rotate this hard-coded number
+      // every time chain fees move.
+      const fees = await queryCDRFees(funderPublic, "testnet");
+      const perCycleWei = accessFeeCost(fees);
+      perWalletFund = computePerWalletFund({
+        perCycleWei,
+        cyclesPerWallet: CYCLES_PER_WALLET,
+        safetyMultiplier: FUND_SAFETY_MULTIPLIER,
+      });
+      writeFeeStats({
+        label: "1000w-perf",
+        network: NETWORK,
+        baseFee_wei: fees.baseFee.toString(),
+        writeFee_wei: fees.writeFee.toString(),
+        readFee_wei: fees.readFee.toString(),
+        allocateFee_wei: fees.allocateFee.toString(),
+        per_cycle_wei: perCycleWei.toString(),
+        cycles_per_wallet: CYCLES_PER_WALLET,
+        safety_multiplier: FUND_SAFETY_MULTIPLIER,
+        per_wallet_fund_wei: perWalletFund.toString(),
+      });
+      logCase("fees + fund sizing", {
+        readFee: fees.readFee.toString(),
+        perCycleWei: perCycleWei.toString(),
+        cyclesPerWallet: CYCLES_PER_WALLET,
+        safetyMultiplier: FUND_SAFETY_MULTIPLIER,
+        perWalletFund: perWalletFund.toString(),
+      });
 
       openCondition = await deployOpenCondition(funderPublic, funderWallet);
       logCase("openCondition", openCondition);
@@ -206,14 +241,14 @@ describe.skipIf(skipUnlessSuite("1000-wallet-performance-devnet-only") || NETWOR
         funderPublic,
         funderWallet,
         wallets,
-        PER_WALLET_FUND,
+        perWalletFund,
         FUND_BATCH_SIZE,
       );
       logCase("multicall3 batched fund", {
         wallets: wallets.length,
         batchSize: FUND_BATCH_SIZE,
         batches: Math.ceil(wallets.length / FUND_BATCH_SIZE),
-        perWallet: formatEther(PER_WALLET_FUND),
+        perWallet: formatEther(perWalletFund),
         totalIP: formatEther(totalFundedWei),
         elapsedMs: formatMs(Date.now() - fundStart),
       });

--- a/packages/sdk/__integration__/ephemeral-100w-fresh-aeneid.test.ts
+++ b/packages/sdk/__integration__/ephemeral-100w-fresh-aeneid.test.ts
@@ -43,16 +43,14 @@ import {
   refundWallets,
 } from "./_ephemeral-wallets.js";
 import {
-  computePerWalletFund,
   cycleFeeCost,
   formatMs,
   logCase,
   mean,
   p50,
   p95,
-  queryCDRFees,
+  sizeFundAndReport,
   statsOf,
-  writeFeeStats,
   writePerfStats,
 } from "./_helpers.js";
 import { pLimit, resilientHttp } from "./_rpc-resilience.js";
@@ -154,38 +152,17 @@ describe.skipIf(skipUnlessSuite("default") || NETWORK !== "aeneid")(
       funderWallet = f.walletClient;
       funderAddress = privateKeyToAccount(FUNDER_KEY!).address;
 
-      // Query live CDR fees and size each wallet's fund to actual on-chain
-      // cost. The previous hard-coded 0.1 IP broke on aeneid once all four
-      // fees moved 0.01 → 0.03 IP — 0.1 IP minus a single upload (~0.078 IP)
-      // left only ~0.022 IP, below the 0.03 IP value the read tx requires.
-      const fees = await queryCDRFees(funderPublic, "testnet");
-      const perCycleWei = cycleFeeCost(fees);
-      perWalletFund = computePerWalletFund({
-        perCycleWei,
-        cyclesPerWallet: CYCLES_PER_WALLET,
-        safetyMultiplier: FUND_SAFETY_MULTIPLIER,
-      });
-      writeFeeStats({
+      // Size each wallet's fund from live CDR fees. The previous hard-coded
+      // 0.1 IP broke on aeneid once all four fees moved 0.01 → 0.03 IP —
+      // 0.1 IP minus a single upload (~0.078 IP) left only ~0.022 IP, below
+      // the 0.03 IP value the read tx requires.
+      perWalletFund = await sizeFundAndReport({
         label: "100w-fresh-aeneid",
         network: NETWORK,
-        baseFee_wei: fees.baseFee.toString(),
-        writeFee_wei: fees.writeFee.toString(),
-        readFee_wei: fees.readFee.toString(),
-        allocateFee_wei: fees.allocateFee.toString(),
-        per_cycle_wei: perCycleWei.toString(),
-        cycles_per_wallet: CYCLES_PER_WALLET,
-        safety_multiplier: FUND_SAFETY_MULTIPLIER,
-        per_wallet_fund_wei: perWalletFund.toString(),
-      });
-      logCase("fees + fund sizing", {
-        baseFee: fees.baseFee.toString(),
-        writeFee: fees.writeFee.toString(),
-        readFee: fees.readFee.toString(),
-        allocateFee: fees.allocateFee.toString(),
-        perCycleWei: perCycleWei.toString(),
+        publicClient: funderPublic,
+        perCycleCost: cycleFeeCost,
         cyclesPerWallet: CYCLES_PER_WALLET,
         safetyMultiplier: FUND_SAFETY_MULTIPLIER,
-        perWalletFund: perWalletFund.toString(),
       });
 
       openCondition = await deployOpenCondition(funderPublic, funderWallet);

--- a/packages/sdk/__integration__/ephemeral-100w-fresh-aeneid.test.ts
+++ b/packages/sdk/__integration__/ephemeral-100w-fresh-aeneid.test.ts
@@ -32,7 +32,6 @@ import {
   type WalletClient,
   createPublicClient,
   createWalletClient,
-  parseEther,
 } from "viem";
 import { privateKeyToAccount } from "viem/accounts";
 import { CDRClient, initWasm } from "../src/index.js";
@@ -43,11 +42,24 @@ import {
   generateEphemeralWallets,
   refundWallets,
 } from "./_ephemeral-wallets.js";
-import { formatMs, logCase, mean, p50, p95, statsOf, writePerfStats } from "./_helpers.js";
+import {
+  computePerWalletFund,
+  cycleFeeCost,
+  formatMs,
+  logCase,
+  mean,
+  p50,
+  p95,
+  queryCDRFees,
+  statsOf,
+  writeFeeStats,
+  writePerfStats,
+} from "./_helpers.js";
 import { pLimit, resilientHttp } from "./_rpc-resilience.js";
 
 const WALLET_COUNT = 100;
-const PER_WALLET_FUND = parseEther("0.1");
+const CYCLES_PER_WALLET = 1; // upload + access
+const FUND_SAFETY_MULTIPLIER = 3;
 const ACCESS_TIMEOUT_MS = 180_000;
 const MAX_INFLIGHT = 25;
 
@@ -125,6 +137,7 @@ describe.skipIf(skipUnlessSuite("default") || NETWORK !== "aeneid")(
     let funderAddress: `0x${string}`;
     let openCondition: `0x${string}`;
     let wallets: EphemeralWallet[];
+    let perWalletFund = 0n;
     let totalFundedWei = 0n;
     let perfBuffer: {
       fulfilled: number;
@@ -141,6 +154,40 @@ describe.skipIf(skipUnlessSuite("default") || NETWORK !== "aeneid")(
       funderWallet = f.walletClient;
       funderAddress = privateKeyToAccount(FUNDER_KEY!).address;
 
+      // Query live CDR fees and size each wallet's fund to actual on-chain
+      // cost. The previous hard-coded 0.1 IP broke on aeneid once all four
+      // fees moved 0.01 → 0.03 IP — 0.1 IP minus a single upload (~0.078 IP)
+      // left only ~0.022 IP, below the 0.03 IP value the read tx requires.
+      const fees = await queryCDRFees(funderPublic, "testnet");
+      const perCycleWei = cycleFeeCost(fees);
+      perWalletFund = computePerWalletFund({
+        perCycleWei,
+        cyclesPerWallet: CYCLES_PER_WALLET,
+        safetyMultiplier: FUND_SAFETY_MULTIPLIER,
+      });
+      writeFeeStats({
+        label: "100w-fresh-aeneid",
+        network: NETWORK,
+        baseFee_wei: fees.baseFee.toString(),
+        writeFee_wei: fees.writeFee.toString(),
+        readFee_wei: fees.readFee.toString(),
+        allocateFee_wei: fees.allocateFee.toString(),
+        per_cycle_wei: perCycleWei.toString(),
+        cycles_per_wallet: CYCLES_PER_WALLET,
+        safety_multiplier: FUND_SAFETY_MULTIPLIER,
+        per_wallet_fund_wei: perWalletFund.toString(),
+      });
+      logCase("fees + fund sizing", {
+        baseFee: fees.baseFee.toString(),
+        writeFee: fees.writeFee.toString(),
+        readFee: fees.readFee.toString(),
+        allocateFee: fees.allocateFee.toString(),
+        perCycleWei: perCycleWei.toString(),
+        cyclesPerWallet: CYCLES_PER_WALLET,
+        safetyMultiplier: FUND_SAFETY_MULTIPLIER,
+        perWalletFund: perWalletFund.toString(),
+      });
+
       openCondition = await deployOpenCondition(funderPublic, funderWallet);
       logCase("openCondition", openCondition);
 
@@ -149,13 +196,13 @@ describe.skipIf(skipUnlessSuite("default") || NETWORK !== "aeneid")(
         funderPublic,
         funderWallet,
         wallets,
-        PER_WALLET_FUND,
+        perWalletFund,
       );
       totalFundedWei = fund.totalFundedWei;
       logCase("multicall3 batch fund", {
         multicall3: fund.multicall3Address,
         wallets: wallets.length,
-        perWallet: PER_WALLET_FUND.toString(),
+        perWallet: perWalletFund.toString(),
         totalWei: fund.totalFundedWei.toString(),
         txHash: fund.txHash,
       });

--- a/packages/sdk/__integration__/ephemeral-100w-fresh.test.ts
+++ b/packages/sdk/__integration__/ephemeral-100w-fresh.test.ts
@@ -35,7 +35,6 @@ import {
   createPublicClient,
   createWalletClient,
   http,
-  parseEther,
 } from "viem";
 import { privateKeyToAccount } from "viem/accounts";
 import { CDRClient, initWasm } from "../src/index.js";
@@ -46,10 +45,23 @@ import {
   generateEphemeralWallets,
   refundWallets,
 } from "./_ephemeral-wallets.js";
-import { formatMs, logCase, mean, p50, p95, statsOf, writePerfStats } from "./_helpers.js";
+import {
+  computePerWalletFund,
+  cycleFeeCost,
+  formatMs,
+  logCase,
+  mean,
+  p50,
+  p95,
+  queryCDRFees,
+  statsOf,
+  writeFeeStats,
+  writePerfStats,
+} from "./_helpers.js";
 
 const WALLET_COUNT = 100;
-const PER_WALLET_FUND = parseEther("0.1");
+const CYCLES_PER_WALLET = 1; // upload + access
+const FUND_SAFETY_MULTIPLIER = 3;
 const ACCESS_TIMEOUT_MS = 180_000;
 
 const API_URL = process.env.CDR_API_URL;
@@ -126,6 +138,7 @@ describe.skipIf(skipUnlessSuite("default") || NETWORK !== "devnet")(
     let funderAddress: `0x${string}`;
     let openCondition: `0x${string}`;
     let wallets: EphemeralWallet[];
+    let perWalletFund = 0n;
     let totalFundedWei = 0n;
     let perfBuffer: {
       fulfilled: number;
@@ -142,6 +155,38 @@ describe.skipIf(skipUnlessSuite("default") || NETWORK !== "devnet")(
       funderWallet = f.walletClient;
       funderAddress = privateKeyToAccount(FUNDER_KEY!).address;
 
+      // Size each wallet's fund from live CDR fees. See the aeneid
+      // sibling suite for the failure-mode rationale.
+      const fees = await queryCDRFees(funderPublic, "testnet");
+      const perCycleWei = cycleFeeCost(fees);
+      perWalletFund = computePerWalletFund({
+        perCycleWei,
+        cyclesPerWallet: CYCLES_PER_WALLET,
+        safetyMultiplier: FUND_SAFETY_MULTIPLIER,
+      });
+      writeFeeStats({
+        label: "100w-fresh",
+        network: NETWORK,
+        baseFee_wei: fees.baseFee.toString(),
+        writeFee_wei: fees.writeFee.toString(),
+        readFee_wei: fees.readFee.toString(),
+        allocateFee_wei: fees.allocateFee.toString(),
+        per_cycle_wei: perCycleWei.toString(),
+        cycles_per_wallet: CYCLES_PER_WALLET,
+        safety_multiplier: FUND_SAFETY_MULTIPLIER,
+        per_wallet_fund_wei: perWalletFund.toString(),
+      });
+      logCase("fees + fund sizing", {
+        baseFee: fees.baseFee.toString(),
+        writeFee: fees.writeFee.toString(),
+        readFee: fees.readFee.toString(),
+        allocateFee: fees.allocateFee.toString(),
+        perCycleWei: perCycleWei.toString(),
+        cyclesPerWallet: CYCLES_PER_WALLET,
+        safetyMultiplier: FUND_SAFETY_MULTIPLIER,
+        perWalletFund: perWalletFund.toString(),
+      });
+
       openCondition = await deployOpenCondition(funderPublic, funderWallet);
       logCase("openCondition", openCondition);
 
@@ -150,13 +195,13 @@ describe.skipIf(skipUnlessSuite("default") || NETWORK !== "devnet")(
         funderPublic,
         funderWallet,
         wallets,
-        PER_WALLET_FUND,
+        perWalletFund,
       );
       totalFundedWei = fund.totalFundedWei;
       logCase("multicall3 batch fund", {
         multicall3: fund.multicall3Address,
         wallets: wallets.length,
-        perWallet: PER_WALLET_FUND.toString(),
+        perWallet: perWalletFund.toString(),
         totalWei: fund.totalFundedWei.toString(),
         txHash: fund.txHash,
       });

--- a/packages/sdk/__integration__/ephemeral-100w-fresh.test.ts
+++ b/packages/sdk/__integration__/ephemeral-100w-fresh.test.ts
@@ -46,16 +46,14 @@ import {
   refundWallets,
 } from "./_ephemeral-wallets.js";
 import {
-  computePerWalletFund,
   cycleFeeCost,
   formatMs,
   logCase,
   mean,
   p50,
   p95,
-  queryCDRFees,
+  sizeFundAndReport,
   statsOf,
-  writeFeeStats,
   writePerfStats,
 } from "./_helpers.js";
 
@@ -157,34 +155,13 @@ describe.skipIf(skipUnlessSuite("default") || NETWORK !== "devnet")(
 
       // Size each wallet's fund from live CDR fees. See the aeneid
       // sibling suite for the failure-mode rationale.
-      const fees = await queryCDRFees(funderPublic, "testnet");
-      const perCycleWei = cycleFeeCost(fees);
-      perWalletFund = computePerWalletFund({
-        perCycleWei,
-        cyclesPerWallet: CYCLES_PER_WALLET,
-        safetyMultiplier: FUND_SAFETY_MULTIPLIER,
-      });
-      writeFeeStats({
+      perWalletFund = await sizeFundAndReport({
         label: "100w-fresh",
         network: NETWORK,
-        baseFee_wei: fees.baseFee.toString(),
-        writeFee_wei: fees.writeFee.toString(),
-        readFee_wei: fees.readFee.toString(),
-        allocateFee_wei: fees.allocateFee.toString(),
-        per_cycle_wei: perCycleWei.toString(),
-        cycles_per_wallet: CYCLES_PER_WALLET,
-        safety_multiplier: FUND_SAFETY_MULTIPLIER,
-        per_wallet_fund_wei: perWalletFund.toString(),
-      });
-      logCase("fees + fund sizing", {
-        baseFee: fees.baseFee.toString(),
-        writeFee: fees.writeFee.toString(),
-        readFee: fees.readFee.toString(),
-        allocateFee: fees.allocateFee.toString(),
-        perCycleWei: perCycleWei.toString(),
+        publicClient: funderPublic,
+        perCycleCost: cycleFeeCost,
         cyclesPerWallet: CYCLES_PER_WALLET,
         safetyMultiplier: FUND_SAFETY_MULTIPLIER,
-        perWalletFund: perWalletFund.toString(),
       });
 
       openCondition = await deployOpenCondition(funderPublic, funderWallet);

--- a/packages/sdk/__integration__/ephemeral-100w-shared.test.ts
+++ b/packages/sdk/__integration__/ephemeral-100w-shared.test.ts
@@ -43,7 +43,6 @@ import {
   createPublicClient,
   createWalletClient,
   http,
-  parseEther,
 } from "viem";
 import { privateKeyToAccount } from "viem/accounts";
 import { CDRClient, initWasm } from "../src/index.js";
@@ -54,10 +53,23 @@ import {
   generateEphemeralWallets,
   refundWallets,
 } from "./_ephemeral-wallets.js";
-import { formatMs, logCase, mean, p50, p95, statsOf, writePerfStats } from "./_helpers.js";
+import {
+  accessFeeCost,
+  computePerWalletFund,
+  formatMs,
+  logCase,
+  mean,
+  p50,
+  p95,
+  queryCDRFees,
+  statsOf,
+  writeFeeStats,
+  writePerfStats,
+} from "./_helpers.js";
 
 const WALLET_COUNT = 100;
-const PER_WALLET_FUND = parseEther("0.05");
+const CYCLES_PER_WALLET = 1; // 1 accessCDR per wallet, no upload
+const FUND_SAFETY_MULTIPLIER = 3;
 const ACCESS_TIMEOUT_MS = 180_000;
 
 const API_URL = process.env.CDR_API_URL;
@@ -143,6 +155,7 @@ describe.skipIf(skipUnlessSuite("default"))(
     let sharedVaultUuid: number;
     let sharedDataKey: Uint8Array;
     let wallets: EphemeralWallet[];
+    let perWalletFund = 0n;
     let totalFundedWei = 0n;
     // Captured by `it`, written to /tmp/perf-stats-100w-shared.json by
     // `afterAll` (so the workflow can render a perf table). null until
@@ -163,6 +176,37 @@ describe.skipIf(skipUnlessSuite("default"))(
       funderWallet = f.walletClient;
       funderClient = f.client;
       funderAddress = privateKeyToAccount(FUNDER_KEY!).address;
+
+      // Read-only suite: each ephemeral wallet pays accessFee only (no
+      // upload / no baseFee). Size fund from the live readFee instead of
+      // a static 0.05 IP that becomes unsafe whenever the chain raises
+      // readFee.
+      const fees = await queryCDRFees(funderPublic, "testnet");
+      const perCycleWei = accessFeeCost(fees);
+      perWalletFund = computePerWalletFund({
+        perCycleWei,
+        cyclesPerWallet: CYCLES_PER_WALLET,
+        safetyMultiplier: FUND_SAFETY_MULTIPLIER,
+      });
+      writeFeeStats({
+        label: "100w-shared",
+        network: NETWORK,
+        baseFee_wei: fees.baseFee.toString(),
+        writeFee_wei: fees.writeFee.toString(),
+        readFee_wei: fees.readFee.toString(),
+        allocateFee_wei: fees.allocateFee.toString(),
+        per_cycle_wei: perCycleWei.toString(),
+        cycles_per_wallet: CYCLES_PER_WALLET,
+        safety_multiplier: FUND_SAFETY_MULTIPLIER,
+        per_wallet_fund_wei: perWalletFund.toString(),
+      });
+      logCase("fees + fund sizing", {
+        readFee: fees.readFee.toString(),
+        perCycleWei: perCycleWei.toString(),
+        cyclesPerWallet: CYCLES_PER_WALLET,
+        safetyMultiplier: FUND_SAFETY_MULTIPLIER,
+        perWalletFund: perWalletFund.toString(),
+      });
 
       openCondition = await deployOpenCondition(funderPublic, funderWallet);
       logCase("openCondition", openCondition);
@@ -187,13 +231,13 @@ describe.skipIf(skipUnlessSuite("default"))(
         funderPublic,
         funderWallet,
         wallets,
-        PER_WALLET_FUND,
+        perWalletFund,
       );
       totalFundedWei = fund.totalFundedWei;
       logCase("multicall3 batch fund", {
         multicall3: fund.multicall3Address,
         wallets: wallets.length,
-        perWallet: PER_WALLET_FUND.toString(),
+        perWallet: perWalletFund.toString(),
         totalWei: fund.totalFundedWei.toString(),
         txHash: fund.txHash,
       });

--- a/packages/sdk/__integration__/ephemeral-100w-shared.test.ts
+++ b/packages/sdk/__integration__/ephemeral-100w-shared.test.ts
@@ -55,15 +55,13 @@ import {
 } from "./_ephemeral-wallets.js";
 import {
   accessFeeCost,
-  computePerWalletFund,
   formatMs,
   logCase,
   mean,
   p50,
   p95,
-  queryCDRFees,
+  sizeFundAndReport,
   statsOf,
-  writeFeeStats,
   writePerfStats,
 } from "./_helpers.js";
 
@@ -177,35 +175,15 @@ describe.skipIf(skipUnlessSuite("default"))(
       funderClient = f.client;
       funderAddress = privateKeyToAccount(FUNDER_KEY!).address;
 
-      // Read-only suite: each ephemeral wallet pays accessFee only (no
-      // upload / no baseFee). Size fund from the live readFee instead of
-      // a static 0.05 IP that becomes unsafe whenever the chain raises
-      // readFee.
-      const fees = await queryCDRFees(funderPublic, "testnet");
-      const perCycleWei = accessFeeCost(fees);
-      perWalletFund = computePerWalletFund({
-        perCycleWei,
-        cyclesPerWallet: CYCLES_PER_WALLET,
-        safetyMultiplier: FUND_SAFETY_MULTIPLIER,
-      });
-      writeFeeStats({
+      // Read-only suite: each wallet pays accessFee only (no upload, no
+      // baseFee). Size fund from live readFee.
+      perWalletFund = await sizeFundAndReport({
         label: "100w-shared",
         network: NETWORK,
-        baseFee_wei: fees.baseFee.toString(),
-        writeFee_wei: fees.writeFee.toString(),
-        readFee_wei: fees.readFee.toString(),
-        allocateFee_wei: fees.allocateFee.toString(),
-        per_cycle_wei: perCycleWei.toString(),
-        cycles_per_wallet: CYCLES_PER_WALLET,
-        safety_multiplier: FUND_SAFETY_MULTIPLIER,
-        per_wallet_fund_wei: perWalletFund.toString(),
-      });
-      logCase("fees + fund sizing", {
-        readFee: fees.readFee.toString(),
-        perCycleWei: perCycleWei.toString(),
+        publicClient: funderPublic,
+        perCycleCost: accessFeeCost,
         cyclesPerWallet: CYCLES_PER_WALLET,
         safetyMultiplier: FUND_SAFETY_MULTIPLIER,
-        perWalletFund: perWalletFund.toString(),
       });
 
       openCondition = await deployOpenCondition(funderPublic, funderWallet);

--- a/packages/sdk/__integration__/ephemeral-60min-stress.test.ts
+++ b/packages/sdk/__integration__/ephemeral-60min-stress.test.ts
@@ -86,20 +86,20 @@ import {
 } from "./_ephemeral-wallets.js";
 import {
   accessFeeCost,
-  computePerWalletFund,
-  queryCDRFees,
+  sizeFundAndReport,
   statsOf,
   uploadFeeCost,
-  writeFeeStats,
   writePerfStats,
 } from "./_helpers.js";
 
 const DURATION_MS = 60 * 60 * 1000; // 1 hour
 const CONCURRENCY = 10;
 // Generous over-estimate of cycles per wallet. Real run on devnet does
-// ~120-200 cycles in 1 hour; 500 here absorbs any speedup while leaving
-// the fund well above what a 60-min loop can plausibly consume.
-const ESTIMATED_CYCLES_PER_WALLET = 500;
+// ~120-200 cycles in 1 hour; 1000 here absorbs any future cycle speedup
+// while staying close to the spirit of the previous static 1000 IP fund
+// (it works out to ~155 IP/wallet on devnet vs the previous 1000 IP —
+// still a 15× buffer over realistic need, but tracks live fees).
+const ESTIMATED_CYCLES_PER_WALLET = 1000;
 const FUND_SAFETY_MULTIPLIER = 3;
 // Generous reserve absorbs any pending-tx mempool cost when refund runs
 // right after the last cycle. Loses ~10 IP across 10 wallets — DevNet
@@ -245,34 +245,17 @@ describe.skipIf(skipUnlessSuite("1H-stress-devnet-only") || skipUnlessDevnet())(
       funderClient = f.client;
       funderAddress = privateKeyToAccount(FUNDER_KEY!).address;
 
-      // Each cycle = 1 uploadCDR + 2 accessCDR (shared + own-fresh).
-      // Size fund from live fees with a 500-cycle generous estimate so the
-      // suite cannot starve even if cycles run faster than expected.
-      const fees = await queryCDRFees(funderPublic, "testnet");
-      const perCycleWei = uploadFeeCost(fees) + accessFeeCost(fees) * 2n;
-      perWalletFund = computePerWalletFund({
-        perCycleWei,
+      // Each cycle = 1 uploadCDR + 2 accessCDR (shared + own-fresh). The
+      // fee snapshot + fund sizing also lands in /tmp/fee-stats-60min-stress.json
+      // for the workflow summary table.
+      perWalletFund = await sizeFundAndReport({
+        label: "60min-stress",
+        network: NETWORK,
+        publicClient: funderPublic,
+        perCycleCost: (fees) => uploadFeeCost(fees) + accessFeeCost(fees) * 2n,
         cyclesPerWallet: ESTIMATED_CYCLES_PER_WALLET,
         safetyMultiplier: FUND_SAFETY_MULTIPLIER,
       });
-      writeFeeStats({
-        label: "60min-stress",
-        network: NETWORK,
-        baseFee_wei: fees.baseFee.toString(),
-        writeFee_wei: fees.writeFee.toString(),
-        readFee_wei: fees.readFee.toString(),
-        allocateFee_wei: fees.allocateFee.toString(),
-        per_cycle_wei: perCycleWei.toString(),
-        cycles_per_wallet: ESTIMATED_CYCLES_PER_WALLET,
-        safety_multiplier: FUND_SAFETY_MULTIPLIER,
-        per_wallet_fund_wei: perWalletFund.toString(),
-      });
-      logLine(
-        `[suite-setup] fee sizing: baseFee=${fees.baseFee} writeFee=${fees.writeFee} ` +
-          `readFee=${fees.readFee} allocateFee=${fees.allocateFee} perCycle=${perCycleWei} ` +
-          `cycles=${ESTIMATED_CYCLES_PER_WALLET} multiplier=${FUND_SAFETY_MULTIPLIER} ` +
-          `perWalletFund=${perWalletFund}`,
-      );
 
       openCondition = await deployOpenCondition(funderPublic, funderWallet);
       logLine(`[suite-setup] openCondition deployed at ${openCondition}`);

--- a/packages/sdk/__integration__/ephemeral-60min-stress.test.ts
+++ b/packages/sdk/__integration__/ephemeral-60min-stress.test.ts
@@ -84,11 +84,23 @@ import {
   generateEphemeralWallets,
   refundWallets,
 } from "./_ephemeral-wallets.js";
-import { statsOf, writePerfStats } from "./_helpers.js";
+import {
+  accessFeeCost,
+  computePerWalletFund,
+  queryCDRFees,
+  statsOf,
+  uploadFeeCost,
+  writeFeeStats,
+  writePerfStats,
+} from "./_helpers.js";
 
 const DURATION_MS = 60 * 60 * 1000; // 1 hour
 const CONCURRENCY = 10;
-const PER_WALLET_FUND = parseEther("1000");
+// Generous over-estimate of cycles per wallet. Real run on devnet does
+// ~120-200 cycles in 1 hour; 500 here absorbs any speedup while leaving
+// the fund well above what a 60-min loop can plausibly consume.
+const ESTIMATED_CYCLES_PER_WALLET = 500;
+const FUND_SAFETY_MULTIPLIER = 3;
 // Generous reserve absorbs any pending-tx mempool cost when refund runs
 // right after the last cycle. Loses ~10 IP across 10 wallets — DevNet
 // anvil-0 has unlimited dev IP, so trading a little waste for refund
@@ -206,6 +218,7 @@ describe.skipIf(skipUnlessSuite("1H-stress-devnet-only") || skipUnlessDevnet())(
     let sharedVaultUuid: number;
     let sharedDataKey: Uint8Array;
     let stressWallets: StressWallet[] = [];
+    let perWalletFund = 0n;
     let totalFundedWei = 0n;
     // Populated by `it`, consumed by `afterAll` to emit the perf-stats
     // JSON. `null` until the workload completes; afterAll skips the write
@@ -232,6 +245,35 @@ describe.skipIf(skipUnlessSuite("1H-stress-devnet-only") || skipUnlessDevnet())(
       funderClient = f.client;
       funderAddress = privateKeyToAccount(FUNDER_KEY!).address;
 
+      // Each cycle = 1 uploadCDR + 2 accessCDR (shared + own-fresh).
+      // Size fund from live fees with a 500-cycle generous estimate so the
+      // suite cannot starve even if cycles run faster than expected.
+      const fees = await queryCDRFees(funderPublic, "testnet");
+      const perCycleWei = uploadFeeCost(fees) + accessFeeCost(fees) * 2n;
+      perWalletFund = computePerWalletFund({
+        perCycleWei,
+        cyclesPerWallet: ESTIMATED_CYCLES_PER_WALLET,
+        safetyMultiplier: FUND_SAFETY_MULTIPLIER,
+      });
+      writeFeeStats({
+        label: "60min-stress",
+        network: NETWORK,
+        baseFee_wei: fees.baseFee.toString(),
+        writeFee_wei: fees.writeFee.toString(),
+        readFee_wei: fees.readFee.toString(),
+        allocateFee_wei: fees.allocateFee.toString(),
+        per_cycle_wei: perCycleWei.toString(),
+        cycles_per_wallet: ESTIMATED_CYCLES_PER_WALLET,
+        safety_multiplier: FUND_SAFETY_MULTIPLIER,
+        per_wallet_fund_wei: perWalletFund.toString(),
+      });
+      logLine(
+        `[suite-setup] fee sizing: baseFee=${fees.baseFee} writeFee=${fees.writeFee} ` +
+          `readFee=${fees.readFee} allocateFee=${fees.allocateFee} perCycle=${perCycleWei} ` +
+          `cycles=${ESTIMATED_CYCLES_PER_WALLET} multiplier=${FUND_SAFETY_MULTIPLIER} ` +
+          `perWalletFund=${perWalletFund}`,
+      );
+
       openCondition = await deployOpenCondition(funderPublic, funderWallet);
       logLine(`[suite-setup] openCondition deployed at ${openCondition}`);
 
@@ -257,13 +299,13 @@ describe.skipIf(skipUnlessSuite("1H-stress-devnet-only") || skipUnlessDevnet())(
         funderPublic,
         funderWallet,
         ephs,
-        PER_WALLET_FUND,
+        perWalletFund,
       );
       totalFundedWei = fund.totalFundedWei;
       stressWallets = ephs.map(makeStressWallet);
       logLine(
         `[suite-setup] funded ${stressWallets.length} wallets via Multicall3 ` +
-          `${fund.multicall3Address} (tx ${fund.txHash}); ${formatEther(PER_WALLET_FUND)} IP each`,
+          `${fund.multicall3Address} (tx ${fund.txHash}); ${formatEther(perWalletFund)} IP each`,
       );
     }, 10 * 60 * 1000);
 


### PR DESCRIPTION
## Problem

[run 26358781110](https://github.com/piplabs/cdr-sdk/actions/runs/26358781110) `ephemeral-100w-fresh-aeneid` failed 100/100 wallets, all with `insufficient funds for transfer` on the `read()` call:

```
from:   0x2B0BFC926aA85E8b4f5efC94E77Ef5b205689817   ← ephemeral wallet
value:  0.03 ETH                                     ← readFee on aeneid
Details: insufficient funds for transfer
```

Funder (`0x5B07…3a75`) was fine at 5515 IP; **the test was just funding too little**:

- aeneid CDR fees (queried live): `baseFee = writeFee = readFee = allocateFee = 0.03 IP` each
- Single (upload + access) cycle on aeneid needs `~0.078 IP` for upload + `~0.035 IP` for access = `~0.113 IP`
- `PER_WALLET_FUND = parseEther(\"0.1\")` (hard-coded, set 2026-05-16 when aeneid fees were 0.01 IP) left only `0.1 − 0.078 = 0.022 IP` after upload — below the `0.03 IP` value the read tx requires.

The static value worked on devnet (where all fees are 0.01 IP and a single cycle costs `~0.04 IP`) but silently broke aeneid the moment its fees moved.

## Solution

Replace static `PER_WALLET_FUND` in all five ephemeral suites with **dynamic sizing off the live CDR contract**:

```ts
const fees = await queryCDRFees(publicClient, \"testnet\");
// uploadFeeCost = baseFee + writeFee + allocateFee
// accessFeeCost = readFee
// cycleFeeCost  = uploadFeeCost + accessFeeCost
const perWalletFund = computePerWalletFund({
  perCycleWei: cycleFeeCost(fees),       // or accessFeeCost / uploadFeeCost
  cyclesPerWallet: CYCLES_PER_WALLET,    // suite-known constant
  safetyMultiplier: 3,                   // fee bumps + gas variance
  gasReserveWei: parseEther(\"0.005\"),    // matches refundWallets reserve
});
```

Each suite picks the cost shape it actually exercises:

| Suite | Per-cycle cost composition |
|---|---|
| `100w-fresh` + `100w-fresh-aeneid` | `cycleFeeCost` (upload + access) |
| `100w-shared` + `1000w-perf` | `accessFeeCost` (read-only) |
| `60min-stress` | `uploadFeeCost + 2 × accessFeeCost` (cycle = upload + accessShared + accessFresh) |

## Workflow summary integration

Each suite writes `/tmp/fee-stats-{label}.json` at setup. The integration workflow's summary step renders a new \"Live CDR fees + ephemeral fund sizing\" table (positioned just before the existing perf table), so any future \"insufficient funds\" run is one table-row away from being diagnosed.

Sample rendered shape:

| Suite | baseFee | writeFee | readFee | allocateFee | Per-cycle | Cycles/wallet | Safety× | Per-wallet fund |
|---|---|---|---|---|---|---|---|---|
| 100w-fresh-aeneid | 0.0300 IP | 0.0300 IP | 0.0300 IP | 0.0300 IP | 0.1200 IP | 1 | 3 | 0.3650 IP |
| 100w-shared | 0.0100 IP | 0.0100 IP | 0.0100 IP | 0.0100 IP | 0.0100 IP | 1 | 3 | 0.0350 IP |

## Files

- `packages/sdk/__integration__/_helpers.ts` — adds `CDRFees`, `queryCDRFees`, `uploadFeeCost`/`accessFeeCost`/`cycleFeeCost`, `computePerWalletFund`, `FeeStatsFile`, `writeFeeStats`
- 5 ephemeral test files — replace static fund constants with dynamic sizing + `writeFeeStats` call
- `.github/workflows/integration.yml` — adds `render_fee_table` reading `/tmp/fee-stats-*.json`, called from the summary block

## Verification

- `tsc --noEmit` passes on the SDK package
- jq `fmtIp` filter in the workflow verified locally: `30000000000000000 wei → 0.0300 IP` ✓
- All 5 suites preserve setup ordering: `queryCDRFees → deployOpenCondition → generateEphemeralWallets → fundWallets`

## Test plan

- [ ] Trigger `integration.yml network=aeneid test_suite=default` after merge — `100w-fresh-aeneid` should now pass on aeneid's 0.03 IP fee schedule
- [ ] Confirm fee table renders in Step Summary