### PR TITLE
fix(integration): refundWallets gasReserveWei sizes from live fee market

### DIFF
--- a/packages/sdk/__integration__/_ephemeral-wallets.ts
+++ b/packages/sdk/__integration__/_ephemeral-wallets.ts
@@ -218,22 +218,37 @@ export async function refundWallets(
   if (gasReserveWei !== undefined) {
     effectiveReserveWei = gasReserveWei;
   } else {
-    // viem's `estimateFeesPerGas()` default-returns the EIP-1559 shape on
-    // chains that support it (all Story networks do) — TypeScript types
-    // `maxFeePerGas: bigint`. Widen the static type so a future cross-chain
-    // caller running against a legacy / non-EIP-1559 chain falls back to
-    // `gasPrice` without a runtime `TypeError: Cannot mix BigInt and other
-    // types` on `bigint * undefined`. The 50 gwei final fallback is a sane
-    // default if viem ever returns neither (shouldn't happen in practice).
-    const fees = (await publicClient.estimateFeesPerGas()) as {
-      maxFeePerGas?: bigint;
-      gasPrice?: bigint;
-    };
-    const perGasWei = fees.maxFeePerGas ?? fees.gasPrice ?? 50_000_000_000n;
-    // 21000 (sweep tx gas) × maxFeePerGas × 1.5 — see header comment for the
-    // 1.5× rationale (covers viem's 1.2× baseFeeMultiplier prep padding +
-    // ~25% spike headroom).
-    effectiveReserveWei = (21_000n * perGasWei * 3n) / 2n;
+    // Wrap the fee-market probe so a transient RPC error here doesn't
+    // throw the whole refundWallets call. The contract — "always returns
+    // a RefundResult, individual sweep errors counted as failedRefunds" —
+    // pre-dated this fee probe; preserve it by falling back to a sane
+    // fixed reserve if the probe fails. 50 gwei × 21000 × 1.5 ≈ 0.00158 IP
+    // covers the viem prep-padded gas cost on networks up to ~40 gwei
+    // base+priority (well above Story chains in practice).
+    const FALLBACK_RESERVE_WEI = (21_000n * 50_000_000_000n * 3n) / 2n;
+    try {
+      // viem's `estimateFeesPerGas()` default-returns the EIP-1559 shape on
+      // chains that support it (all Story networks do) — TypeScript types
+      // `maxFeePerGas: bigint`. Widen the static type so a future cross-chain
+      // caller running against a legacy / non-EIP-1559 chain falls back to
+      // `gasPrice` without a runtime `TypeError: Cannot mix BigInt and other
+      // types` on `bigint * undefined`. The 50 gwei final fallback is a sane
+      // default if viem ever returns neither (shouldn't happen in practice).
+      const fees = (await publicClient.estimateFeesPerGas()) as {
+        maxFeePerGas?: bigint;
+        gasPrice?: bigint;
+      };
+      const perGasWei = fees.maxFeePerGas ?? fees.gasPrice ?? 50_000_000_000n;
+      // 21000 (sweep tx gas) × maxFeePerGas × 1.5 — see header comment for
+      // the 1.5× rationale (covers viem's 1.2× baseFeeMultiplier prep
+      // padding + ~25% spike headroom).
+      effectiveReserveWei = (21_000n * perGasWei * 3n) / 2n;
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      const e = err as { shortMessage?: string; message?: string };
+      console.warn(`[refundWallets] estimateFeesPerGas probe failed, using ${FALLBACK_RESERVE_WEI} wei fallback: ${e.shortMessage ?? e.message ?? String(err)}`);
+      effectiveReserveWei = FALLBACK_RESERVE_WEI;
+    }
   }
 
   const perWalletRefundWei = await Promise.all(

--- a/packages/sdk/__integration__/_ephemeral-wallets.ts
+++ b/packages/sdk/__integration__/_ephemeral-wallets.ts
@@ -28,7 +28,6 @@ import {
   type WalletClient,
   createWalletClient,
   http,
-  parseEther,
 } from "viem";
 import {
   generatePrivateKey,
@@ -168,8 +167,30 @@ export interface RefundResult {
 
 /**
  * Sweep every ephemeral wallet's remaining balance back to `recipient`,
- * minus `gasReserveWei` per wallet (covers the sweep tx's own gas).
- * Per-wallet refunds run concurrently — order-independent.
+ * minus a per-tx gas reserve. Per-wallet refunds run concurrently —
+ * order-independent.
+ *
+ * `gasReserveWei` defaults to `undefined`; in that case the reserve is
+ * computed once at entry from the live fee market:
+ *
+ *   reserve = 21000 × maxFeePerGas × 1.5
+ *
+ * `maxFeePerGas` here is `estimateFeesPerGas` — but viem's
+ * `prepareTransactionRequest` pads that by another **1.2×** (the default
+ * `baseFeeMultiplier`) when actually building the tx, so the true
+ * worst-case gas cost is `21000 × estimateFeesPerGas × 1.2`. The 1.5×
+ * multiplier covers the 1.2× prep padding (25% headroom over that) plus
+ * any fee spike between this probe and the sweep tx.
+ *
+ * The previous fixed default `parseEther("0.001")` (≈ 21000 × 50 gwei)
+ * was just under the prep-padded cost on aeneid — 21000 × 1.2 × 42.71
+ * gwei ≈ 0.00108 IP > 0.001 IP — so every sweep tx was rejected by viem
+ * with "insufficient funds for gas * price + value", surfaced as
+ * `failedRefunds: <wallet_count>` in cdr-sdk runs 26501253421 and
+ * 26561212732 on `100w-fresh-aeneid` + `100w-shared` (~200 IP stranded
+ * per run across the two suites' ephemeral wallets). On a directly-
+ * connected DevNet at 10 gwei the static default worked fine; dynamic
+ * sizing makes the helper safe across chains regardless of gas market.
  *
  * On any individual sweep failure the helper does NOT throw; it counts
  * the failure and continues. The reasoning: a single ephemeral wallet
@@ -188,18 +209,29 @@ export async function refundWallets(
   wallets: EphemeralWallet[],
   recipient: Address,
   rpcUrl: string,
-  gasReserveWei: bigint = parseEther("0.001"),
+  gasReserveWei?: bigint,
   transportFactory: (url: string) => Transport = http,
 ): Promise<RefundResult> {
   const chain = publicClient.chain as Chain;
+
+  let effectiveReserveWei: bigint;
+  if (gasReserveWei !== undefined) {
+    effectiveReserveWei = gasReserveWei;
+  } else {
+    const fees = await publicClient.estimateFeesPerGas();
+    // 21000 (sweep tx gas) × maxFeePerGas × 1.5 — see header comment for the
+    // 1.5× rationale (covers viem's 1.2× baseFeeMultiplier prep padding +
+    // ~25% spike headroom).
+    effectiveReserveWei = (21_000n * fees.maxFeePerGas * 3n) / 2n;
+  }
 
   const perWalletRefundWei = await Promise.all(
     wallets.map(async (w) => {
       try {
         const balance = await publicClient.getBalance({ address: w.address });
-        if (balance <= gasReserveWei) return 0n;
+        if (balance <= effectiveReserveWei) return 0n;
 
-        const sweepAmount = balance - gasReserveWei;
+        const sweepAmount = balance - effectiveReserveWei;
         const wc = createWalletClient({
           account: w.account,
           chain,
@@ -212,7 +244,10 @@ export async function refundWallets(
         });
         await waitForReceiptResilient(publicClient, hash);
         return sweepAmount;
-      } catch {
+      } catch (err) {
+        // eslint-disable-next-line no-console
+        const e = err as { shortMessage?: string; message?: string };
+        console.warn(`[refundWallets][${w.address}] sweep failed: ${e.shortMessage ?? e.message ?? String(err)}`);
         return -1n; // sentinel for failed sweep
       }
     }),

--- a/packages/sdk/__integration__/_ephemeral-wallets.ts
+++ b/packages/sdk/__integration__/_ephemeral-wallets.ts
@@ -218,11 +218,22 @@ export async function refundWallets(
   if (gasReserveWei !== undefined) {
     effectiveReserveWei = gasReserveWei;
   } else {
-    const fees = await publicClient.estimateFeesPerGas();
+    // viem's `estimateFeesPerGas()` default-returns the EIP-1559 shape on
+    // chains that support it (all Story networks do) — TypeScript types
+    // `maxFeePerGas: bigint`. Widen the static type so a future cross-chain
+    // caller running against a legacy / non-EIP-1559 chain falls back to
+    // `gasPrice` without a runtime `TypeError: Cannot mix BigInt and other
+    // types` on `bigint * undefined`. The 50 gwei final fallback is a sane
+    // default if viem ever returns neither (shouldn't happen in practice).
+    const fees = (await publicClient.estimateFeesPerGas()) as {
+      maxFeePerGas?: bigint;
+      gasPrice?: bigint;
+    };
+    const perGasWei = fees.maxFeePerGas ?? fees.gasPrice ?? 50_000_000_000n;
     // 21000 (sweep tx gas) × maxFeePerGas × 1.5 — see header comment for the
     // 1.5× rationale (covers viem's 1.2× baseFeeMultiplier prep padding +
     // ~25% spike headroom).
-    effectiveReserveWei = (21_000n * fees.maxFeePerGas * 3n) / 2n;
+    effectiveReserveWei = (21_000n * perGasWei * 3n) / 2n;
   }
 
   const perWalletRefundWei = await Promise.all(


### PR DESCRIPTION
## Summary

`refundWallets`' default `gasReserveWei` of `0.001 IP` was just under viem's true worst-case per-tx gas cost on aeneid. **All 100 sweep txs in two ephemeral aeneid suites silently failed** on every run (`failedRefunds: 100` × 2 → ~200 IP stranded across throwaway wallets per run; runs [26501253421](https://github.com/piplabs/cdr-sdk/actions/runs/26501253421) and [26561212732](https://github.com/piplabs/cdr-sdk/actions/runs/26561212732)).

## Root cause (reproduced locally)

viem's `prepareTransactionRequest` pads `maxFeePerGas` by another **1.2×** (the default `baseFeeMultiplier`) over what `estimateFeesPerGas` returns. So on aeneid:

| | value |
|---|---|
| `estimateFeesPerGas.maxFeePerGas` | 42.71 gwei |
| `prepareTransactionRequest.maxFeePerGas` | **51.26 gwei** (= 1.2 × 42.71) |
| 21000 × prep maxFeePerGas | **0.00108 IP** |
| previous `gasReserveWei` default | 0.001 IP |
| → outcome | viem rejects: `"insufficient funds for gas * price + value: balance 0, tx cost 1076414055339001, overshot 1076414055339001"` |

`refundWallets` catch block swallowed the error → `failedRefunds: 100`. On a directly-connected DevNet at ~10 gwei, the static 0.001 IP default was generous (~5× headroom), so this only surfaced on the chains with higher gas markets.

## Fix

When `gasReserveWei` isn't passed by the caller, compute it once at entry from the live fee market:

```ts
const fees = await publicClient.estimateFeesPerGas();
effectiveReserveWei = (21_000n * fees.maxFeePerGas * 3n) / 2n;  // × 1.5
```

The `1.5×` covers viem's `1.2×` prep padding (leaving ~25% headroom over the actual reserved budget) plus any fee spike between this probe and the sweep tx.

**Verified locally against aeneid:**

```
estimate maxFeePerGas:      42.71 gwei
dynamic reserve (× 1.5):    0.001346 IP
prep maxFeePerGas:          51.26 gwei
actual prep gas cost:       0.001076 IP
margin: +24.99%             ✅
1 IP wallet sweep residual: 0.000269 IP  (vs the 0.001 IP intent)
```

## Per-run cost comparison

| | per ephemeral run (2 suites × 100 wallets) |
|---|---|
| Before (`failedRefunds: 100`) | **~200 IP stranded** |
| After (clean sweep, dynamic reserve) | ~0.054 IP residual |

## Additional change

The previous `try { … } catch { return -1n; }` block swallowed the viem error message, making this bug invisible for two CI runs before it could be diagnosed. Added a `console.warn` with the actual error text so future refund failures surface their cause:

```ts
console.warn(`[refundWallets][${w.address}] sweep failed: ${e.shortMessage ?? e.message ?? String(err)}`);
```

## Callers

- `ephemeral-1000w-perf.test.ts`, `ephemeral-100w-fresh.test.ts`, `ephemeral-100w-shared.test.ts`, `ephemeral-100w-fresh-aeneid.test.ts` (passes `undefined`) → all use the new dynamic branch
- `ephemeral-60min-stress.test.ts` passes `REFUND_GAS_RESERVE = parseEther("1")` → explicit override, unaffected

## Test plan

- [ ] Verified locally: dynamic reserve formula > actual viem prep-time gas cost with +25% headroom on aeneid (script in commit body)
- [ ] After merge, dispatch `gh workflow run integration.yml -f network=aeneid -f test_suite=default` and confirm both `100w-fresh-aeneid` and `100w-shared` show `failedRefunds: 0` (down from 100) with non-zero `totalRefundedWei`
