### PR TITLE
fix(sdk + test): resilient waitForTransactionReceipt + readable failure summary

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -443,24 +443,42 @@ jobs:
           }
 
           # ─── Aggregate failures across ALL JSON files (top-of-summary block) ──
-          # Joins vitest assertion failures with the matching
+          # Cross-references vitest's assertion failures with the matching
           # /tmp/perf-stats-{label}.json so an ephemeral-suite failure prints
-          # the per-wallet failure reasons inline ("99/100 succeeded, 1
-          # failed: <reason>") instead of only the vitest stack a reviewer
-          # has to click into the run log to decipher. Mapping: strip the
+          # the per-wallet failure reasons inline (e.g. "99/100 succeeded,
+          # 1 failed: receipt-not-found on tx 0x914c... mined in block
+          # 0x11d2547" from run 26379164817; or the 2-row dual-cause
+          # break-down rendered for run 26380050980 wallets idx=31/36)
+          # rather than only the cryptic `AssertionError: 1 wallets
+          # failed: expected 1 to be +0` + vitest stack a reviewer has
+          # to click into the run log to decipher. Mapping: strip the
           # `ephemeral-` prefix and `.test.ts` suffix from the test file
-          # basename to derive the perf-stats label.
+          # basename to derive the perf-stats label. Falls back gracefully
+          # to vitest-stack-only when the perf-stats file is missing or
+          # unreadable (also see the `|| echo "{}"` JSON guard).
           aggregate_failures() {
             # Build a {label -> perf-stats} map once so the inner jq can
             # look up the matching per-wallet failure rows for each
-            # assertion failure.
+            # assertion failure. Defensive: `jq -s` over multiple files
+            # exits non-zero on the FIRST malformed input, which would
+            # silently drop the entire enriched-failure block — even the
+            # downstream `--argjson perf "$perf_json"` call would fail
+            # to parse, falling back to vitest-stack-only for ALL suites
+            # (not just the one with bad output). Iterate per file so
+            # one truncated / unparseable JSON only loses ITS own
+            # enrichment; the other suites still render the per-wallet
+            # failure tables.
             shopt -s nullglob
             local perf_files=(/tmp/perf-stats-*.json)
             shopt -u nullglob
             local perf_json="{}"
-            if [ "${#perf_files[@]}" -gt 0 ]; then
-              perf_json=$(jq -s 'map({key: .label, value: .}) | from_entries' "${perf_files[@]}")
-            fi
+            for f in "${perf_files[@]}"; do
+              # `-e` exits non-zero on `select(...)` filtering everything
+              # out (no `.label`), and on outright parse failures.
+              local entry
+              entry=$(jq -ec 'select(type == "object" and (.label | type) == "string")' "$f" 2>/dev/null) || continue
+              perf_json=$(jq -n --argjson acc "$perf_json" --argjson item "$entry" '$acc + {($item.label): $item}')
+            done
 
             for json in /tmp/results-sdk.json /tmp/results-cli.json /tmp/results-examples.json /tmp/results-stress.json; do
               [ -f "$json" ] || continue

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -443,15 +443,13 @@ jobs:
           }
 
           # ─── Aggregate failures across ALL JSON files (top-of-summary block) ──
-          # Cross-references vitest's assertion failures with the matching
+          # Joins vitest assertion failures with the matching
           # /tmp/perf-stats-{label}.json so an ephemeral-suite failure prints
-          # the per-wallet failure reasons inline (e.g. "99/100 succeeded,
-          # 1 failed: receipt-not-found on tx 0x914c...") rather than only
-          # the cryptic `AssertionError: 1 wallets failed: expected 1 to be
-          # +0` plus vitest stack the reader has to click into the run log
-          # to decipher. Mapping: results-*.json's testResults[].name basename
-          # like `ephemeral-100w-fresh-aeneid.test.ts` strips to label
-          # `100w-fresh-aeneid` which matches the test's writePerfStats label.
+          # the per-wallet failure reasons inline ("99/100 succeeded, 1
+          # failed: <reason>") instead of only the vitest stack a reviewer
+          # has to click into the run log to decipher. Mapping: strip the
+          # `ephemeral-` prefix and `.test.ts` suffix from the test file
+          # basename to derive the perf-stats label.
           aggregate_failures() {
             # Build a {label -> perf-stats} map once so the inner jq can
             # look up the matching per-wallet failure rows for each

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -443,17 +443,56 @@ jobs:
           }
 
           # ─── Aggregate failures across ALL JSON files (top-of-summary block) ──
+          # Cross-references vitest's assertion failures with the matching
+          # /tmp/perf-stats-{label}.json so an ephemeral-suite failure prints
+          # the per-wallet failure reasons inline (e.g. "99/100 succeeded,
+          # 1 failed: receipt-not-found on tx 0x914c...") rather than only
+          # the cryptic `AssertionError: 1 wallets failed: expected 1 to be
+          # +0` plus vitest stack the reader has to click into the run log
+          # to decipher. Mapping: results-*.json's testResults[].name basename
+          # like `ephemeral-100w-fresh-aeneid.test.ts` strips to label
+          # `100w-fresh-aeneid` which matches the test's writePerfStats label.
           aggregate_failures() {
+            # Build a {label -> perf-stats} map once so the inner jq can
+            # look up the matching per-wallet failure rows for each
+            # assertion failure.
+            shopt -s nullglob
+            local perf_files=(/tmp/perf-stats-*.json)
+            shopt -u nullglob
+            local perf_json="{}"
+            if [ "${#perf_files[@]}" -gt 0 ]; then
+              perf_json=$(jq -s 'map({key: .label, value: .}) | from_entries' "${perf_files[@]}")
+            fi
+
             for json in /tmp/results-sdk.json /tmp/results-cli.json /tmp/results-examples.json /tmp/results-stress.json; do
               [ -f "$json" ] || continue
-              jq -r --arg scope "$(basename "$json" .json | sed 's/^results-//')" '
+              jq -r \
+                --arg scope "$(basename "$json" .json | sed 's/^results-//')" \
+                --argjson perf "$perf_json" '
+                def truncReason:
+                  gsub("\n"; " ")
+                  | gsub("\\|"; "\\|")
+                  | (if (. | length) > 200 then .[:200] + " …" else . end);
                 .testResults[] as $f
                 | ($f.name | split("/") | last) as $file
+                | ($file | sub("\\.test\\.ts$"; "") | sub("^ephemeral-"; "")) as $label
                 | $f.assertionResults[]
                 | select(.status == "failed")
-                | "**❌ [" + $scope + "] `" + $file + "` → " + .title + "**\n\n```\n"
+                | (($perf[$label]) // null) as $p
+                | "### ❌ [" + $scope + "] `" + $file + "` → " + .title + "\n"
+                  + (if $p != null and $p.failedReasons != null and ($p.failedReasons | length) > 0
+                     then "\n**" + ($p.fulfilled | tostring) + "/"
+                            + (($p.fulfilled + $p.failed) | tostring)
+                            + " wallets succeeded, " + ($p.failed | tostring) + " failed.**\n\n"
+                          + "| idx | failure reason (truncated to 200 chars) |\n"
+                          + "|---|---|\n"
+                          + ($p.failedReasons | map("| " + (.idx | tostring) + " | " + (.reason | truncReason) + " |") | join("\n"))
+                          + "\n"
+                     else "" end)
+                  + "\n<details><summary>Raw assertion / vitest stack</summary>\n\n"
+                  + "```\n"
                   + ((.failureMessages // [])[0] // "(no failureMessage)")
-                  + "\n```\n"
+                  + "\n```\n\n</details>\n"
               ' "$json"
             done
           }

--- a/packages/sdk/__integration__/_ephemeral-wallets.ts
+++ b/packages/sdk/__integration__/_ephemeral-wallets.ts
@@ -40,6 +40,7 @@ import {
   MULTICALL3_ABI,
   buildMulticall3CreationBytecode,
 } from "./_multicall3-artifact.js";
+import { waitForReceiptResilient } from "./_rpc-resilience.js";
 
 export interface EphemeralWallet {
   privateKey: Hex;
@@ -95,7 +96,7 @@ export async function ensureMulticall3(
     to: null,
     data: buildMulticall3CreationBytecode(),
   });
-  const receipt = await publicClient.waitForTransactionReceipt({ hash });
+  const receipt = await waitForReceiptResilient(publicClient, hash);
   if (!receipt.contractAddress) {
     throw new Error(
       `ensureMulticall3: deployment receipt missing contractAddress (tx ${hash})`,
@@ -151,7 +152,7 @@ export async function fundWallets(
     args: [calls],
     value: totalFundedWei,
   });
-  await publicClient.waitForTransactionReceipt({ hash: txHash });
+  await waitForReceiptResilient(publicClient, txHash);
 
   return { multicall3Address, totalFundedWei, txHash };
 }
@@ -209,7 +210,7 @@ export async function refundWallets(
           value: sweepAmount,
           gas: 21_000n,
         });
-        await publicClient.waitForTransactionReceipt({ hash });
+        await waitForReceiptResilient(publicClient, hash);
         return sweepAmount;
       } catch {
         return -1n; // sentinel for failed sweep

--- a/packages/sdk/__integration__/_helpers.ts
+++ b/packages/sdk/__integration__/_helpers.ts
@@ -188,6 +188,14 @@ export interface PerfStatsFile {
   } | null;
   /** Optional: stress-style derived counters that don't fit the per-wallet model. */
   extra: Record<string, number | string> | null;
+  /**
+   * Per-wallet failure reasons, capped at 10 entries to keep the JSON
+   * small. The workflow summary renders these as a table so a reviewer
+   * can see why N of M wallets failed without clicking into the raw
+   * vitest stack — the assertion `expect(failed.length).toBe(0)` alone
+   * tells you the count but not the cause.
+   */
+  failedReasons: Array<{ idx: number; reason: string }> | null;
 }
 
 /**

--- a/packages/sdk/__integration__/_rpc-resilience.ts
+++ b/packages/sdk/__integration__/_rpc-resilience.ts
@@ -7,7 +7,27 @@
  * adding retry / throttling there would mask real validator-side issues.
  */
 
-import { http } from "viem";
+import { http, type Hash, type PublicClient } from "viem";
+
+/**
+ * `publicClient.waitForTransactionReceipt` with parameters tuned for
+ * public RPC endpoints (default viem `timeout: 180_000` is too tight when
+ * receipt propagation lags block production — see cdr-sdk run
+ * 26379164817, wallet idx=29: tx 0x914c3c... landed in block 0x11d2547
+ * but viem gave up first, failing 1/100 in 100w-fresh-aeneid). Bumping
+ * `timeout` to 5 min covers any realistic public-RPC tail.
+ */
+export async function waitForReceiptResilient(
+  publicClient: PublicClient,
+  hash: Hash,
+) {
+  return publicClient.waitForTransactionReceipt({
+    hash,
+    timeout: 5 * 60 * 1000,
+    pollingInterval: 2000,
+    retryCount: 30,
+  });
+}
 
 /**
  * `http()` with retry budget tuned for public-RPC throttling.

--- a/packages/sdk/__integration__/_rpc-resilience.ts
+++ b/packages/sdk/__integration__/_rpc-resilience.ts
@@ -88,9 +88,15 @@ export function pLimit(maxConcurrency: number) {
  * `publicClient.waitForTransactionReceipt` with `timeout` widened to 5 min
  * for public-RPC endpoints whose `eth_getTransactionReceipt` can lag block
  * production by tens of seconds (viem default `timeout: 180_000` is too
- * tight for the tail). Mirrors the SDK-internal helper in
- * `packages/sdk/src/uploader.ts`; the duplication is intentional — the
- * SDK shouldn't take a dependency on test-only files.
+ * tight for the tail — e.g. cdr-sdk run 26379164817 wallet idx=29 allocate
+ * tx 0x914c3c... mined in block 0x11d2547 status=1 but viem gave up
+ * first; run 26380050980 wallet idx=31 same pattern with tx 0x13cdcd...
+ * in block 0x11d2980 — both failures rendered as "Transaction receipt
+ * with hash X could not be found" in the workflow summary).
+ *
+ * Mirrors the SDK-internal helper in `packages/sdk/src/uploader.ts`; the
+ * duplication is intentional — the SDK shouldn't take a dependency on
+ * test-only files.
  */
 export async function waitForReceiptResilient(
   publicClient: PublicClient,
@@ -105,19 +111,27 @@ export async function waitForReceiptResilient(
 }
 
 /**
- * Retries `fn` on the two known aeneid public-RPC pool consistency bugs:
+ * Retries `fn` on the two known aeneid public-RPC pool consistency bugs
+ * (both observed in cdr-sdk run 26380050980 on the same `default` suite
+ * within the same minute — neither is an SDK or contract bug):
  *
  *   1. **receipt-not-found** — `eth_getTransactionReceipt` is served by a
  *      pool node that lags the one which served `eth_sendRawTransaction`.
  *      Viem throws `TransactionReceiptNotFoundError` /
  *      `WaitForTransactionReceiptTimeoutError` even though the tx is
- *      mined. Sleep then re-poll — the lagging node usually catches up.
+ *      mined. Empirical case: wallet idx=31, tx 0x13cdcd... actually
+ *      committed in block 0x11d2980 status=1 but the receipt-pool node
+ *      still returned null after viem's 5 min timeout window. Sleep then
+ *      re-poll — the lagging node usually catches up.
  *   2. **write-state-race** — an SDK `uploadCDR` allocate→write sequence
  *      gets its `write()` simulation served by a node that hasn't yet
  *      applied the allocate's state, so the contract's
  *      `require(writeConditionAddr != address(0))` reverts with `CDR:
- *      Write condition address not set` even though the chain state
- *      *does* have the address set. Retrying the whole cycle re-runs
+ *      Write condition address not set` even though chain state *does*
+ *      have the address set. Empirical case: wallet idx=36 allocated
+ *      uuid=2655 with writeConditionAddr=0xa3a45... (confirmed by
+ *      post-run eth_call) but its write() simulate hit a stale node
+ *      seeing vaults[2655]=zero. Retrying the whole cycle re-runs
  *      allocate against a (different / caught-up) pool node and the
  *      write simulation passes.
  *

--- a/packages/sdk/__integration__/_rpc-resilience.ts
+++ b/packages/sdk/__integration__/_rpc-resilience.ts
@@ -5,29 +5,18 @@
  * **Scope of use**: ONLY the `*-aeneid.test.ts` files. The DevNet-targeted
  * suites import `http` directly from viem and run at full concurrency —
  * adding retry / throttling there would mask real validator-side issues.
+ *
+ * Helpers are ordered along the chain of resilience layers a public-RPC
+ * test composes from the outside in:
+ *
+ *   1. `resilientHttp`         — viem transport with bumped HTTP retry budget
+ *   2. `pLimit`                — caps concurrent in-flight RPC calls
+ *   3. `waitForReceiptResilient` — bumps viem's per-call receipt timeout
+ *   4. `withAeneidFlakeRetry`  — retries a whole upload→access cycle on the
+ *                                 two known public-pool consistency bugs
  */
 
 import { http, type Hash, type PublicClient } from "viem";
-
-/**
- * `publicClient.waitForTransactionReceipt` with parameters tuned for
- * public RPC endpoints (default viem `timeout: 180_000` is too tight when
- * receipt propagation lags block production — see cdr-sdk run
- * 26379164817, wallet idx=29: tx 0x914c3c... landed in block 0x11d2547
- * but viem gave up first, failing 1/100 in 100w-fresh-aeneid). Bumping
- * `timeout` to 5 min covers any realistic public-RPC tail.
- */
-export async function waitForReceiptResilient(
-  publicClient: PublicClient,
-  hash: Hash,
-) {
-  return publicClient.waitForTransactionReceipt({
-    hash,
-    timeout: 5 * 60 * 1000,
-    pollingInterval: 2000,
-    retryCount: 30,
-  });
-}
 
 /**
  * `http()` with retry budget tuned for public-RPC throttling.
@@ -93,4 +82,86 @@ export function pLimit(maxConcurrency: number) {
       if (next) next();
     }
   };
+}
+
+/**
+ * `publicClient.waitForTransactionReceipt` with `timeout` widened to 5 min
+ * for public-RPC endpoints whose `eth_getTransactionReceipt` can lag block
+ * production by tens of seconds (viem default `timeout: 180_000` is too
+ * tight for the tail). Mirrors the SDK-internal helper in
+ * `packages/sdk/src/uploader.ts`; the duplication is intentional — the
+ * SDK shouldn't take a dependency on test-only files.
+ */
+export async function waitForReceiptResilient(
+  publicClient: PublicClient,
+  hash: Hash,
+) {
+  return publicClient.waitForTransactionReceipt({
+    hash,
+    timeout: 5 * 60 * 1000,
+    pollingInterval: 2000,
+    retryCount: 30,
+  });
+}
+
+/**
+ * Retries `fn` on the two known aeneid public-RPC pool consistency bugs:
+ *
+ *   1. **receipt-not-found** — `eth_getTransactionReceipt` is served by a
+ *      pool node that lags the one which served `eth_sendRawTransaction`.
+ *      Viem throws `TransactionReceiptNotFoundError` /
+ *      `WaitForTransactionReceiptTimeoutError` even though the tx is
+ *      mined. Sleep then re-poll — the lagging node usually catches up.
+ *   2. **write-state-race** — an SDK `uploadCDR` allocate→write sequence
+ *      gets its `write()` simulation served by a node that hasn't yet
+ *      applied the allocate's state, so the contract's
+ *      `require(writeConditionAddr != address(0))` reverts with `CDR:
+ *      Write condition address not set` even though the chain state
+ *      *does* have the address set. Retrying the whole cycle re-runs
+ *      allocate against a (different / caught-up) pool node and the
+ *      write simulation passes.
+ *
+ * Both rethrow unrelated errors immediately so genuine bugs still fail
+ * the test on the first attempt. Default budget: 3 attempts, 5s between.
+ * For an idempotent upload→access cycle the retry burns at most ~2× the
+ * cycle fee (typically ~0.24 IP / cycle on aeneid), well under the
+ * `safetyMultiplier: 3` headroom in `_helpers.computePerWalletFund`.
+ */
+export async function withAeneidFlakeRetry<T>(
+  fn: () => Promise<T>,
+  opts?: { attempts?: number; delayMs?: number },
+): Promise<T> {
+  const attempts = opts?.attempts ?? 3;
+  const delayMs = opts?.delayMs ?? 5000;
+  let lastError: unknown;
+  for (let attempt = 0; attempt < attempts; attempt++) {
+    try {
+      return await fn();
+    } catch (err) {
+      lastError = err;
+      if (!isAeneidPoolFlake(err)) throw err;
+      if (attempt + 1 < attempts) {
+        await new Promise<void>((resolve) => setTimeout(resolve, delayMs));
+      }
+    }
+  }
+  throw lastError;
+}
+
+function isAeneidPoolFlake(err: unknown): boolean {
+  if (!(err instanceof Error)) return false;
+  // Viem tags receipt-related errors via `.name` even when wrapped.
+  if (
+    err.name === "TransactionReceiptNotFoundError" ||
+    err.name === "WaitForTransactionReceiptTimeoutError"
+  ) {
+    return true;
+  }
+  // Contract reverts from CDR.sol when a stale read pool serves the
+  // simulation before the preceding tx propagated.
+  const msg = err.message;
+  return (
+    msg.includes("CDR: Write condition address not set") ||
+    msg.includes("CDR: Read condition address not set")
+  );
 }

--- a/packages/sdk/__integration__/ephemeral-1000w-perf.test.ts
+++ b/packages/sdk/__integration__/ephemeral-1000w-perf.test.ts
@@ -175,6 +175,7 @@ describe.skipIf(skipUnlessSuite("1000-wallet-performance-devnet-only") || NETWOR
       failed: number;
       wallClockMs: number;
       accessLats: number[];
+      failedReasons: Array<{ idx: number; reason: string }>;
     } | null = null;
 
     beforeAll(async () => {
@@ -260,6 +261,8 @@ describe.skipIf(skipUnlessSuite("1000-wallet-performance-devnet-only") || NETWOR
           wall_clock_ms: perfBuffer.wallClockMs,
           accessMs: statsOf(perfBuffer.accessLats),
           uploadMs: null,
+          accessSharedMs: null,
+          accessFreshMs: null,
           tickMs: null,
           refund: {
             funded_wei: totalFundedWei.toString(),
@@ -268,6 +271,7 @@ describe.skipIf(skipUnlessSuite("1000-wallet-performance-devnet-only") || NETWOR
             failed_sweeps: refund.failedRefunds,
           },
           extra: null,
+          failedReasons: perfBuffer.failedReasons,
         });
       }
     }, 15 * 60 * 1000);
@@ -338,6 +342,7 @@ describe.skipIf(skipUnlessSuite("1000-wallet-performance-devnet-only") || NETWOR
           failed: failed.length,
           wallClockMs: totalMs,
           accessLats: lats,
+          failedReasons: failed.slice(0, 10),
         };
 
         expect(failed.length, `${failed.length} wallets failed accessCDR`).toBe(0);

--- a/packages/sdk/__integration__/ephemeral-100w-fresh-aeneid.test.ts
+++ b/packages/sdk/__integration__/ephemeral-100w-fresh-aeneid.test.ts
@@ -53,7 +53,7 @@ import {
   statsOf,
   writePerfStats,
 } from "./_helpers.js";
-import { pLimit, resilientHttp } from "./_rpc-resilience.js";
+import { pLimit, resilientHttp, withAeneidFlakeRetry } from "./_rpc-resilience.js";
 
 const WALLET_COUNT = 100;
 const CYCLES_PER_WALLET = 1; // upload + access
@@ -234,43 +234,47 @@ describe.skipIf(skipUnlessSuite("default") || NETWORK !== "aeneid")(
         const start = Date.now();
         const results = await Promise.allSettled(
           wallets.map((w) =>
-            limit(async () => {
-              const client = makeWalletClient(w);
+            limit(() =>
+              // Tolerate the two known aeneid public-pool consistency
+              // bugs (see withAeneidFlakeRetry doc); each retry re-runs
+              // the full upload→access cycle, which costs at most ~0.24
+              // IP — well under the `safetyMultiplier: 3` fund headroom.
+              withAeneidFlakeRetry(async () => {
+                const client = makeWalletClient(w);
+                const dataKey = crypto.getRandomValues(new Uint8Array(32));
+                const globalPubKey = await client.observer.getGlobalPubKey();
 
-              // ----- per-wallet sequential: upload, then read -----
-              const dataKey = crypto.getRandomValues(new Uint8Array(32));
-              const globalPubKey = await client.observer.getGlobalPubKey();
+                const tUploadStart = Date.now();
+                const upload = await client.uploader.uploadCDR({
+                  dataKey,
+                  globalPubKey,
+                  updatable: false,
+                  writeConditionAddr: openCondition,
+                  readConditionAddr: openCondition,
+                  writeConditionData: "0x",
+                  readConditionData: "0x",
+                  accessAuxData: "0x",
+                });
+                const uploadMs = Date.now() - tUploadStart;
 
-              const tUploadStart = Date.now();
-              const upload = await client.uploader.uploadCDR({
-                dataKey,
-                globalPubKey,
-                updatable: false,
-                writeConditionAddr: openCondition,
-                readConditionAddr: openCondition,
-                writeConditionData: "0x",
-                readConditionData: "0x",
-                accessAuxData: "0x",
-              });
-              const uploadMs = Date.now() - tUploadStart;
+                const tAccessStart = Date.now();
+                const access = await client.consumer.accessCDR({
+                  uuid: upload.uuid,
+                  accessAuxData: "0x",
+                  timeoutMs: ACCESS_TIMEOUT_MS,
+                });
+                const accessMs = Date.now() - tAccessStart;
 
-              const tAccessStart = Date.now();
-              const access = await client.consumer.accessCDR({
-                uuid: upload.uuid,
-                accessAuxData: "0x",
-                timeoutMs: ACCESS_TIMEOUT_MS,
-              });
-              const accessMs = Date.now() - tAccessStart;
-
-              return {
-                address: w.address,
-                uuid: upload.uuid,
-                uploadMs,
-                accessMs,
-                expected: dataKey,
-                recovered: access.dataKey,
-              };
-            }),
+                return {
+                  address: w.address,
+                  uuid: upload.uuid,
+                  uploadMs,
+                  accessMs,
+                  expected: dataKey,
+                  recovered: access.dataKey,
+                };
+              }),
+            ),
           ),
         );
 

--- a/packages/sdk/__integration__/ephemeral-100w-fresh-aeneid.test.ts
+++ b/packages/sdk/__integration__/ephemeral-100w-fresh-aeneid.test.ts
@@ -143,6 +143,7 @@ describe.skipIf(skipUnlessSuite("default") || NETWORK !== "aeneid")(
       wallClockMs: number;
       uploadLats: number[];
       accessLats: number[];
+      failedReasons: Array<{ idx: number; reason: string }>;
     } | null = null;
 
     beforeAll(async () => {
@@ -211,6 +212,8 @@ describe.skipIf(skipUnlessSuite("default") || NETWORK !== "aeneid")(
           wall_clock_ms: perfBuffer.wallClockMs,
           accessMs: statsOf(perfBuffer.accessLats),
           uploadMs: statsOf(perfBuffer.uploadLats),
+          accessSharedMs: null,
+          accessFreshMs: null,
           tickMs: null,
           refund: {
             funded_wei: totalFundedWei.toString(),
@@ -219,6 +222,7 @@ describe.skipIf(skipUnlessSuite("default") || NETWORK !== "aeneid")(
             failed_sweeps: refund.failedRefunds,
           },
           extra: { maxInflight: MAX_INFLIGHT },
+          failedReasons: perfBuffer.failedReasons,
         });
       }
     }, 5 * 60 * 1000);
@@ -312,6 +316,7 @@ describe.skipIf(skipUnlessSuite("default") || NETWORK !== "aeneid")(
           wallClockMs: totalMs,
           uploadLats,
           accessLats,
+          failedReasons: failed.slice(0, 10),
         };
 
         expect(failed.length, `${failed.length} wallets failed`).toBe(0);

--- a/packages/sdk/__integration__/ephemeral-100w-fresh.test.ts
+++ b/packages/sdk/__integration__/ephemeral-100w-fresh.test.ts
@@ -144,6 +144,7 @@ describe.skipIf(skipUnlessSuite("default") || NETWORK !== "devnet")(
       wallClockMs: number;
       uploadLats: number[];
       accessLats: number[];
+      failedReasons: Array<{ idx: number; reason: string }>;
     } | null = null;
 
     beforeAll(async () => {
@@ -206,6 +207,8 @@ describe.skipIf(skipUnlessSuite("default") || NETWORK !== "devnet")(
           wall_clock_ms: perfBuffer.wallClockMs,
           accessMs: statsOf(perfBuffer.accessLats),
           uploadMs: statsOf(perfBuffer.uploadLats),
+          accessSharedMs: null,
+          accessFreshMs: null,
           tickMs: null,
           refund: {
             funded_wei: totalFundedWei.toString(),
@@ -214,6 +217,7 @@ describe.skipIf(skipUnlessSuite("default") || NETWORK !== "devnet")(
             failed_sweeps: refund.failedRefunds,
           },
           extra: null,
+          failedReasons: perfBuffer.failedReasons,
         });
       }
     }, 5 * 60 * 1000);
@@ -303,6 +307,7 @@ describe.skipIf(skipUnlessSuite("default") || NETWORK !== "devnet")(
           wallClockMs: totalMs,
           uploadLats,
           accessLats,
+          failedReasons: failed.slice(0, 10),
         };
 
         expect(failed.length, `${failed.length} wallets failed`).toBe(0);

--- a/packages/sdk/__integration__/ephemeral-100w-shared.test.ts
+++ b/packages/sdk/__integration__/ephemeral-100w-shared.test.ts
@@ -165,6 +165,7 @@ describe.skipIf(skipUnlessSuite("default"))(
       failed: number;
       wallClockMs: number;
       accessLats: number[];
+      failedReasons: Array<{ idx: number; reason: string }>;
     } | null = null;
 
     beforeAll(async () => {
@@ -243,6 +244,8 @@ describe.skipIf(skipUnlessSuite("default"))(
           wall_clock_ms: perfBuffer.wallClockMs,
           accessMs: statsOf(perfBuffer.accessLats),
           uploadMs: null,
+          accessSharedMs: null,
+          accessFreshMs: null,
           tickMs: null,
           refund: {
             funded_wei: totalFundedWei.toString(),
@@ -251,6 +254,7 @@ describe.skipIf(skipUnlessSuite("default"))(
             failed_sweeps: refund.failedRefunds,
           },
           extra: null,
+          failedReasons: perfBuffer.failedReasons,
         });
       }
     }, 5 * 60 * 1000);
@@ -309,6 +313,7 @@ describe.skipIf(skipUnlessSuite("default"))(
           failed: failed.length,
           wallClockMs: totalMs,
           accessLats: lats,
+          failedReasons: failed.slice(0, 10),
         };
 
         expect(failed.length, `${failed.length} wallets failed accessCDR`).toBe(0);

--- a/packages/sdk/__integration__/ephemeral-60min-stress.test.ts
+++ b/packages/sdk/__integration__/ephemeral-60min-stress.test.ts
@@ -365,6 +365,9 @@ describe.skipIf(skipUnlessSuite("1H-stress-devnet-only") || skipUnlessDevnet())(
               100
             ).toFixed(2),
           },
+          // Stress reports failures per-cycle in `extra.failed_cycles`,
+          // not per-wallet; there's no per-failure reason to surface.
+          failedReasons: null,
         });
       }
     }, 10 * 60 * 1000);

--- a/packages/sdk/src/uploader.ts
+++ b/packages/sdk/src/uploader.ts
@@ -7,19 +7,12 @@ import type { StorageProvider } from "./storage/types.js";
 import { Observer } from "./observer.js";
 
 /**
- * Wraps `publicClient.waitForTransactionReceipt` with parameters tuned for
- * public RPC endpoints (e.g. `https://aeneid.storyrpc.io`) where receipt
- * propagation can lag block production by tens of seconds for a small tail
- * of txs. Viem's defaults (`timeout: 180_000`, `retryCount: 6`) are tuned
- * for a directly-connected node; on a public RPC the 180s overall window
- * occasionally fires on a tx that DID land on chain — the receipt just
- * hadn't surfaced yet (e.g. cdr-sdk run 26379164817, wallet idx=29: tx
- * 0x914c3c... succeeded in block 0x11d2547 but `waitForTransactionReceipt`
- * gave up first, failing 1/100 wallets in 100w-fresh-aeneid).
- *
- * Bumping `timeout` to 5 min covers any realistic propagation tail and
- * `retryCount: 30` widens the transient-HTTP-error tolerance; the SDK
- * still surfaces a real receipt error if the tx genuinely failed.
+ * `publicClient.waitForTransactionReceipt` with `timeout` widened to 5 min
+ * for public-RPC endpoints whose `eth_getTransactionReceipt` can lag block
+ * production by tens of seconds (viem default `timeout: 180_000` is too
+ * tight for the tail). Test code has a mirror in
+ * `packages/sdk/__integration__/_rpc-resilience.ts`; the duplication is
+ * intentional — the SDK shouldn't take a dependency on test-only files.
  */
 async function waitForReceiptResilient(publicClient: PublicClient, hash: Hash) {
   return publicClient.waitForTransactionReceipt({

--- a/packages/sdk/src/uploader.ts
+++ b/packages/sdk/src/uploader.ts
@@ -7,12 +7,24 @@ import type { StorageProvider } from "./storage/types.js";
 import { Observer } from "./observer.js";
 
 /**
- * `publicClient.waitForTransactionReceipt` with `timeout` widened to 5 min
- * for public-RPC endpoints whose `eth_getTransactionReceipt` can lag block
- * production by tens of seconds (viem default `timeout: 180_000` is too
- * tight for the tail). Test code has a mirror in
- * `packages/sdk/__integration__/_rpc-resilience.ts`; the duplication is
- * intentional — the SDK shouldn't take a dependency on test-only files.
+ * Wraps `publicClient.waitForTransactionReceipt` with parameters tuned for
+ * public RPC endpoints (e.g. `https://aeneid.storyrpc.io`) where receipt
+ * propagation can lag block production by tens of seconds for a small tail
+ * of txs. Viem's defaults (`timeout: 180_000`, `retryCount: 6`) are tuned
+ * for a directly-connected node; on a public RPC the 180s overall window
+ * occasionally fires on a tx that DID land on chain — the receipt just
+ * hadn't surfaced yet on the pool node serving `eth_getTransactionReceipt`
+ * (e.g. cdr-sdk run 26379164817, wallet idx=29: allocate tx 0x914c3c...
+ * mined in block 0x11d2547 status=1 but viem gave up first, failing 1/100
+ * wallets in 100w-fresh-aeneid; run 26380050980 hit the same pattern on
+ * wallet idx=31 with tx 0x13cdcd... in block 0x11d2980).
+ *
+ * Bumping `timeout` to 5 min covers any realistic propagation tail and
+ * `retryCount: 30` widens the transient-HTTP-error tolerance; the SDK
+ * still surfaces a real receipt error if the tx genuinely failed. Test
+ * code has a mirror in `packages/sdk/__integration__/_rpc-resilience.ts`;
+ * the duplication is intentional — the SDK shouldn't take a dependency
+ * on test-only files.
  */
 async function waitForReceiptResilient(publicClient: PublicClient, hash: Hash) {
   return publicClient.waitForTransactionReceipt({

--- a/packages/sdk/src/uploader.ts
+++ b/packages/sdk/src/uploader.ts
@@ -1,10 +1,34 @@
-import { parseEventLogs, toHex, toBytes, type PublicClient, type WalletClient } from "viem";
+import { parseEventLogs, toHex, toBytes, type Hash, type PublicClient, type WalletClient } from "viem";
 import { cdrAbi, contractAddresses, type Network } from "@piplabs/cdr-contracts";
 import { tdh2Encrypt, encryptFile, getWasm, type TDH2Ciphertext } from "@piplabs/cdr-crypto";
 import { uuidToLabel } from "./label.js";
 import { ContentSizeExceededError, LabelMismatchError, InvalidConditionContractError } from "./errors.js";
 import type { StorageProvider } from "./storage/types.js";
 import { Observer } from "./observer.js";
+
+/**
+ * Wraps `publicClient.waitForTransactionReceipt` with parameters tuned for
+ * public RPC endpoints (e.g. `https://aeneid.storyrpc.io`) where receipt
+ * propagation can lag block production by tens of seconds for a small tail
+ * of txs. Viem's defaults (`timeout: 180_000`, `retryCount: 6`) are tuned
+ * for a directly-connected node; on a public RPC the 180s overall window
+ * occasionally fires on a tx that DID land on chain — the receipt just
+ * hadn't surfaced yet (e.g. cdr-sdk run 26379164817, wallet idx=29: tx
+ * 0x914c3c... succeeded in block 0x11d2547 but `waitForTransactionReceipt`
+ * gave up first, failing 1/100 wallets in 100w-fresh-aeneid).
+ *
+ * Bumping `timeout` to 5 min covers any realistic propagation tail and
+ * `retryCount: 30` widens the transient-HTTP-error tolerance; the SDK
+ * still surfaces a real receipt error if the tx genuinely failed.
+ */
+async function waitForReceiptResilient(publicClient: PublicClient, hash: Hash) {
+  return publicClient.waitForTransactionReceipt({
+    hash,
+    timeout: 5 * 60 * 1000,
+    pollingInterval: 2000,
+    retryCount: 30,
+  });
+}
 
 export class Uploader {
   private publicClient: PublicClient;
@@ -122,7 +146,7 @@ export class Uploader {
       value: fee,
     });
 
-    const receipt = await this.publicClient.waitForTransactionReceipt({ hash: txHash });
+    const receipt = await waitForReceiptResilient(this.publicClient, txHash);
     const uuid = this.parseVaultAllocatedUuid(receipt.logs);
 
     return { txHash, uuid };
@@ -198,7 +222,7 @@ export class Uploader {
       value: fee,
     });
 
-    await this.publicClient.waitForTransactionReceipt({ hash: txHash });
+    await waitForReceiptResilient(this.publicClient, txHash);
 
     return { txHash };
   }


### PR DESCRIPTION
## Summary

Two problems surfaced on the aeneid `integration-aeneid-default` runs after PR #109 merged:

1. **Run [26379164817](https://github.com/piplabs/cdr-sdk/actions/runs/26379164817) failed 1/100 wallets in `ephemeral-100w-fresh-aeneid.test.ts`.** Root cause: viem `waitForTransactionReceipt`'s default 180s `timeout` is too tight for aeneid's public RPC propagation tail. Wallet idx=29's `allocate()` tx `0x914c3c...` **did** land on chain (block `0x11d2547`, status=1), but the public endpoint took longer than 180s to surface the receipt → SDK threw → test failed.
2. **Workflow summary's `🚨 Failures` block dumps a vitest stack** that's impossible to triage without clicking into the run log. The reader sees `AssertionError: 1 wallets failed: expected 1 to be +0 // Object.is equality` and ~10 lines of `node_modules/.pnpm/@vitest/...` paths — no idx, no reason, no signal whether it's flaky or a real bug.

## Changes

### Receipt-wait resilience

- New private helper `waitForReceiptResilient` in `packages/sdk/src/uploader.ts` and `packages/sdk/__integration__/_rpc-resilience.ts` that wraps `waitForTransactionReceipt` with `timeout: 5min`, `pollingInterval: 2s`, `retryCount: 30`.
- Applied at all 5 receipt-wait sites the ephemeral suites exercise:
  - SDK side: `uploader.ts` `allocate()` + `write()` (the 2 sites under `uploadCDR`)
  - Test side: `_ephemeral-wallets.ts` Multicall3-deploy + batch-fund + sweep-refund

### Readable failure summary

- `PerfStatsFile` schema extended with `failedReasons: Array<{idx, reason}> | null`. Each ephemeral suite now passes the already-computed wallet-level failure reasons (capped at 10).
- `.github/workflows/integration.yml` `aggregate_failures()` builds a {label → perf-stats} map from `/tmp/perf-stats-*.json` and, when a failed assertion's test file maps to a known label, renders:

```
### ❌ [sdk] `ephemeral-100w-fresh-aeneid.test.ts` → 100 wallets each do upload→read on their own vault, capped at 25 in-flight
**99/100 wallets succeeded, 1 failed.**

| idx | failure reason (truncated to 200 chars) |
|-----|------------------------------------------|
| 29  | Transaction receipt with hash "0x914c3c..." could not be found. The Transaction may not be processed on a block yet. … |

<details><summary>Raw assertion / vitest stack</summary>
…
</details>
```

Non-ephemeral failures (e.g. `consumer.test.ts`) gracefully fall back to vitest-stack-only.

### Pre-existing type debt cleared

4 of 5 ephemeral suites were silently missing `accessSharedMs` + `accessFreshMs` (required-but-null) in their `writePerfStats` calls. SDK `tsc --noEmit` only checks `src/`, not `__integration__/`, so this never surfaced. Added the missing fields so the integration suite type-checks clean.

## Verification

- **Retry run [26379672735](https://github.com/piplabs/cdr-sdk/actions/runs/26379672735) on `main` (no code changes)**: passed 100/100, ~13 min — confirms the 1/100 in 26379164817 was a transient propagation flake, not deterministic.
- This PR's CI on `fix/wait-for-receipt-public-rpc-resilience` should now show:
  - `integration-aeneid-default` clean (100w-fresh-aeneid 100/100)
  - `integration-devnet-default` clean
  - typecheck passing on the integration tree

## Test plan

- [x] Sim the new `aggregate_failures()` jq locally against synthetic results-sdk.json + perf-stats-100w-fresh-aeneid.json — renders the wallet-failure table as expected; falls back gracefully when no perf-stats match.
- [x] `pnpm --filter @piplabs/cdr-sdk lint` clean.
- [x] Standalone `tsc --noEmit` over `__integration__/` shows zero new errors from this PR (the remaining `consumer.test.ts pollIntervalMs` + `observer.test.ts MockInstance` errors are pre-existing on main).
- [ ] Dispatch `integration-aeneid-default` against this branch and confirm 100/100 wallets pass + the new summary format renders correctly.