### PR TITLE
fix(ci): monitor resolves network from inputs.network, not github.event_name

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -75,11 +75,21 @@ jobs:
       - id: resolve
         name: Resolve effective inputs
         run: |
-          # workflow_call (from cdr-monitor-per-round.yml) carries the same
-          # input shape as workflow_dispatch, so the two paths are treated
-          # identically. Only pull_request falls back to the safe defaults.
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ] \
-             || [ "${{ github.event_name }}" = "workflow_call" ]; then
+          # Key off the presence of `inputs.network`, NOT `github.event_name`.
+          #
+          # In a reusable workflow `github.event_name` reflects the CALLER's
+          # top-level trigger, not "workflow_call". cdr-monitor-per-round.yml
+          # is `schedule`-triggered, so when it invokes this workflow via
+          # `workflow_call` the event_name here is "schedule" — the old
+          # `event_name == workflow_call` check never matched and silently
+          # fell through to the devnet default, running the aeneid monitor's
+          # suite against devnet (run 26495210233: monitor fired on aeneid
+          # round 12→13 but tested devnet).
+          #
+          # `inputs.network` is populated for BOTH workflow_dispatch (has a
+          # `default`) and workflow_call (`required: true`), and is empty for
+          # pull_request (no inputs). So presence is the reliable signal.
+          if [ -n "${{ inputs.network }}" ]; then
             NETWORK="${{ inputs.network }}"
             SUITE="${{ inputs.test_suite }}"
           else


### PR DESCRIPTION
## Summary

`cdr-monitor-per-round.yml` (the aeneid CDR watcher) fires on each new aeneid DKG round and invokes `integration.yml` via `workflow_call` with `network=aeneid`. But the monitor's schedule-fired runs were silently testing **devnet**, not aeneid.

## Root cause

`integration.yml`'s `prepare` step resolved `NETWORK` by checking:

```bash
if [ "${{ github.event_name }}" = "workflow_dispatch" ] \
   || [ "${{ github.event_name }}" = "workflow_call" ]; then
  NETWORK="${{ inputs.network }}"
else
  NETWORK="devnet"
fi
```

In a **reusable workflow**, `github.event_name` reflects the **caller's top-level trigger**, not `"workflow_call"`. `cdr-monitor-per-round.yml` is `schedule`-triggered, so inside the called `integration.yml` the event name is `"schedule"`. The condition never matched → fell through to `NETWORK="devnet"`.

### Observed

[Run 26495210233](https://github.com/piplabs/cdr-sdk/actions/runs/26495210233) — `cdr-monitor-aeneid`, schedule-fired, watch job correctly detected `new round detected (round 12 → 13)` on aeneid, but the `test / integration` job resolved:

```
NETWORK: devnet
CDR_API_URL: http://172.207.250.203:1317   ← devnet val2
CDR_RPC_URL: http://172.207.250.203:8545   ← devnet val2
```

So the Slack notification reported "aeneid round 13 passed" while the suite actually exercised devnet. **aeneid CDR has never been verified by the monitor since it went live on 2026-05-25.** Manual `workflow_dispatch` runs were unaffected (there `github.event_name` genuinely equals `workflow_dispatch`).

## Fix

Gate on the presence of `inputs.network` instead of the event name:

```bash
if [ -n "${{ inputs.network }}" ]; then
  NETWORK="${{ inputs.network }}"
  SUITE="${{ inputs.test_suite }}"
else
  NETWORK="devnet"
  SUITE="default"
fi
```

`inputs.network` is populated for both `workflow_dispatch` (has a `default: devnet`) and `workflow_call` (`required: true`), and is empty for `pull_request` (no inputs) — so its presence is the reliable signal regardless of the top-level event.

## Impact note

After this merges, the monitor will start hitting **aeneid for real**. aeneid is a public testnet with CDR fees at 0.03 IP, so each round-transition-fired run will consume real IP from the funder wallet `0x5B07…3a75` (previously it hit devnet, which is free). The per-run cost is one `integration-aeneid-default` suite (~13 min, ~0.45 IP).

## Test plan

- [ ] After merge, `gh workflow run cdr-monitor-per-round.yml -f force=true` and confirm the `test / integration` job resolves `NETWORK: aeneid` + `CDR_RPC_URL: https://aeneid.storyrpc.io`
- [ ] Wait for / observe the next schedule-fired run on an aeneid round transition and confirm it tests aeneid, and the Slack post reflects an aeneid result
