### PR TITLE
fix(sdk): waitForReceiptResilient survives TransactionReceiptNotFoundError

### DIFF
--- a/packages/sdk/__integration__/_rpc-resilience.ts
+++ b/packages/sdk/__integration__/_rpc-resilience.ts
@@ -134,7 +134,10 @@ export async function waitForReceiptResilient(
       await new Promise((resolve) => setTimeout(resolve, 2000));
     }
   }
-  throw lastError;
+  // The loop always runs at least once (deadlineMs is now + 5 min), so
+  // lastError is always set here — the fallback is for the type-checker and
+  // to avoid a stackless `throw undefined` if the deadline logic ever changes.
+  throw lastError ?? new Error("waitForReceiptResilient: receipt wait deadline exceeded");
 }
 
 /**

--- a/packages/sdk/__integration__/_rpc-resilience.ts
+++ b/packages/sdk/__integration__/_rpc-resilience.ts
@@ -16,7 +16,13 @@
  *                                 two known public-pool consistency bugs
  */
 
-import { http, type Hash, type PublicClient } from "viem";
+import {
+  http,
+  TransactionReceiptNotFoundError,
+  WaitForTransactionReceiptTimeoutError,
+  type Hash,
+  type PublicClient,
+} from "viem";
 
 /**
  * `http()` with retry budget tuned for public-RPC throttling.
@@ -85,14 +91,19 @@ export function pLimit(maxConcurrency: number) {
 }
 
 /**
- * `publicClient.waitForTransactionReceipt` with `timeout` widened to 5 min
- * for public-RPC endpoints whose `eth_getTransactionReceipt` can lag block
- * production by tens of seconds (viem default `timeout: 180_000` is too
- * tight for the tail — e.g. cdr-sdk run 26379164817 wallet idx=29 allocate
- * tx 0x914c3c... mined in block 0x11d2547 status=1 but viem gave up
- * first; run 26380050980 wallet idx=31 same pattern with tx 0x13cdcd...
- * in block 0x11d2980 — both failures rendered as "Transaction receipt
- * with hash X could not be found" in the workflow summary).
+ * `publicClient.waitForTransactionReceipt` hardened for public-RPC endpoints
+ * whose `eth_getTransactionReceipt` lags block production by tens of seconds.
+ *
+ * viem's `timeout` / `retryCount` do NOT cover the case where the tx is
+ * observed in a block but the receipt is momentarily null on the pool node
+ * serving that call — viem throws `TransactionReceiptNotFoundError` straight
+ * out of its block-watcher callback (e.g. cdr-sdk run 26379164817 wallet
+ * idx=29 allocate 0x914c3c... block 0x11d2547 status=1; run 26501253421
+ * uploadCDR write 0x8d1ae... block 0x11eb8d2 status=1 — both threw despite
+ * landing). So we re-poll the whole wait on that error (and on the overall
+ * timeout), bounded by a 5 min deadline. A reverted tx returns a
+ * `status: "reverted"` receipt rather than throwing, so this never masks a
+ * real revert.
  *
  * Mirrors the SDK-internal helper in `packages/sdk/src/uploader.ts`; the
  * duplication is intentional — the SDK shouldn't take a dependency on
@@ -102,12 +113,28 @@ export async function waitForReceiptResilient(
   publicClient: PublicClient,
   hash: Hash,
 ) {
-  return publicClient.waitForTransactionReceipt({
-    hash,
-    timeout: 5 * 60 * 1000,
-    pollingInterval: 2000,
-    retryCount: 30,
-  });
+  const deadlineMs = Date.now() + 5 * 60 * 1000;
+  let lastError: unknown;
+  while (Date.now() < deadlineMs) {
+    try {
+      return await publicClient.waitForTransactionReceipt({
+        hash,
+        timeout: 30_000,
+        pollingInterval: 2000,
+        retryCount: 10,
+      });
+    } catch (err) {
+      if (
+        !(err instanceof TransactionReceiptNotFoundError) &&
+        !(err instanceof WaitForTransactionReceiptTimeoutError)
+      ) {
+        throw err;
+      }
+      lastError = err;
+      await new Promise((resolve) => setTimeout(resolve, 2000));
+    }
+  }
+  throw lastError;
 }
 
 /**

--- a/packages/sdk/src/uploader.ts
+++ b/packages/sdk/src/uploader.ts
@@ -1,4 +1,4 @@
-import { parseEventLogs, toHex, toBytes, type Hash, type PublicClient, type WalletClient } from "viem";
+import { parseEventLogs, toHex, toBytes, TransactionReceiptNotFoundError, WaitForTransactionReceiptTimeoutError, type Hash, type PublicClient, type WalletClient } from "viem";
 import { cdrAbi, contractAddresses, type Network } from "@piplabs/cdr-contracts";
 import { tdh2Encrypt, encryptFile, getWasm, type TDH2Ciphertext } from "@piplabs/cdr-crypto";
 import { uuidToLabel } from "./label.js";
@@ -7,32 +7,56 @@ import type { StorageProvider } from "./storage/types.js";
 import { Observer } from "./observer.js";
 
 /**
- * Wraps `publicClient.waitForTransactionReceipt` with parameters tuned for
- * public RPC endpoints (e.g. `https://aeneid.storyrpc.io`) where receipt
- * propagation can lag block production by tens of seconds for a small tail
- * of txs. Viem's defaults (`timeout: 180_000`, `retryCount: 6`) are tuned
- * for a directly-connected node; on a public RPC the 180s overall window
- * occasionally fires on a tx that DID land on chain — the receipt just
- * hadn't surfaced yet on the pool node serving `eth_getTransactionReceipt`
- * (e.g. cdr-sdk run 26379164817, wallet idx=29: allocate tx 0x914c3c...
- * mined in block 0x11d2547 status=1 but viem gave up first, failing 1/100
- * wallets in 100w-fresh-aeneid; run 26380050980 hit the same pattern on
- * wallet idx=31 with tx 0x13cdcd... in block 0x11d2980).
+ * Wraps `publicClient.waitForTransactionReceipt` for public RPC endpoints
+ * (e.g. `https://aeneid.storyrpc.io`) where receipt propagation can lag
+ * block production by tens of seconds for a small tail of txs.
  *
- * Bumping `timeout` to 5 min covers any realistic propagation tail and
- * `retryCount: 30` widens the transient-HTTP-error tolerance; the SDK
- * still surfaces a real receipt error if the tx genuinely failed. Test
- * code has a mirror in `packages/sdk/__integration__/_rpc-resilience.ts`;
- * the duplication is intentional — the SDK shouldn't take a dependency
- * on test-only files.
+ * The key failure this guards against: viem observes the tx included in a
+ * block, immediately calls `eth_getTransactionReceipt`, and the pool node
+ * serving that call hasn't surfaced the receipt yet → viem throws
+ * `TransactionReceiptNotFoundError` out of its block-watcher callback. That
+ * throw does NOT respect the `timeout` / `retryCount` options — those cover
+ * the overall deadline and transport-level errors, not a receipt that is
+ * momentarily null after the block is seen. So bumping `timeout`/`retryCount`
+ * alone (the previous approach) still failed on this race:
+ *   - run 26379164817 wallet idx=29: allocate 0x914c3c... mined block
+ *     0x11d2547 status=1, viem gave up first (1/100 fail in 100w-fresh-aeneid)
+ *   - run 26501253421: uploadCDR write 0x8d1ae... committed block 0x11eb8d2
+ *     status=1, threw TransactionReceiptNotFoundError after ~8s, failing the
+ *     consumer feeOverride test (which itself never waits on a receipt — the
+ *     throw came from its uploadCDR preamble)
+ *
+ * Fix: re-poll the whole `waitForTransactionReceipt` on
+ * `TransactionReceiptNotFoundError` / `WaitForTransactionReceiptTimeoutError`,
+ * bounded by an overall 5 min deadline. A genuinely reverted tx returns a
+ * receipt with `status: "reverted"` (it does NOT throw), so this never masks
+ * a real revert. Test code has a mirror in
+ * `packages/sdk/__integration__/_rpc-resilience.ts`; the duplication is
+ * intentional — the SDK shouldn't take a dependency on test-only files.
  */
 async function waitForReceiptResilient(publicClient: PublicClient, hash: Hash) {
-  return publicClient.waitForTransactionReceipt({
-    hash,
-    timeout: 5 * 60 * 1000,
-    pollingInterval: 2000,
-    retryCount: 30,
-  });
+  const deadlineMs = Date.now() + 5 * 60 * 1000;
+  let lastError: unknown;
+  while (Date.now() < deadlineMs) {
+    try {
+      return await publicClient.waitForTransactionReceipt({
+        hash,
+        timeout: 30_000,
+        pollingInterval: 2000,
+        retryCount: 10,
+      });
+    } catch (err) {
+      if (
+        !(err instanceof TransactionReceiptNotFoundError) &&
+        !(err instanceof WaitForTransactionReceiptTimeoutError)
+      ) {
+        throw err;
+      }
+      lastError = err;
+      await new Promise((resolve) => setTimeout(resolve, 2000));
+    }
+  }
+  throw lastError;
 }
 
 export class Uploader {

--- a/packages/sdk/src/uploader.ts
+++ b/packages/sdk/src/uploader.ts
@@ -56,7 +56,10 @@ async function waitForReceiptResilient(publicClient: PublicClient, hash: Hash) {
       await new Promise((resolve) => setTimeout(resolve, 2000));
     }
   }
-  throw lastError;
+  // The loop always runs at least once (deadlineMs is now + 5 min), so
+  // lastError is always set here — the fallback is for the type-checker and
+  // to avoid a stackless `throw undefined` if the deadline logic ever changes.
+  throw lastError ?? new Error("waitForReceiptResilient: receipt wait deadline exceeded");
 }
 
 export class Uploader {


### PR DESCRIPTION
## Summary

Harden `waitForReceiptResilient` so a transaction that lands on-chain but whose receipt hasn't yet surfaced on the public-RPC pool node is re-polled instead of throwing.

## Root cause

The previous helper only bumped viem's `timeout` (5 min) and `retryCount` (30). Neither covers the failure mode that actually bites on `https://aeneid.storyrpc.io`:

> viem observes the tx included in a block → immediately calls `eth_getTransactionReceipt` → the pool node serving that call hasn't surfaced the receipt yet → viem throws `TransactionReceiptNotFoundError` **out of its block-watcher callback**.

That throw bypasses `timeout` (overall deadline) and `retryCount` (transport-level errors). So a tx with `status=1` still failed the wait.

### Observed ([run 26501253421](https://github.com/piplabs/cdr-sdk/actions/runs/26501253421), aeneid)

- `uploadCDR` `write()` tx `0x8d1ae…` committed in block `0x11eb8d2`, `status=1`, but threw `TransactionReceiptNotFoundError` after ~8s.
- This failed the `consumer.test.ts > read with a wrong feeOverride reverts` test — which **never waits on a receipt itself** (`read()` returns `{ txHash }`); the throw came from its `uploadCDR` preamble.
- The same race made all 200 ephemeral-wallet refund sweeps report `failedRefunds` (`totalRefundedWei: 0` on both `100w-fresh-aeneid` and `100w-shared`) — the refund waits hit the same null-receipt window.

The existing `withAeneidFlakeRetry` (in `_rpc-resilience.ts`) does catch this error, but only wraps full upload→access cycles in the `*-aeneid.test.ts` ephemeral suites — not the functional suites' `uploadCDR`, nor the refund sweeps. Fixing the receipt-wait at the lowest layer covers all of them.

## Fix

Re-poll the whole `waitForTransactionReceipt` on `TransactionReceiptNotFoundError` / `WaitForTransactionReceiptTimeoutError`, bounded by an overall 5 min deadline (inner per-attempt timeout 30s, 2s between attempts):

```ts
const deadlineMs = Date.now() + 5 * 60 * 1000;
let lastError: unknown;
while (Date.now() < deadlineMs) {
  try {
    return await publicClient.waitForTransactionReceipt({
      hash, timeout: 30_000, pollingInterval: 2000, retryCount: 10,
    });
  } catch (err) {
    if (!(err instanceof TransactionReceiptNotFoundError)
        && !(err instanceof WaitForTransactionReceiptTimeoutError)) throw err;
    lastError = err;
    await new Promise((r) => setTimeout(r, 2000));
  }
}
throw lastError;
```

A reverted tx returns a `status: "reverted"` receipt (it does **not** throw), so this never masks a real revert — the `read with a wrong feeOverride reverts` assertion (which surfaces the revert via `writeContract` gas estimation, before any receipt wait) is unaffected.

## Changed

| File | Why |
|---|---|
| `packages/sdk/src/uploader.ts` | SDK-internal `waitForReceiptResilient`, used by `allocate()` + `write()` (shipped code) |
| `packages/sdk/__integration__/_rpc-resilience.ts` | Test-side mirror, used by the ephemeral suites' Multicall3 deploy + batch-fund + sweep-refund |

(`deployOpenCondition`'s bare `waitForTransactionReceipt` in the functional suites is intentionally left alone — it runs once in `beforeAll`, was not implicated in the failure, and `_rpc-resilience.ts` is scoped to `*-aeneid.test.ts` only.)

## Test plan

- [ ] `gh workflow run integration.yml -f network=aeneid -f test_suite=default` and confirm `consumer.test.ts` / `uploader.test.ts` pass, and the ephemeral suites' refund summary shows `failedRefunds: 0` (down from 100)
- [ ] Confirm a deliberately-reverting tx (the feeOverride tests) still surfaces `/Invalid fee amount/` and is not swallowed by the re-poll loop
