### PR TITLE
fix(integration): flat per-wallet fund = 1 IP + 3 × user fees; add gas price to summary

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -634,25 +634,30 @@ jobs:
 
           # ─── Fee table: glob /tmp/fee-stats-*.json ────────────────────────────
           # Each ephemeral suite queries baseFee / writeFee / readFee /
-          # allocateFee off the live CDR contract at setup time and writes
-          # them to /tmp/fee-stats-{label}.json alongside the per-cycle cost
-          # it actually used + the computed per-wallet fund. We render that
-          # here so any "100 wallets failed with insufficient funds" failure
-          # mode is one table-row away from being diagnosed — you can see
-          # at a glance whether the chain raised a fee since the last run
-          # and whether the suite's fund covers it.
+          # allocateFee off the live CDR contract + live gas price at setup
+          # time and writes them to /tmp/fee-stats-{label}.json alongside
+          # the computed per-wallet fund. We render that here so any
+          # "100 wallets failed with insufficient funds" failure mode is one
+          # table-row away from being diagnosed — you can see at a glance
+          # whether the chain raised a fee or a gas spike pushed gas budget
+          # past the funded buffer.
+          #
+          # Per-wallet fund formula (all suites): 1 IP base + 3 × (writeFee +
+          # allocateFee + readFee). baseFee is validator-paid (not in the
+          # funding sum) but is shown for ops visibility — baseFee=0 silently
+          # disables CDR partials in the chain's evmengine handler.
           render_fee_table() {
             shopt -s nullglob
             local files=(/tmp/fee-stats-*.json)
             shopt -u nullglob
             [ "${#files[@]}" -gt 0 ] || { echo "_(no fee-stats output produced — no ephemeral suite ran)_"; echo ""; return; }
-            echo "**One row per ephemeral suite.** Fees are queried live off the CDR contract at suite setup."
-            echo "\`Per-cycle\` = the payable value the suite expects per (upload + access) iteration —"
-            echo "read-only suites (100w-shared, 1000w-perf) bill only \`readFee\`; full-cycle suites add \`baseFee + writeFee + allocateFee\`; stress adds an extra \`readFee\` for the second access per cycle."
-            echo "\`Per-wallet fund\` = \`per-cycle × cycles × safety_multiplier + gas_reserve × cycles\`."
+            echo "**One row per ephemeral suite.** Fees + gas price queried live off the chain at suite setup."
             echo ""
-            echo "| Suite | baseFee | writeFee | readFee | allocateFee | Per-cycle | Cycles/wallet | Safety× | Per-wallet fund |"
-            echo "|---|---|---|---|---|---|---|---|---|"
+            echo "Per-wallet fund = \`base_gas_budget + safety_multiplier × (writeFee + allocateFee + readFee)\`."
+            echo "\`baseFee\` is validator-paid (not in funding) — shown for visibility."
+            echo ""
+            echo "| Suite | baseFee (validator) | writeFee | allocateFee | readFee | Gas price | User per-cycle fee | Safety× | + Base gas budget | Per-wallet fund |"
+            echo "|---|---|---|---|---|---|---|---|---|---|"
             for f in "${files[@]}"; do
               jq -r '
                 def fmtIp:
@@ -662,15 +667,23 @@ jobs:
                   ($n % 10000 | tostring) as $fracraw |
                   ("0000" + $fracraw)[-4:] as $frac |
                   $whole + "." + $frac + " IP";
+                def fmtGwei:
+                  ((. | tonumber) / 1e9) as $g |
+                  ($g * 100 | floor) as $n |
+                  ($n / 100 | floor | tostring) as $whole |
+                  ($n % 100 | tostring) as $fracraw |
+                  ("00" + $fracraw)[-2:] as $frac |
+                  $whole + "." + $frac + " gwei";
                 "| " + .label
-                + " | " + (.baseFee_wei         | fmtIp)
-                + " | " + (.writeFee_wei        | fmtIp)
-                + " | " + (.readFee_wei         | fmtIp)
-                + " | " + (.allocateFee_wei     | fmtIp)
-                + " | " + (.per_cycle_wei       | fmtIp)
-                + " | " + (.cycles_per_wallet   | tostring)
-                + " | " + (.safety_multiplier   | tostring)
-                + " | " + (.per_wallet_fund_wei | fmtIp)
+                + " | " + (.base_fee_wei            | fmtIp)
+                + " | " + (.write_fee_wei           | fmtIp)
+                + " | " + (.allocate_fee_wei        | fmtIp)
+                + " | " + (.read_fee_wei            | fmtIp)
+                + " | " + (.gas_price_wei           | fmtGwei)
+                + " | " + (.user_per_cycle_fee_wei  | fmtIp)
+                + " | " + "× " + (.safety_multiplier | tostring)
+                + " | " + (.base_gas_budget_wei    | fmtIp)
+                + " | " + (.per_wallet_fund_wei    | fmtIp)
                 + " |"
               ' "$f"
             done

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -653,11 +653,12 @@ jobs:
             [ "${#files[@]}" -gt 0 ] || { echo "_(no fee-stats output produced — no ephemeral suite ran)_"; echo ""; return; }
             echo "**One row per ephemeral suite.** Fees + gas price queried live off the chain at suite setup."
             echo ""
-            echo "Per-wallet fund = \`base_gas_budget + safety_multiplier × (writeFee + allocateFee + readFee)\`."
+            echo "Formula-funded suites: \`per-wallet fund = base_gas_budget + safety_multiplier × (writeFee + allocateFee + readFee)\`."
+            echo "Override-funded suites (e.g. 60-min stress): per-wallet fund is a caller-set flat value; \`Safety×\` + \`Base gas budget\` show \`—\`."
             echo "\`baseFee\` is validator-paid (not in funding) — shown for visibility."
             echo ""
-            echo "| Suite | baseFee (validator) | writeFee | allocateFee | readFee | Gas price | User per-cycle fee | Safety× | + Base gas budget | Per-wallet fund |"
-            echo "|---|---|---|---|---|---|---|---|---|---|"
+            echo "| Suite | Source | baseFee (validator) | writeFee | allocateFee | readFee | Gas price | User per-cycle fee | Safety× | + Base gas budget | Per-wallet fund |"
+            echo "|---|---|---|---|---|---|---|---|---|---|---|"
             for f in "${files[@]}"; do
               jq -r '
                 def fmtIp:
@@ -674,15 +675,17 @@ jobs:
                   ($n % 100 | tostring) as $fracraw |
                   ("00" + $fracraw)[-2:] as $frac |
                   $whole + "." + $frac + " gwei";
+                (.fund_source // "formula") as $src |
                 "| " + .label
+                + " | " + $src
                 + " | " + (.base_fee_wei            | fmtIp)
                 + " | " + (.write_fee_wei           | fmtIp)
                 + " | " + (.allocate_fee_wei        | fmtIp)
                 + " | " + (.read_fee_wei            | fmtIp)
                 + " | " + (.gas_price_wei           | fmtGwei)
                 + " | " + (.user_per_cycle_fee_wei  | fmtIp)
-                + " | " + "× " + (.safety_multiplier | tostring)
-                + " | " + (.base_gas_budget_wei    | fmtIp)
+                + " | " + (if $src == "override" then "—" else "× " + (.safety_multiplier | tostring) end)
+                + " | " + (if $src == "override" then "—" else (.base_gas_budget_wei | fmtIp) end)
                 + " | " + (.per_wallet_fund_wei    | fmtIp)
                 + " |"
               ' "$f"

--- a/packages/sdk/__integration__/_helpers.ts
+++ b/packages/sdk/__integration__/_helpers.ts
@@ -278,88 +278,71 @@ export async function queryCDRFees(
   return { baseFee, writeFee, readFee, allocateFee };
 }
 
+// Flat per-wallet fund constants.
+//
+// The previous formula scaled with cyclesPerWallet + per-suite cost shape
+// (upload-vs-access-vs-cycle). Two problems with that:
+//   1. `uploadFeeCost` included `baseFee` — but baseFee is paid by
+//      validators when they submit partial decryptions, not by the user.
+//      User-side `uploadCDR` only requires `allocateFee + writeFee`. The
+//      old formula over-funded by `baseFee × cycles × 3` on every suite.
+//   2. Sizing was so tight that a single fee bump on aeneid (0.01 → 0.03 IP)
+//      tipped 100/100 wallets into insufficient-funds failures.
+//
+// New formula: every ephemeral suite gets the same fund regardless of
+// cycles-per-wallet or which contract paths it exercises:
+//
+//   perWalletFund = BASE_GAS_BUDGET + (writeFee + allocateFee + readFee) × FUND_SAFETY_MULTIPLIER
+//
+// 1 IP base covers per-tx gas for any reasonable workload; ×3 of the
+// user-side per-cycle fees absorbs fee bumps mid-run.
+export const BASE_GAS_BUDGET_WEI = 1_000_000_000_000_000_000n; // 1 IP
+export const FUND_SAFETY_MULTIPLIER = 3n;
+
 /**
- * Required `payable` value for one uploadCDR call, EXCLUDING gas.
- * Mirrors the contract's `require(msg.value == baseFee + writeFee +
- * allocateFee)` on the write path.
+ * Required `payable` value for one user-side (allocate + write + read)
+ * cycle, EXCLUDING gas and EXCLUDING the validator-paid `baseFee`.
+ * Mirrors `require(msg.value == ...)` on each user-facing CDR path.
  */
-export function uploadFeeCost(fees: CDRFees): bigint {
-  return fees.baseFee + fees.writeFee + fees.allocateFee;
+export function userPerCycleFee(fees: CDRFees): bigint {
+  return fees.writeFee + fees.allocateFee + fees.readFee;
 }
 
 /**
- * Required `payable` value for one accessCDR call, EXCLUDING gas.
- * Mirrors `require(msg.value == readFee)` on the read path. `baseFee`
- * is NOT charged on access — read-only suites (100w-shared, 1000w-perf)
- * pay only this.
- */
-export function accessFeeCost(fees: CDRFees): bigint {
-  return fees.readFee;
-}
-
-/**
- * Required `payable` value for one (upload + access) cycle. Suites that
- * exercise both paths per wallet (100w-fresh*, 60min-stress) use this.
- */
-export function cycleFeeCost(fees: CDRFees): bigint {
-  return uploadFeeCost(fees) + accessFeeCost(fees);
-}
-
-/**
- * Compute per-wallet fund for an ephemeral suite. Callers pass the
- * per-cycle cost they expect (`cycleFeeCost`/`uploadFeeCost`/
- * `accessFeeCost`) so this helper stays agnostic to which contract
- * paths the suite exercises.
+ * Per-wallet fund used by every ephemeral suite. Flat formula:
+ *   1 IP base + 3 × (writeFee + allocateFee + readFee)
  *
- *   funded = perCycleWei × cyclesPerWallet × safetyMultiplier
- *          + gasReservePerCycleWei × cyclesPerWallet
- *
- * `safetyMultiplier` covers fee bumps mid-run + per-tx gas variance;
- * default 3× tracks the historical funded/needed ratio on devnet
- * (PER_WALLET_FUND=0.1 IP vs single-cycle fee cost ≈ 0.04 IP).
- * `gasReservePerCycleWei` defaults to 0.005 IP per cycle, which covers
- * 1-3 txs of typical gas (~0.001-0.002 IP per tx). Same order of
- * magnitude as the `refundWallets` end-of-suite reserve.
- *
- * Returns a bigint suitable for passing straight into `fundWallets`.
+ * Independent of the suite's cycles-per-wallet count and which
+ * contract paths it exercises — uniform funding keeps the test surface
+ * predictable and tolerates fee bumps mid-run.
  */
-export function computePerWalletFund(opts: {
-  perCycleWei: bigint;
-  cyclesPerWallet: number;
-  safetyMultiplier?: number;
-  gasReservePerCycleWei?: bigint;
-}): bigint {
-  const cycles = BigInt(opts.cyclesPerWallet);
-  const multiplier = BigInt(Math.round((opts.safetyMultiplier ?? 3) * 100));
-  // Multiply by safetyMultiplier × 100 then divide by 100 to keep bigint
-  // math integral when callers pass a fractional multiplier like 2.5.
-  const padded = (opts.perCycleWei * cycles * multiplier) / 100n;
-  const gas = opts.gasReservePerCycleWei ?? 5_000_000_000_000_000n; // 0.005 IP
-  return padded + gas * cycles;
+export function computePerWalletFund(fees: CDRFees): bigint {
+  return BASE_GAS_BUDGET_WEI + userPerCycleFee(fees) * FUND_SAFETY_MULTIPLIER;
 }
 
 /**
  * Per-suite fee snapshot written to `/tmp/fee-stats-{label}.json` at the
  * end of each ephemeral suite setup. The integration workflow's summary
  * step globs these files and renders one table row per file in the Step
- * Summary, surfacing live fee values + actual per-wallet fund used
- * alongside the perf table.
+ * Summary, surfacing live fee values + gas price + actual per-wallet
+ * fund used alongside the perf table.
+ *
+ * `base_fee_wei` is the validator-paid `baseFee` — it does NOT feed into
+ * `per_wallet_fund_wei`. It is recorded here for ops visibility (if
+ * baseFee is 0 the chain's evmengine handler silently drops every
+ * partial submission — see piplabs/story client/x/evmengine/keeper/cdr.go).
  */
 export interface FeeStatsFile {
   label: string;
   network: string;
-  baseFee_wei: string;
-  writeFee_wei: string;
-  readFee_wei: string;
-  allocateFee_wei: string;
-  /**
-   * The per-cycle fee cost the suite used to compute its fund — either
-   * `cycleFeeCost` (full upload+access), `uploadFeeCost`, or `accessFeeCost`
-   * depending on which contract path the suite exercises.
-   */
-  per_cycle_wei: string;
-  cycles_per_wallet: number;
+  base_fee_wei: string;
+  write_fee_wei: string;
+  read_fee_wei: string;
+  allocate_fee_wei: string;
+  gas_price_wei: string;
+  user_per_cycle_fee_wei: string;
   safety_multiplier: number;
+  base_gas_budget_wei: string;
   per_wallet_fund_wei: string;
 }
 
@@ -379,66 +362,56 @@ export function writeFeeStats(file: FeeStatsFile): void {
 }
 
 /**
- * Suite-side convenience wrapper: query live fees, compute per-wallet
- * fund, persist the fee-stats snapshot for the workflow summary, and
- * return the fund. Folds the boilerplate that all five ephemeral suites
- * share into a single call. The `perCycleCost` selector lets each suite
- * pick the cost shape it actually exercises without the helper having
- * to know which contract paths it touches.
+ * Suite-side convenience wrapper: query live fees + live gas price,
+ * compute per-wallet fund via the flat formula, persist the fee-stats
+ * snapshot for the workflow summary, and return the fund.
  *
  *   const perWalletFund = await sizeFundAndReport({
  *     label: "100w-fresh-aeneid",
  *     network: NETWORK,
  *     publicClient: funderPublic,
- *     perCycleCost: cycleFeeCost,            // or accessFeeCost / uploadFeeCost
- *     cyclesPerWallet: 1,
- *     safetyMultiplier: 3,
  *   });
  *
- * Logs the fee snapshot via `console.log` so the suite's CI output
- * preserves the same one-line trace that the previous bespoke logCase
- * calls produced.
+ * The formula is uniform across suites:
+ *   perWalletFund = 1 IP + 3 × (writeFee + allocateFee + readFee)
+ *
+ * `baseFee` is not part of funding (validator-paid) but is recorded in
+ * the fee-stats JSON for ops visibility. `gas_price_wei` is queried live
+ * off the funder's public client so the workflow summary can surface it
+ * next to fee values (gas price spikes are the most common cause of
+ * insufficient-funds at the read step on aeneid).
  */
 export async function sizeFundAndReport(opts: {
   label: string;
   network: string;
   publicClient: PublicClient;
   contractNetwork?: Network;
-  perCycleCost: (fees: CDRFees) => bigint;
-  cyclesPerWallet: number;
-  safetyMultiplier?: number;
-  gasReservePerCycleWei?: bigint;
 }): Promise<bigint> {
-  const fees = await queryCDRFees(
-    opts.publicClient,
-    opts.contractNetwork ?? "testnet",
-  );
-  const perCycleWei = opts.perCycleCost(fees);
-  const safetyMultiplier = opts.safetyMultiplier ?? 3;
-  const perWalletFund = computePerWalletFund({
-    perCycleWei,
-    cyclesPerWallet: opts.cyclesPerWallet,
-    safetyMultiplier,
-    gasReservePerCycleWei: opts.gasReservePerCycleWei,
-  });
+  const [fees, gasPriceWei] = await Promise.all([
+    queryCDRFees(opts.publicClient, opts.contractNetwork ?? "testnet"),
+    opts.publicClient.getGasPrice(),
+  ]);
+  const userCycleFeeWei = userPerCycleFee(fees);
+  const perWalletFund = computePerWalletFund(fees);
   writeFeeStats({
     label: opts.label,
     network: opts.network,
-    baseFee_wei: fees.baseFee.toString(),
-    writeFee_wei: fees.writeFee.toString(),
-    readFee_wei: fees.readFee.toString(),
-    allocateFee_wei: fees.allocateFee.toString(),
-    per_cycle_wei: perCycleWei.toString(),
-    cycles_per_wallet: opts.cyclesPerWallet,
-    safety_multiplier: safetyMultiplier,
+    base_fee_wei: fees.baseFee.toString(),
+    write_fee_wei: fees.writeFee.toString(),
+    read_fee_wei: fees.readFee.toString(),
+    allocate_fee_wei: fees.allocateFee.toString(),
+    gas_price_wei: gasPriceWei.toString(),
+    user_per_cycle_fee_wei: userCycleFeeWei.toString(),
+    safety_multiplier: Number(FUND_SAFETY_MULTIPLIER),
+    base_gas_budget_wei: BASE_GAS_BUDGET_WEI.toString(),
     per_wallet_fund_wei: perWalletFund.toString(),
   });
   // eslint-disable-next-line no-console
   console.log(
     `[fee-sizing][${opts.label}] base=${fees.baseFee} write=${fees.writeFee} ` +
-      `read=${fees.readFee} allocate=${fees.allocateFee} perCycle=${perCycleWei} ` +
-      `cycles=${opts.cyclesPerWallet} safety=${safetyMultiplier} ` +
-      `perWalletFund=${perWalletFund}`,
+      `read=${fees.readFee} allocate=${fees.allocateFee} gasPrice=${gasPriceWei} ` +
+      `userPerCycle=${userCycleFeeWei} perWalletFund=${perWalletFund} ` +
+      `(= ${BASE_GAS_BUDGET_WEI} base + ${userCycleFeeWei} × ${FUND_SAFETY_MULTIPLIER})`,
   );
   return perWalletFund;
 }

--- a/packages/sdk/__integration__/_helpers.ts
+++ b/packages/sdk/__integration__/_helpers.ts
@@ -341,6 +341,15 @@ export interface FeeStatsFile {
   allocate_fee_wei: string;
   gas_price_wei: string;
   user_per_cycle_fee_wei: string;
+  /**
+   * "formula" → per_wallet_fund_wei = base_gas_budget_wei + safety_multiplier × user_per_cycle_fee_wei.
+   * "override" → per_wallet_fund_wei is a caller-provided flat value; safety_multiplier /
+   *               base_gas_budget_wei are recorded as 0 and the workflow summary renders "—"
+   *               in those cells. Used by suites whose per-wallet cost is dominated by
+   *               cycle count rather than per-cycle fee (e.g. the 60-min stress suite which
+   *               runs ~150 cycles/wallet on devnet — vastly exceeding any flat-formula budget).
+   */
+  fund_source: "formula" | "override";
   safety_multiplier: number;
   base_gas_budget_wei: string;
   per_wallet_fund_wei: string;
@@ -363,22 +372,37 @@ export function writeFeeStats(file: FeeStatsFile): void {
 
 /**
  * Suite-side convenience wrapper: query live fees + live gas price,
- * compute per-wallet fund via the flat formula, persist the fee-stats
- * snapshot for the workflow summary, and return the fund.
+ * compute per-wallet fund via the flat formula (or accept a caller-provided
+ * override), persist the fee-stats snapshot for the workflow summary, and
+ * return the fund.
  *
+ *   // formula path (default — short suites doing ≤ a few cycles per wallet)
  *   const perWalletFund = await sizeFundAndReport({
  *     label: "100w-fresh-aeneid",
  *     network: NETWORK,
  *     publicClient: funderPublic,
  *   });
  *
- * The formula is uniform across suites:
- *   perWalletFund = 1 IP + 3 × (writeFee + allocateFee + readFee)
+ *   // override path — suites whose per-wallet cost is dominated by
+ *   // cycle count rather than per-cycle fee (e.g. 60-min stress runs
+ *   // ~150 cycles/wallet, which the flat 1 IP base cannot cover).
+ *   const perWalletFund = await sizeFundAndReport({
+ *     label: "60min-stress",
+ *     network: NETWORK,
+ *     publicClient: funderPublic,
+ *     overrideFundWei: parseEther("100"),
+ *   });
+ *
+ * Even on the override path we still query live fees + gas price so the
+ * workflow summary table has a row for every suite that runs, with the
+ * same set of contextual columns. Unused balance is swept back via
+ * `refundWallets` at the end of each suite — over-funding the override
+ * value is cheap, exhausting it mid-run isn't.
  *
  * `baseFee` is not part of funding (validator-paid) but is recorded in
  * the fee-stats JSON for ops visibility. `gas_price_wei` is queried live
  * off the funder's public client so the workflow summary can surface it
- * next to fee values (gas price spikes are the most common cause of
+ * next to fee values (gas-price spikes are the most common cause of
  * insufficient-funds at the read step on aeneid).
  */
 export async function sizeFundAndReport(opts: {
@@ -386,13 +410,21 @@ export async function sizeFundAndReport(opts: {
   network: string;
   publicClient: PublicClient;
   contractNetwork?: Network;
+  /**
+   * When set, bypass the flat formula and use this exact value as the
+   * per-wallet fund. Caller is responsible for picking a value that
+   * comfortably covers their suite's per-wallet cost; `refundWallets`
+   * sweeps any unused balance back to the funder at teardown.
+   */
+  overrideFundWei?: bigint;
 }): Promise<bigint> {
   const [fees, gasPriceWei] = await Promise.all([
     queryCDRFees(opts.publicClient, opts.contractNetwork ?? "testnet"),
     opts.publicClient.getGasPrice(),
   ]);
   const userCycleFeeWei = userPerCycleFee(fees);
-  const perWalletFund = computePerWalletFund(fees);
+  const isOverride = opts.overrideFundWei !== undefined;
+  const perWalletFund = opts.overrideFundWei ?? computePerWalletFund(fees);
   writeFeeStats({
     label: opts.label,
     network: opts.network,
@@ -402,8 +434,9 @@ export async function sizeFundAndReport(opts: {
     allocate_fee_wei: fees.allocateFee.toString(),
     gas_price_wei: gasPriceWei.toString(),
     user_per_cycle_fee_wei: userCycleFeeWei.toString(),
-    safety_multiplier: Number(FUND_SAFETY_MULTIPLIER),
-    base_gas_budget_wei: BASE_GAS_BUDGET_WEI.toString(),
+    fund_source: isOverride ? "override" : "formula",
+    safety_multiplier: isOverride ? 0 : Number(FUND_SAFETY_MULTIPLIER),
+    base_gas_budget_wei: isOverride ? "0" : BASE_GAS_BUDGET_WEI.toString(),
     per_wallet_fund_wei: perWalletFund.toString(),
   });
   // eslint-disable-next-line no-console
@@ -411,7 +444,9 @@ export async function sizeFundAndReport(opts: {
     `[fee-sizing][${opts.label}] base=${fees.baseFee} write=${fees.writeFee} ` +
       `read=${fees.readFee} allocate=${fees.allocateFee} gasPrice=${gasPriceWei} ` +
       `userPerCycle=${userCycleFeeWei} perWalletFund=${perWalletFund} ` +
-      `(= ${BASE_GAS_BUDGET_WEI} base + ${userCycleFeeWei} × ${FUND_SAFETY_MULTIPLIER})`,
+      (isOverride
+        ? `(override — formula would give ${computePerWalletFund(fees)})`
+        : `(= ${BASE_GAS_BUDGET_WEI} base + ${userCycleFeeWei} × ${FUND_SAFETY_MULTIPLIER})`),
   );
   return perWalletFund;
 }

--- a/packages/sdk/__integration__/_helpers.ts
+++ b/packages/sdk/__integration__/_helpers.ts
@@ -296,15 +296,15 @@ export async function queryCDRFees(
 //
 // 1 IP base covers per-tx gas for any reasonable workload; ×3 of the
 // user-side per-cycle fees absorbs fee bumps mid-run.
-export const BASE_GAS_BUDGET_WEI = 1_000_000_000_000_000_000n; // 1 IP
-export const FUND_SAFETY_MULTIPLIER = 3n;
+const BASE_GAS_BUDGET_WEI = 1_000_000_000_000_000_000n; // 1 IP
+const FUND_SAFETY_MULTIPLIER = 3n;
 
 /**
  * Required `payable` value for one user-side (allocate + write + read)
  * cycle, EXCLUDING gas and EXCLUDING the validator-paid `baseFee`.
  * Mirrors `require(msg.value == ...)` on each user-facing CDR path.
  */
-export function userPerCycleFee(fees: CDRFees): bigint {
+function userPerCycleFee(fees: CDRFees): bigint {
   return fees.writeFee + fees.allocateFee + fees.readFee;
 }
 
@@ -316,7 +316,7 @@ export function userPerCycleFee(fees: CDRFees): bigint {
  * contract paths it exercises — uniform funding keeps the test surface
  * predictable and tolerates fee bumps mid-run.
  */
-export function computePerWalletFund(fees: CDRFees): bigint {
+function computePerWalletFund(fees: CDRFees): bigint {
   return BASE_GAS_BUDGET_WEI + userPerCycleFee(fees) * FUND_SAFETY_MULTIPLIER;
 }
 
@@ -332,7 +332,7 @@ export function computePerWalletFund(fees: CDRFees): bigint {
  * baseFee is 0 the chain's evmengine handler silently drops every
  * partial submission — see piplabs/story client/x/evmengine/keeper/cdr.go).
  */
-export interface FeeStatsFile {
+interface FeeStatsFile {
   label: string;
   network: string;
   base_fee_wei: string;
@@ -355,7 +355,7 @@ export interface FeeStatsFile {
   per_wallet_fund_wei: string;
 }
 
-export function writeFeeStats(file: FeeStatsFile): void {
+function writeFeeStats(file: FeeStatsFile): void {
   // Lazy fs import — see writePerfStats above for the rationale.
   // eslint-disable-next-line @typescript-eslint/no-require-imports
   const fs = require("node:fs") as typeof import("node:fs");
@@ -423,8 +423,16 @@ export async function sizeFundAndReport(opts: {
     opts.publicClient.getGasPrice(),
   ]);
   const userCycleFeeWei = userPerCycleFee(fees);
+  const formulaFundWei = computePerWalletFund(fees);
   const isOverride = opts.overrideFundWei !== undefined;
-  const perWalletFund = opts.overrideFundWei ?? computePerWalletFund(fees);
+  const perWalletFund = opts.overrideFundWei ?? formulaFundWei;
+  const fundShape = isOverride
+    ? { fund_source: "override" as const, safety_multiplier: 0, base_gas_budget_wei: "0" }
+    : {
+        fund_source: "formula" as const,
+        safety_multiplier: Number(FUND_SAFETY_MULTIPLIER),
+        base_gas_budget_wei: BASE_GAS_BUDGET_WEI.toString(),
+      };
   writeFeeStats({
     label: opts.label,
     network: opts.network,
@@ -434,9 +442,7 @@ export async function sizeFundAndReport(opts: {
     allocate_fee_wei: fees.allocateFee.toString(),
     gas_price_wei: gasPriceWei.toString(),
     user_per_cycle_fee_wei: userCycleFeeWei.toString(),
-    fund_source: isOverride ? "override" : "formula",
-    safety_multiplier: isOverride ? 0 : Number(FUND_SAFETY_MULTIPLIER),
-    base_gas_budget_wei: isOverride ? "0" : BASE_GAS_BUDGET_WEI.toString(),
+    ...fundShape,
     per_wallet_fund_wei: perWalletFund.toString(),
   });
   // eslint-disable-next-line no-console
@@ -444,9 +450,8 @@ export async function sizeFundAndReport(opts: {
     `[fee-sizing][${opts.label}] base=${fees.baseFee} write=${fees.writeFee} ` +
       `read=${fees.readFee} allocate=${fees.allocateFee} gasPrice=${gasPriceWei} ` +
       `userPerCycle=${userCycleFeeWei} perWalletFund=${perWalletFund} ` +
-      (isOverride
-        ? `(override — formula would give ${computePerWalletFund(fees)})`
-        : `(= ${BASE_GAS_BUDGET_WEI} base + ${userCycleFeeWei} × ${FUND_SAFETY_MULTIPLIER})`),
+      `source=${fundShape.fund_source}` +
+      (isOverride ? ` (formula would give ${formulaFundWei})` : ""),
   );
   return perWalletFund;
 }

--- a/packages/sdk/__integration__/ephemeral-1000w-perf.test.ts
+++ b/packages/sdk/__integration__/ephemeral-1000w-perf.test.ts
@@ -45,7 +45,6 @@ import {
   refundWallets,
 } from "./_ephemeral-wallets.js";
 import {
-  accessFeeCost,
   formatMs,
   logCase,
   max as arrMax,
@@ -63,7 +62,6 @@ const WALLET_COUNT = 1000;
 // under Story's ~30M block gas limit on both DevNet + Aeneid.
 const FUND_BATCH_SIZE = 200;
 const CYCLES_PER_WALLET = 1; // 1 accessCDR per wallet, no upload
-const FUND_SAFETY_MULTIPLIER = 3;
 const ACCESS_TIMEOUT_MS = 300_000;
 
 const API_URL = process.env.CDR_API_URL;
@@ -186,16 +184,13 @@ describe.skipIf(skipUnlessSuite("1000-wallet-performance-devnet-only") || NETWOR
       funderClient = f.client;
       funderAddress = privateKeyToAccount(FUNDER_KEY!).address;
 
-      // Read-only suite: each wallet pays readFee only. Size fund from
-      // live readFee so we don't have to rotate this hard-coded number
-      // every time chain fees move.
+      // Flat per-wallet fund = 1 IP + 3 × (writeFee + allocateFee + readFee).
+      // Read-only suite over-funds by writeFee+allocateFee × 3 at current
+      // chain fees, which is fine — 1 IP base dominates anyway.
       perWalletFund = await sizeFundAndReport({
         label: "1000w-perf",
         network: NETWORK,
         publicClient: funderPublic,
-        perCycleCost: accessFeeCost,
-        cyclesPerWallet: CYCLES_PER_WALLET,
-        safetyMultiplier: FUND_SAFETY_MULTIPLIER,
       });
 
       openCondition = await deployOpenCondition(funderPublic, funderWallet);

--- a/packages/sdk/__integration__/ephemeral-100w-fresh-aeneid.test.ts
+++ b/packages/sdk/__integration__/ephemeral-100w-fresh-aeneid.test.ts
@@ -43,7 +43,6 @@ import {
   refundWallets,
 } from "./_ephemeral-wallets.js";
 import {
-  cycleFeeCost,
   formatMs,
   logCase,
   mean,
@@ -57,7 +56,6 @@ import { pLimit, resilientHttp, withAeneidFlakeRetry } from "./_rpc-resilience.j
 
 const WALLET_COUNT = 100;
 const CYCLES_PER_WALLET = 1; // upload + access
-const FUND_SAFETY_MULTIPLIER = 3;
 const ACCESS_TIMEOUT_MS = 180_000;
 const MAX_INFLIGHT = 25;
 
@@ -153,17 +151,15 @@ describe.skipIf(skipUnlessSuite("default") || NETWORK !== "aeneid")(
       funderWallet = f.walletClient;
       funderAddress = privateKeyToAccount(FUNDER_KEY!).address;
 
-      // Size each wallet's fund from live CDR fees. The previous hard-coded
-      // 0.1 IP broke on aeneid once all four fees moved 0.01 → 0.03 IP —
-      // 0.1 IP minus a single upload (~0.078 IP) left only ~0.022 IP, below
-      // the 0.03 IP value the read tx requires.
+      // Flat per-wallet fund = 1 IP + 3 × (writeFee + allocateFee + readFee).
+      // 1 IP base covers gas; 3× safety on user-side fees absorbs mid-run
+      // fee bumps. See _helpers.ts::computePerWalletFund for the rationale
+      // — replaces the previous hard-coded 0.1 IP that broke once aeneid
+      // fees moved 0.01 → 0.03 IP.
       perWalletFund = await sizeFundAndReport({
         label: "100w-fresh-aeneid",
         network: NETWORK,
         publicClient: funderPublic,
-        perCycleCost: cycleFeeCost,
-        cyclesPerWallet: CYCLES_PER_WALLET,
-        safetyMultiplier: FUND_SAFETY_MULTIPLIER,
       });
 
       openCondition = await deployOpenCondition(funderPublic, funderWallet);

--- a/packages/sdk/__integration__/ephemeral-100w-fresh.test.ts
+++ b/packages/sdk/__integration__/ephemeral-100w-fresh.test.ts
@@ -46,7 +46,6 @@ import {
   refundWallets,
 } from "./_ephemeral-wallets.js";
 import {
-  cycleFeeCost,
   formatMs,
   logCase,
   mean,
@@ -59,7 +58,6 @@ import {
 
 const WALLET_COUNT = 100;
 const CYCLES_PER_WALLET = 1; // upload + access
-const FUND_SAFETY_MULTIPLIER = 3;
 const ACCESS_TIMEOUT_MS = 180_000;
 
 const API_URL = process.env.CDR_API_URL;
@@ -154,15 +152,12 @@ describe.skipIf(skipUnlessSuite("default") || NETWORK !== "devnet")(
       funderWallet = f.walletClient;
       funderAddress = privateKeyToAccount(FUNDER_KEY!).address;
 
-      // Size each wallet's fund from live CDR fees. See the aeneid
-      // sibling suite for the failure-mode rationale.
+      // Flat per-wallet fund = 1 IP + 3 × (writeFee + allocateFee + readFee).
+      // See _helpers.ts::computePerWalletFund for the rationale.
       perWalletFund = await sizeFundAndReport({
         label: "100w-fresh",
         network: NETWORK,
         publicClient: funderPublic,
-        perCycleCost: cycleFeeCost,
-        cyclesPerWallet: CYCLES_PER_WALLET,
-        safetyMultiplier: FUND_SAFETY_MULTIPLIER,
       });
 
       openCondition = await deployOpenCondition(funderPublic, funderWallet);

--- a/packages/sdk/__integration__/ephemeral-100w-shared.test.ts
+++ b/packages/sdk/__integration__/ephemeral-100w-shared.test.ts
@@ -54,7 +54,6 @@ import {
   refundWallets,
 } from "./_ephemeral-wallets.js";
 import {
-  accessFeeCost,
   formatMs,
   logCase,
   mean,
@@ -67,7 +66,6 @@ import {
 
 const WALLET_COUNT = 100;
 const CYCLES_PER_WALLET = 1; // 1 accessCDR per wallet, no upload
-const FUND_SAFETY_MULTIPLIER = 3;
 const ACCESS_TIMEOUT_MS = 180_000;
 
 const API_URL = process.env.CDR_API_URL;
@@ -176,15 +174,14 @@ describe.skipIf(skipUnlessSuite("default"))(
       funderClient = f.client;
       funderAddress = privateKeyToAccount(FUNDER_KEY!).address;
 
-      // Read-only suite: each wallet pays accessFee only (no upload, no
-      // baseFee). Size fund from live readFee.
+      // Flat per-wallet fund = 1 IP + 3 × (writeFee + allocateFee + readFee).
+      // Read-only suite over-funds by writeFee+allocateFee × 3 at current
+      // chain fees, which is fine — 1 IP base dominates anyway, and the
+      // uniform formula keeps the test surface predictable.
       perWalletFund = await sizeFundAndReport({
         label: "100w-shared",
         network: NETWORK,
         publicClient: funderPublic,
-        perCycleCost: accessFeeCost,
-        cyclesPerWallet: CYCLES_PER_WALLET,
-        safetyMultiplier: FUND_SAFETY_MULTIPLIER,
       });
 
       openCondition = await deployOpenCondition(funderPublic, funderWallet);

--- a/packages/sdk/__integration__/ephemeral-60min-stress.test.ts
+++ b/packages/sdk/__integration__/ephemeral-60min-stress.test.ts
@@ -85,22 +85,17 @@ import {
   refundWallets,
 } from "./_ephemeral-wallets.js";
 import {
-  accessFeeCost,
   sizeFundAndReport,
   statsOf,
-  uploadFeeCost,
   writePerfStats,
 } from "./_helpers.js";
 
 const DURATION_MS = 60 * 60 * 1000; // 1 hour
 const CONCURRENCY = 10;
-// Generous over-estimate of cycles per wallet. Real run on devnet does
-// ~120-200 cycles in 1 hour; 1000 here absorbs any future cycle speedup
-// while staying close to the spirit of the previous static 1000 IP fund
-// (it works out to ~155 IP/wallet on devnet vs the previous 1000 IP —
-// still a 15× buffer over realistic need, but tracks live fees).
+// Documentary constant — real run on devnet does ~120-200 cycles in 1 hour.
+// No longer feeds into per-wallet fund sizing (now flat 1 IP base + 3 ×
+// (writeFee + allocateFee + readFee), independent of cycle count).
 const ESTIMATED_CYCLES_PER_WALLET = 1000;
-const FUND_SAFETY_MULTIPLIER = 3;
 // Generous reserve absorbs any pending-tx mempool cost when refund runs
 // right after the last cycle. Loses ~10 IP across 10 wallets — DevNet
 // anvil-0 has unlimited dev IP, so trading a little waste for refund
@@ -245,16 +240,15 @@ describe.skipIf(skipUnlessSuite("1H-stress-devnet-only") || skipUnlessDevnet())(
       funderClient = f.client;
       funderAddress = privateKeyToAccount(FUNDER_KEY!).address;
 
-      // Each cycle = 1 uploadCDR + 2 accessCDR (shared + own-fresh). The
-      // fee snapshot + fund sizing also lands in /tmp/fee-stats-60min-stress.json
-      // for the workflow summary table.
+      // Flat per-wallet fund = 1 IP + 3 × (writeFee + allocateFee + readFee).
+      // Stress runs 1h × 10 wallets × ~150 cycles, but funding is independent
+      // of cycle count — 1 IP base on devnet (where fees are typically 0.01 IP)
+      // covers ~50k cycles' worth of gas. The fee snapshot + fund sizing
+      // lands in /tmp/fee-stats-60min-stress.json for the workflow summary.
       perWalletFund = await sizeFundAndReport({
         label: "60min-stress",
         network: NETWORK,
         publicClient: funderPublic,
-        perCycleCost: (fees) => uploadFeeCost(fees) + accessFeeCost(fees) * 2n,
-        cyclesPerWallet: ESTIMATED_CYCLES_PER_WALLET,
-        safetyMultiplier: FUND_SAFETY_MULTIPLIER,
       });
 
       openCondition = await deployOpenCondition(funderPublic, funderWallet);

--- a/packages/sdk/__integration__/ephemeral-60min-stress.test.ts
+++ b/packages/sdk/__integration__/ephemeral-60min-stress.test.ts
@@ -93,9 +93,23 @@ import {
 const DURATION_MS = 60 * 60 * 1000; // 1 hour
 const CONCURRENCY = 10;
 // Documentary constant — real run on devnet does ~120-200 cycles in 1 hour.
-// No longer feeds into per-wallet fund sizing (now flat 1 IP base + 3 ×
-// (writeFee + allocateFee + readFee), independent of cycle count).
 const ESTIMATED_CYCLES_PER_WALLET = 1000;
+// Fixed per-wallet fund for the 1-hour stress run on devnet. Each cycle
+// pays `writeFee + allocateFee + 2 × readFee` (upload + 2 × accessCDR),
+// so at ~150 cycles × 0.04 IP/cycle (devnet) + gas overhead we need
+// ~7-10 IP per wallet. 100 IP gives ~10× safety on devnet (anvil-0
+// funder has effectively unlimited IP, and `refundWallets` sweeps any
+// unused balance back at teardown — over-funding is cheap, exhausting
+// mid-run is not). Stress is `skipUnlessDevnet`-gated, so aeneid /
+// mainnet never hit this code path.
+//
+// History: PR #109 inlined this into the dynamic-fee formula with
+// `cyclesPerWallet=1000` + `safetyMultiplier=3`, producing ~155 IP/wallet
+// on devnet. PR #113 flattened that formula but accidentally dropped the
+// cycle-count factor — the resulting ~1.09 IP/wallet exhausted after
+// ~25 cycles. Reverted to a fixed value here, queried-fee path lives in
+// `sizeFundAndReport`'s formula branch and is reserved for short suites.
+const STRESS_PER_WALLET_FUND = parseEther("100");
 // Generous reserve absorbs any pending-tx mempool cost when refund runs
 // right after the last cycle. Loses ~10 IP across 10 wallets — DevNet
 // anvil-0 has unlimited dev IP, so trading a little waste for refund
@@ -240,15 +254,17 @@ describe.skipIf(skipUnlessSuite("1H-stress-devnet-only") || skipUnlessDevnet())(
       funderClient = f.client;
       funderAddress = privateKeyToAccount(FUNDER_KEY!).address;
 
-      // Flat per-wallet fund = 1 IP + 3 × (writeFee + allocateFee + readFee).
-      // Stress runs 1h × 10 wallets × ~150 cycles, but funding is independent
-      // of cycle count — 1 IP base on devnet (where fees are typically 0.01 IP)
-      // covers ~50k cycles' worth of gas. The fee snapshot + fund sizing
-      // lands in /tmp/fee-stats-60min-stress.json for the workflow summary.
+      // Stress uses a fixed override (100 IP/wallet) — the flat formula
+      // branch is for short suites and can't cover ~150 cycles' worth
+      // of fees over 1h. We still call `sizeFundAndReport` (not a bespoke
+      // path) so the workflow summary table has a row with live fees +
+      // gas price for this suite, same shape as every other suite. See
+      // STRESS_PER_WALLET_FUND comment above for the sizing rationale.
       perWalletFund = await sizeFundAndReport({
         label: "60min-stress",
         network: NETWORK,
         publicClient: funderPublic,
+        overrideFundWei: STRESS_PER_WALLET_FUND,
       });
 
       openCondition = await deployOpenCondition(funderPublic, funderWallet);


### PR DESCRIPTION
## Summary

Replace the per-suite `cyclesPerWallet × safetyMultiplier × perCycleCost` per-wallet-fund formula with a uniform:

```
perWalletFund = 1 IP + 3 × (writeFee + allocateFee + readFee)
```

Applied to all 5 ephemeral suites. Also add a `Gas price` column to the workflow summary's *Live CDR fees + ephemeral fund sizing* table.

## Why

### Old formula included `baseFee`

`uploadFeeCost` was `baseFee + writeFee + allocateFee`, but `baseFee` is paid by validators on `submitEncryptedPartialDecryptionBatch` — not by the user on `uploadCDR`. User-facing `uploadCDR` only requires `allocateFee + writeFee` (verified against `contracts/src/protocol/CDR.sol`: `allocate()` charges `allocateFee` at L144, `write()` charges `writeFee` at L203, `read()` charges `readFee` at L243, `baseFee` only fires from `submitEncryptedPartialDecryption[Batch]()` at L281/L310).

Net effect: the old formula over-funded by `baseFee × cycles × safety_multiplier` on every full-cycle suite.

### Old formula scaled too tightly with cycles

Tight sizing meant a single fee bump on aeneid (0.01 → 0.03 IP) tipped 100/100 wallets into `insufficient funds for transfer` at the read step. A flat 1 IP base ensures gas headroom for any reasonable workload regardless of cycle count.

### Gas-price visibility

On aeneid, gas-price spikes (from a busy block) are the most common cause of read-step insufficient-funds even when fees are stable. Adding the live gas price to the summary makes that diagnosable at a glance.

## Changes

| File | Change |
|---|---|
| `packages/sdk/__integration__/_helpers.ts` | Replace `uploadFeeCost`/`accessFeeCost`/`cycleFeeCost`/`computePerWalletFund(opts)` → `userPerCycleFee(fees)` + `computePerWalletFund(fees)` flat formula. `sizeFundAndReport` queries `publicClient.getGasPrice()` and writes a new `FeeStatsFile` schema (snake_case throughout, adds `gas_price_wei` + `user_per_cycle_fee_wei` + `base_gas_budget_wei`, drops `cycles_per_wallet` + `per_cycle_wei`). |
| 5 ephemeral suite test files | Drop dead `cycleFeeCost`/`accessFeeCost`/`uploadFeeCost`/`FUND_SAFETY_MULTIPLIER` references; simplify `sizeFundAndReport` call to `{label, network, publicClient}`. |
| `.github/workflows/integration.yml` | Rewrite the `Live CDR fees + ephemeral fund sizing` table: add `baseFee (validator)` label, drop `Per-cycle`/`Cycles/wallet`, add `Gas price` (gwei), `User per-cycle fee`, `+ Base gas budget`. New jq pipeline matches snake_case schema. |

## What stays hard-coded

| Constant | Value | Why |
|---|---|---|
| `BASE_GAS_BUDGET_WEI` | 1 IP | Generous gas headroom; not chain-derived |
| `FUND_SAFETY_MULTIPLIER` | 3 | Empirical multiplier for fee bumps mid-run |

Everything else (4 fees + gas price) is queried live off the chain at suite setup.

## Verification

- `pnpm lint` on `packages/sdk` passes
- Ad-hoc `tsc --noEmit` on all 5 ephemeral suites + `_helpers.ts` passes
- YAML syntax check on `integration.yml` passes
- Schema cross-checked against the workflow's jq pipeline (all `.<snake_case>` keys present in `FeeStatsFile`)

## Test plan

- [ ] After merge, dispatch `integration-devnet-default` and confirm the new fee table renders correctly with all columns populated
- [ ] Dispatch `integration-aeneid-default` and confirm gas price column shows non-zero gwei
- [ ] Confirm per-wallet fund visibly equals `1.<X>` IP where `X` reflects 3 × sum(write+allocate+read)
