### PR TITLE
fix(sdk): improve robustness ergonomics

### DIFF
--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -46,9 +46,10 @@ await initWasm();
 const account = privateKeyToAccount("0xYOUR_PRIVATE_KEY");
 const publicClient = createPublicClient({ transport: http("https://aeneid.storyrpc.io") });
 const walletClient = createWalletClient({ account, transport: http("https://aeneid.storyrpc.io") });
+const apiUrl = "http://172.192.41.96:1317"; // Story-API REST endpoint
 
 // 3. Create a CDR client
-const client = new CDRClient({ network: "testnet", publicClient, walletClient });
+const client = new CDRClient({ network: "testnet", publicClient, walletClient, apiUrl });
 
 // 4. Upload encrypted data
 const globalPubKey = await client.observer.getGlobalPubKey();
@@ -98,7 +99,11 @@ Both networks use the same pre-deployed system contract addresses:
 const publicClient = createPublicClient({
   transport: http("https://aeneid.storyrpc.io"),
 });
-const client = new CDRClient({ network: "testnet", publicClient });
+const client = new CDRClient({
+  network: "testnet",
+  publicClient,
+  apiUrl: "http://172.192.41.96:1317",
+});
 ```
 
 **Mainnet:**
@@ -107,12 +112,16 @@ const client = new CDRClient({ network: "testnet", publicClient });
 const publicClient = createPublicClient({
   transport: http("https://rpc.story.foundation"),
 });
-const client = new CDRClient({ network: "mainnet", publicClient });
+const client = new CDRClient({
+  network: "mainnet",
+  publicClient,
+  apiUrl: "https://your-mainnet-story-api.example.com",
+});
 ```
 
 **Custom RPC URL (devnets, local nodes, or third-party providers):**
 
-You can point the SDK to any Story-compatible RPC endpoint by changing the `http()` transport URL. This is useful for:
+You can point the SDK to any Story-compatible EVM RPC endpoint by changing the `http()` transport URL. `apiUrl` must point to the matching Story-API REST endpoint. This is useful for:
 
 - **Devnets / private testnets** run by your team
 - **Local development nodes** (e.g., `http://localhost:8545`)
@@ -127,10 +136,11 @@ const walletClient = createWalletClient({
   account,
   transport: http("https://your-devnet-rpc.example.com"),
 });
+const apiUrl = "https://your-devnet-story-api.example.com";
 
 // Use "testnet" or "mainnet" depending on which contract addresses your devnet uses.
 // If the devnet mirrors testnet contracts, use "testnet".
-const client = new CDRClient({ network: "testnet", publicClient, walletClient });
+const client = new CDRClient({ network: "testnet", publicClient, walletClient, apiUrl });
 ```
 
 > **Note:** The `network` parameter determines which contract addresses the SDK uses. When pointing to a custom RPC, choose the `network` value that matches the contract deployment on that chain. Both `"testnet"` and `"mainnet"` currently use the same contract addresses, but this may change in the future.
@@ -141,21 +151,22 @@ A common pattern is to configure the network via environment variables:
 
 ```typescript
 const RPC_URL = process.env.RPC_URL ?? "https://aeneid.storyrpc.io";
+const API_URL = process.env.API_URL ?? "http://172.192.41.96:1317";
 const NETWORK = (process.env.NETWORK ?? "testnet") as "testnet" | "mainnet";
 
 const publicClient = createPublicClient({ transport: http(RPC_URL) });
-const client = new CDRClient({ network: NETWORK, publicClient });
+const client = new CDRClient({ network: NETWORK, publicClient, apiUrl: API_URL });
 ```
 
 ```bash
 # Testnet (default)
-RPC_URL=https://aeneid.storyrpc.io NETWORK=testnet node app.js
+RPC_URL=https://aeneid.storyrpc.io API_URL=http://172.192.41.96:1317 NETWORK=testnet node app.js
 
 # Mainnet
-RPC_URL=https://rpc.story.foundation NETWORK=mainnet node app.js
+RPC_URL=https://rpc.story.foundation API_URL=https://your-mainnet-story-api.example.com NETWORK=mainnet node app.js
 
 # Custom devnet
-RPC_URL=http://localhost:8545 NETWORK=testnet node app.js
+RPC_URL=http://localhost:8545 API_URL=http://localhost:1317 NETWORK=testnet node app.js
 ```
 
 ---
@@ -196,8 +207,10 @@ The main entry point. Provides access to `observer`, `uploader`, and `consumer` 
 ```typescript
 const client = new CDRClient({
   network: "testnet" | "mainnet",
-  publicClient: PublicClient,     // viem public client
-  walletClient?: WalletClient,    // viem wallet client (optional, needed for write ops)
+  publicClient: CDRPublicClient,  // viem, wagmi, or custom structural public client
+  walletClient?: CDRWalletClient, // optional; required for upload/access operations
+  apiUrl: string,                 // Story-API REST endpoint
+  logger?: CDRLogger,             // optional structured logger
 });
 
 client.observer   // Always available — read-only queries
@@ -215,10 +228,10 @@ Query on-chain state without a wallet.
 | `getAllocateFee()` | `bigint` | Current vault allocation fee (wei) |
 | `getWriteFee()` | `bigint` | Current write fee (wei) |
 | `getReadFee()` | `bigint` | Current read fee (wei) |
-| `getGlobalPubKey(fromBlock?)` | `Uint8Array` | DKG global public key (with Ed25519 curve prefix) |
+| `getGlobalPubKey()` | `Uint8Array` | DKG global public key (with Ed25519 curve prefix) |
 | `getOperationalThreshold()` | `bigint` | Raw operational threshold (parts per 1000) |
-| `getParticipantCount(fromBlock?)` | `number` | Number of DKG participants in latest round |
-| `getThreshold(fromBlock?)` | `number` | Absolute threshold = ceil(participants * operationalThreshold / 1000) |
+| `getParticipantCount()` | `number` | Number of DKG participants in latest round |
+| `getThreshold()` | `number` | Active round partial-decryption threshold |
 
 ### Uploader (Write)
 
@@ -270,8 +283,7 @@ const { dataKey, txHash } = await client.consumer.accessCDR({
   accessAuxData: `0x${string}`,           // auxiliary data for condition check
   requesterPubKey: `0x${string}`,         // your uncompressed secp256k1 public key
   recipientPrivKey: Uint8Array,           // your private key bytes (for ECIES decryption)
-  globalPubKey: Uint8Array,               // from observer.getGlobalPubKey()
-  threshold: number,                      // from observer.getThreshold()
+  globalPubKey?: Uint8Array,              // optional; auto-queried if omitted
   timeoutMs?: number,                     // partial collection timeout (default: 60000)
   feeOverride?: bigint,                   // optional: override auto-queried read fee
 });
@@ -281,9 +293,9 @@ const { dataKey, txHash } = await client.consumer.accessCDR({
 
 | Method | Description |
 |--------|-------------|
-| `read({ uuid, accessAuxData, requesterPubKey })` | Submit a read request on-chain |
-| `collectPartials({ uuid, minPartials, fromBlock, timeoutMs?, pollIntervalMs? })` | Poll for partial decryption events |
-| `decryptDataKey({ ciphertext, partials, recipientPrivKey, globalPubKey, label, threshold })` | Decrypt and combine partials |
+| `read({ uuid, accessAuxData, requesterPubKey, feeOverride? })` | Submit a read request on-chain |
+| `collectPartials({ uuid, requesterPubKey, timeoutMs?, pollIntervalMs?, attestationConfig? })` | Poll Story-API for partial decryptions |
+| `decryptDataKey({ ciphertext, partials, recipientPrivKey, globalPubKey, label })` | Decrypt and combine partials |
 
 ---
 
@@ -298,7 +310,11 @@ import { createPublicClient, http } from "viem";
 import { CDRClient } from "@piplabs/cdr-sdk";
 
 const publicClient = createPublicClient({ transport: http("https://aeneid.storyrpc.io") });
-const client = new CDRClient({ network: "testnet", publicClient });
+const client = new CDRClient({
+  network: "testnet",
+  publicClient,
+  apiUrl: "http://172.192.41.96:1317",
+});
 
 const threshold = await client.observer.getOperationalThreshold();
 console.log("Operational threshold:", threshold);
@@ -327,7 +343,12 @@ await initWasm();
 const account = privateKeyToAccount("0xYOUR_PRIVATE_KEY");
 const publicClient = createPublicClient({ transport: http("https://aeneid.storyrpc.io") });
 const walletClient = createWalletClient({ account, transport: http("https://aeneid.storyrpc.io") });
-const client = new CDRClient({ network: "testnet", publicClient, walletClient });
+const client = new CDRClient({
+  network: "testnet",
+  publicClient,
+  walletClient,
+  apiUrl: "http://172.192.41.96:1317",
+});
 
 // Fetch DKG global public key
 const globalPubKey = await client.observer.getGlobalPubKey();
@@ -367,11 +388,15 @@ const PRIVATE_KEY = "0xYOUR_PRIVATE_KEY";
 const account = privateKeyToAccount(PRIVATE_KEY as `0x${string}`);
 const publicClient = createPublicClient({ transport: http("https://aeneid.storyrpc.io") });
 const walletClient = createWalletClient({ account, transport: http("https://aeneid.storyrpc.io") });
-const client = new CDRClient({ network: "testnet", publicClient, walletClient });
+const client = new CDRClient({
+  network: "testnet",
+  publicClient,
+  walletClient,
+  apiUrl: "http://172.192.41.96:1317",
+});
 
-// Get DKG parameters
+// Optionally prefetch DKG parameters
 const globalPubKey = await client.observer.getGlobalPubKey();
-const threshold = await client.observer.getThreshold();
 
 // Derive secp256k1 public key for ECIES
 const privKeyBytes = Buffer.from(PRIVATE_KEY.slice(2), "hex");
@@ -384,7 +409,6 @@ const { dataKey, txHash } = await client.consumer.accessCDR({
   requesterPubKey: requesterPubKey as `0x${string}`,
   recipientPrivKey: privKeyBytes,
   globalPubKey,
-  threshold,
 });
 
 console.log("Recovered data key:", toHex(dataKey));
@@ -401,6 +425,11 @@ The SDK throws typed errors you can catch and handle:
 | `WalletClientRequiredError` | `WALLET_CLIENT_REQUIRED` | Accessing `uploader` or `consumer` without a `walletClient` |
 | `PartialCollectionTimeoutError` | `PARTIAL_COLLECTION_TIMEOUT` | `collectPartials` or `accessCDR` times out waiting for validator responses |
 | `ContractRevertError` | `CONTRACT_REVERT` | On-chain transaction reverted |
+| `InsufficientBalanceError` | `INSUFFICIENT_BALANCE` | Wallet balance is below the read fee before `read()` submits a tx |
+| `InvalidPartialError` | `INVALID_PARTIAL` | A partial is rejected and reported through `onInvalidPartial` |
+| `InvalidHexError` | `INVALID_HEX` | Story-API hex decoding receives malformed input |
+| `AttestationQuoteError` | `ATTESTATION_QUOTE` | SGX quote bytes are too short or use an unsupported quote version |
+| `VaultAllocatedEventNotFoundError` | `VAULT_ALLOCATED_EVENT_NOT_FOUND` | Allocation receipt does not contain the expected event |
 
 All errors extend `CDRError`, which has a `code` property for programmatic handling:
 

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -48,6 +48,11 @@ See the full [repository README](https://github.com/piplabs/cdr-sdk#readme) for 
 - `Consumer` — request a vault read and combine partial decryptions
 - `Observer` — query CDR contract state and DKG round info
 - `conditions` — helpers for write/read condition contracts (`open`, `ownerOnly`, `tokenGate`, `merkle`, `custom`)
+- `CDRPublicClient` / `CDRWalletClient` — structural client interfaces accepted by `CDRClient`. Any viem version (or wagmi wrapper / custom client) that implements the subset works, so dual-viem monorepos don't need `pnpm.overrides` or `as any` casts
+- `CDRLogger`, `noopLogger` — optional structured logger passed to `new CDRClient({ logger })`. SDK emits stable events such as `registry.prefetch.ready`, `read.tx.sent`, `read.preflight.insufficient_balance`, `partial.accepted`, and `partial.dropped` with non-sensitive contexts. Amounts are logged as decimal strings. Defaults to a no-op
+- `Consumer.registryStatus` — synchronous getter (`"unbuilt" | "building" | "ready" | "failed"`) reflecting the most recent `prefetchRegistry()` call, for UIs that want to show a "preparing verifier" chip
+- Typed errors — `CDRError` is the common base, and SDK errors expose stable `code` fields. Branch on `err.code` rather than matching message text
+- `Consumer.read()` runs a balance pre-flight before submitting the fee-bearing read tx (skipped when the client surface omits `getBalance` or the wallet has no resolvable address) and throws `InsufficientBalanceError` if the wallet is short on IP
 - Re-exported from `@piplabs/cdr-crypto`: `tdh2Encrypt`, `tdh2Combine`, `verifyPartialSignature`, `encryptFile`, `decryptFile`, `initWasm`, ...
 - Re-exported from `@piplabs/cdr-contracts`: `cdrAbi`, `dkgAbi`, `contractAddresses`, `Network`, ...
 

--- a/packages/sdk/__tests__/attestation.test.ts
+++ b/packages/sdk/__tests__/attestation.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { parseSgxQuote, verifyAttestation } from "../src/attestation.js";
+import { AttestationQuoteError } from "../src/errors.js";
 
 const SGX_MIN_QUOTE_SIZE = 432;
 const MRENCLAVE_OFFSET = 112;
@@ -81,6 +82,7 @@ describe("parseSgxQuote", () => {
     expect(() => parseSgxQuote(quote)).toThrow(
       "Invalid SGX quote: 431 bytes, minimum 432 required",
     );
+    expect(() => parseSgxQuote(quote)).toThrow(AttestationQuoteError);
   });
 
   it("works for exactly 432 bytes (boundary)", () => {

--- a/packages/sdk/__tests__/consumer.test.ts
+++ b/packages/sdk/__tests__/consumer.test.ts
@@ -38,7 +38,10 @@ import {
   PartialCollectionTimeoutError,
   InvalidParamsError,
   EmptyVaultError,
+  InvalidPartialError,
+  InsufficientBalanceError,
 } from "../src/errors.js";
+import type { CDRLogger } from "../src/logger.js";
 import { toHex } from "viem";
 import type { Observer } from "../src/observer.js";
 import type { DKGPartialDecryptionSubmission } from "../src/story-api/types.js";
@@ -998,6 +1001,283 @@ describe("Consumer", () => {
       ).rejects.toThrow(EmptyVaultError);
       // Should not even poll the REST endpoint — fail fast.
       expect(queryCDRPartials).not.toHaveBeenCalled();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // registryStatus state machine (#56 2.5)
+  // -------------------------------------------------------------------------
+  describe("registryStatus", () => {
+    it("starts in 'unbuilt'", () => {
+      const { consumer } = makeConsumer();
+      expect(consumer.registryStatus).toBe("unbuilt");
+    });
+
+    it("moves to 'ready' after a successful prefetchRegistry", async () => {
+      const observer = makeFakeObserver();
+      const { consumer } = makeConsumer(observer);
+      await consumer.prefetchRegistry();
+      expect(consumer.registryStatus).toBe("ready");
+    });
+
+    it("moves to 'failed' when prefetchRegistry rejects, and back to 'building' on retry", async () => {
+      const observer = makeFakeObserver();
+      vi.mocked(observer.getRegisteredValidators)
+        .mockRejectedValueOnce(new Error("network down"))
+        .mockResolvedValueOnce(new Map());
+      const { consumer } = makeConsumer(observer);
+
+      await expect(consumer.prefetchRegistry()).rejects.toThrow("network down");
+      expect(consumer.registryStatus).toBe("failed");
+
+      // Retry: the immediate transition is 'building' (we observe it via the
+      // in-flight Promise), and the resolved state is 'ready'.
+      const retry = consumer.prefetchRegistry();
+      expect(consumer.registryStatus).toBe("building");
+      await retry;
+      expect(consumer.registryStatus).toBe("ready");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // read() balance preflight (#56 2.6)
+  // -------------------------------------------------------------------------
+  describe("read balance preflight", () => {
+    it("skips preflight when publicClient has no getBalance method", async () => {
+      const { consumer, publicClient, walletClient } = makeConsumer();
+      // Default mock has no getBalance — read should succeed.
+      publicClient.readContract.mockResolvedValueOnce(5n);
+      await consumer.read({
+        uuid: 42,
+        accessAuxData: "0x",
+        requesterPubKey: "0x04abcd" as `0x${string}`,
+      });
+      expect(walletClient.writeContract).toHaveBeenCalledOnce();
+    });
+
+    it("throws InsufficientBalanceError when balance < fee and tx is NOT sent", async () => {
+      const { consumer, publicClient, walletClient } = makeConsumer();
+      publicClient.readContract.mockResolvedValueOnce(100n); // fee = 100
+      publicClient.getBalance = vi.fn().mockResolvedValue(50n); // wallet has 50
+
+      await expect(
+        consumer.read({
+          uuid: 1,
+          accessAuxData: "0x",
+          requesterPubKey: "0x04" as `0x${string}`,
+        }),
+      ).rejects.toThrow(InsufficientBalanceError);
+
+      expect(walletClient.writeContract).not.toHaveBeenCalled();
+    });
+
+    it("passes preflight when balance >= fee and proceeds to send the tx", async () => {
+      const { consumer, publicClient, walletClient } = makeConsumer();
+      publicClient.readContract.mockResolvedValueOnce(100n);
+      publicClient.getBalance = vi.fn().mockResolvedValue(100n); // exact
+
+      const result = await consumer.read({
+        uuid: 1,
+        accessAuxData: "0x",
+        requesterPubKey: "0x04" as `0x${string}`,
+      });
+
+      expect(publicClient.getBalance).toHaveBeenCalledWith({
+        address: walletClient.account.address,
+      });
+      expect(walletClient.writeContract).toHaveBeenCalledOnce();
+      expect(result.txHash).toBe("0xtxhash");
+    });
+
+    it("propagates getBalance failures and does not send the tx", async () => {
+      const { consumer, publicClient, walletClient } = makeConsumer();
+      publicClient.readContract.mockResolvedValueOnce(100n);
+      publicClient.getBalance = vi.fn().mockRejectedValue(new Error("rpc down"));
+
+      await expect(
+        consumer.read({
+          uuid: 1,
+          accessAuxData: "0x",
+          requesterPubKey: "0x04" as `0x${string}`,
+        }),
+      ).rejects.toThrow("rpc down");
+
+      expect(walletClient.writeContract).not.toHaveBeenCalled();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Logger plumbing (#56 2.3)
+  // -------------------------------------------------------------------------
+  describe("logger", () => {
+    function makeLogger(): CDRLogger & { calls: Array<[string, string, unknown?]> } {
+      const calls: Array<[string, string, unknown?]> = [];
+      return {
+        calls,
+        debug: (msg, ctx) => { calls.push(["debug", msg, ctx]); },
+        info:  (msg, ctx) => { calls.push(["info",  msg, ctx]); },
+        warn:  (msg, ctx) => { calls.push(["warn",  msg, ctx]); },
+        error: (msg, ctx) => { calls.push(["error", msg, ctx]); },
+      };
+    }
+
+    it("emits registry.prefetch.start + ready around a successful prefetch", async () => {
+      const observer = makeFakeObserver();
+      const { publicClient, walletClient } = mockClients();
+      const logger = makeLogger();
+      const consumer = new Consumer({
+        network: "testnet",
+        publicClient,
+        walletClient,
+        observer,
+        apiUrl: API_URL,
+        logger,
+      });
+      await consumer.prefetchRegistry();
+      const events = logger.calls.map(([, msg]) => msg);
+      expect(events).toContain("registry.prefetch.start");
+      expect(events).toContain("registry.prefetch.ready");
+    });
+
+    it("emits read.tx.sent on success", async () => {
+      const observer = makeFakeObserver();
+      const { publicClient, walletClient } = mockClients();
+      publicClient.readContract.mockResolvedValueOnce(5n);
+      const logger = makeLogger();
+      const consumer = new Consumer({
+        network: "testnet",
+        publicClient,
+        walletClient,
+        observer,
+        apiUrl: API_URL,
+        logger,
+      });
+      await consumer.read({
+        uuid: 42,
+        accessAuxData: "0x",
+        requesterPubKey: "0x04" as `0x${string}`,
+      });
+      const events = logger.calls.map(([, msg]) => msg);
+      expect(events).toContain("read.tx.sent");
+      const sent = logger.calls.find(([, msg]) => msg === "read.tx.sent");
+      expect(sent?.[2]).toMatchObject({ fee: "5" });
+    });
+
+    it("emits read.preflight.insufficient_balance when balance < fee", async () => {
+      const observer = makeFakeObserver();
+      const { publicClient, walletClient } = mockClients();
+      publicClient.readContract.mockResolvedValueOnce(100n);
+      publicClient.getBalance = vi.fn().mockResolvedValue(0n);
+      const logger = makeLogger();
+      const consumer = new Consumer({
+        network: "testnet",
+        publicClient,
+        walletClient,
+        observer,
+        apiUrl: API_URL,
+        logger,
+      });
+      await expect(
+        consumer.read({
+          uuid: 1,
+          accessAuxData: "0x",
+          requesterPubKey: "0x04" as `0x${string}`,
+        }),
+      ).rejects.toThrow(InsufficientBalanceError);
+      const events = logger.calls.map(([, msg]) => msg);
+      expect(events).toContain("read.preflight.insufficient_balance");
+      const insufficient = logger.calls.find(([, msg]) => (
+        msg === "read.preflight.insufficient_balance"
+      ));
+      expect(insufficient?.[2]).toMatchObject({ balance: "0", required: "100" });
+    });
+
+    it("emits read.preflight.failed when getBalance rejects", async () => {
+      const observer = makeFakeObserver();
+      const { publicClient, walletClient } = mockClients();
+      publicClient.readContract.mockResolvedValueOnce(100n);
+      publicClient.getBalance = vi.fn().mockRejectedValue(new Error("rpc down"));
+      const logger = makeLogger();
+      const consumer = new Consumer({
+        network: "testnet",
+        publicClient,
+        walletClient,
+        observer,
+        apiUrl: API_URL,
+        logger,
+      });
+
+      await expect(
+        consumer.read({
+          uuid: 1,
+          accessAuxData: "0x",
+          requesterPubKey: "0x04" as `0x${string}`,
+        }),
+      ).rejects.toThrow("rpc down");
+
+      const events = logger.calls.map(([, msg]) => msg);
+      expect(events).toContain("read.preflight.failed");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // InvalidPartialError surfaces to onInvalidPartial (#56 2.2)
+  // -------------------------------------------------------------------------
+  describe("onInvalidPartial receives typed InvalidPartialError", () => {
+    it("reports rejected partials with .code === 'INVALID_PARTIAL'", async () => {
+      const VAULT_CIPHERTEXT = new Uint8Array([0xc1, 0xc2]);
+      const observer = makeFakeObserver({ threshold: 2 });
+      const { consumer } = makeConsumer(observer, {
+        vaultEncryptedData: toHex(VAULT_CIPHERTEXT),
+      });
+
+      // VALIDATOR_A's attestation passes; VALIDATOR_B's fails. We use a
+      // 3-of-3 group so the trust set has to filter B out before the
+      // bucket can clear threshold.
+      vi.mocked(verifyAttestation).mockImplementation(async (report: Uint8Array) => {
+        const isA = report[0] === 0xaa;
+        return { valid: isA };
+      });
+
+      vi.mocked(observer.getValidatorAttestations).mockResolvedValue(
+        new Map<string, Uint8Array>([
+          [VALIDATOR_A, new Uint8Array([0xaa])],
+          [VALIDATOR_B, new Uint8Array([0xbb])],
+          [VALIDATOR_C, new Uint8Array([0xaa])],
+        ]),
+      );
+
+      vi.mocked(queryCDRPartials).mockResolvedValueOnce([
+        makeGroup({
+          round: 4,
+          ciphertext: VAULT_CIPHERTEXT,
+          submissions: [
+            makeSubmission({ validator: VALIDATOR_A, pid: 1, ciphertext: VAULT_CIPHERTEXT }),
+            makeSubmission({ validator: VALIDATOR_B, pid: 2, ciphertext: VAULT_CIPHERTEXT }),
+            makeSubmission({ validator: VALIDATOR_C, pid: 3, ciphertext: VAULT_CIPHERTEXT }),
+          ],
+          thresholdMet: true,
+        }),
+      ]);
+
+      const reported: Error[] = [];
+      const result = await consumer.collectPartials({
+        uuid: 7,
+        requesterPubKey: "0x04ab" as `0x${string}`,
+        timeoutMs: 200,
+        pollIntervalMs: 5,
+        attestationConfig: { minSecurityVersion: 1 },
+        onInvalidPartial: (_event, err) => reported.push(err),
+      });
+
+      expect(result).toHaveLength(2);
+      expect(reported).toHaveLength(1);
+      const err = reported[0] as InvalidPartialError;
+      expect(err).toBeInstanceOf(InvalidPartialError);
+      expect(err.code).toBe("INVALID_PARTIAL");
+      expect(err.validator).toBe(VALIDATOR_B);
+      expect(err.pid).toBe(2);
+      expect(err.reason).toBe("attestation rejected");
     });
   });
 });

--- a/packages/sdk/__tests__/errors.test.ts
+++ b/packages/sdk/__tests__/errors.test.ts
@@ -11,6 +11,12 @@ import {
   InvalidConditionContractError,
   LabelMismatchError,
   ContentSizeExceededError,
+  VaultAllocatedEventNotFoundError,
+  InvalidHexError,
+  AttestationQuoteError,
+  InvalidPartialError,
+  InsufficientBalanceError,
+  EmptyVaultError,
 } from "../src/errors.js";
 
 describe("errors", () => {
@@ -133,6 +139,95 @@ describe("errors", () => {
     });
   });
 
+  describe("VaultAllocatedEventNotFoundError", () => {
+    it('has code "VAULT_ALLOCATED_EVENT_NOT_FOUND"', () => {
+      const err = new VaultAllocatedEventNotFoundError();
+      expect(err.code).toBe("VAULT_ALLOCATED_EVENT_NOT_FOUND");
+      expect(err.message).toContain("VaultAllocated event not found");
+      expect(err).toBeInstanceOf(CDRError);
+    });
+  });
+
+  describe("InvalidHexError", () => {
+    it('ODD_LENGTH carries length and code "INVALID_HEX"', () => {
+      const err = new InvalidHexError("ODD_LENGTH", { length: 13 });
+      expect(err.code).toBe("INVALID_HEX");
+      expect(err.reason).toBe("ODD_LENGTH");
+      expect(err.length).toBe(13);
+      expect(err.offset).toBeUndefined();
+      expect(err.message).toContain("odd-length");
+      expect(err.message).toContain("13");
+      expect(err).toBeInstanceOf(CDRError);
+    });
+
+    it("INVALID_CHAR carries offset", () => {
+      const err = new InvalidHexError("INVALID_CHAR", { offset: 4 });
+      expect(err.reason).toBe("INVALID_CHAR");
+      expect(err.offset).toBe(4);
+      expect(err.length).toBeUndefined();
+      expect(err.message).toContain("invalid hex character");
+      expect(err.message).toContain("4");
+    });
+  });
+
+  describe("AttestationQuoteError", () => {
+    it("TOO_SHORT carries actualLength and minLength, message preserves prior format", () => {
+      const err = new AttestationQuoteError("TOO_SHORT", {
+        actualLength: 431,
+        minLength: 432,
+      });
+      expect(err.code).toBe("ATTESTATION_QUOTE");
+      expect(err.reason).toBe("TOO_SHORT");
+      expect(err.actualLength).toBe(431);
+      expect(err.minLength).toBe(432);
+      expect(err.message).toBe(
+        "Invalid SGX quote: 431 bytes, minimum 432 required",
+      );
+      expect(err).toBeInstanceOf(CDRError);
+    });
+
+    it("UNSUPPORTED_VERSION carries version and expectedVersion", () => {
+      const err = new AttestationQuoteError("UNSUPPORTED_VERSION", {
+        version: 4,
+        expectedVersion: 3,
+      });
+      expect(err.reason).toBe("UNSUPPORTED_VERSION");
+      expect(err.version).toBe(4);
+      expect(err.expectedVersion).toBe(3);
+      expect(err.message).toContain("Unsupported SGX quote version: 4");
+      expect(err.message).toContain("expected 3");
+    });
+  });
+
+  describe("InvalidPartialError", () => {
+    it("carries validator, pid, reason and uses code INVALID_PARTIAL", () => {
+      const err = new InvalidPartialError(
+        "0x0000000000000000000000000000000000000001",
+        7,
+        "attestation rejected",
+      );
+      expect(err.code).toBe("INVALID_PARTIAL");
+      expect(err.validator).toBe("0x0000000000000000000000000000000000000001");
+      expect(err.pid).toBe(7);
+      expect(err.reason).toBe("attestation rejected");
+      expect(err.message).toContain("pid 7");
+      expect(err.message).toContain("attestation rejected");
+      expect(err).toBeInstanceOf(CDRError);
+    });
+  });
+
+  describe("InsufficientBalanceError", () => {
+    it("carries balance and required (bigint)", () => {
+      const err = new InsufficientBalanceError(10n, 100n);
+      expect(err.code).toBe("INSUFFICIENT_BALANCE");
+      expect(err.balance).toBe(10n);
+      expect(err.required).toBe(100n);
+      expect(err.message).toContain("10");
+      expect(err.message).toContain("100");
+      expect(err).toBeInstanceOf(CDRError);
+    });
+  });
+
   describe("all errors extend CDRError", () => {
     it("every error class is an instance of CDRError and Error", () => {
       const errors = [
@@ -146,6 +241,14 @@ describe("errors", () => {
         new InvalidConditionContractError("0x00", "write"),
         new LabelMismatchError("0x11", "0x22"),
         new ContentSizeExceededError(100, 50n),
+        new EmptyVaultError(42),
+        new VaultAllocatedEventNotFoundError(),
+        new InvalidHexError("ODD_LENGTH", { length: 3 }),
+        new InvalidHexError("INVALID_CHAR", { offset: 0 }),
+        new AttestationQuoteError("TOO_SHORT", { actualLength: 1, minLength: 2 }),
+        new AttestationQuoteError("UNSUPPORTED_VERSION", { version: 4, expectedVersion: 3 }),
+        new InvalidPartialError("0xabc", 1, "reason"),
+        new InsufficientBalanceError(1n, 2n),
       ];
 
       for (const err of errors) {

--- a/packages/sdk/__tests__/logger.test.ts
+++ b/packages/sdk/__tests__/logger.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from "vitest";
+import { errorMessage } from "../src/logger.js";
+
+describe("logger", () => {
+  describe("errorMessage", () => {
+    it("always returns a string for non-Error values", () => {
+      expect(errorMessage(undefined)).toBe("undefined");
+      expect(errorMessage({ code: "NOPE" })).toBe('{"code":"NOPE"}');
+    });
+  });
+});

--- a/packages/sdk/__tests__/story-api-bytes.test.ts
+++ b/packages/sdk/__tests__/story-api-bytes.test.ts
@@ -5,6 +5,7 @@ import {
   hexToBytes,
   bytesToHex,
 } from "../src/story-api/bytes.js";
+import { InvalidHexError } from "../src/errors.js";
 
 describe("story-api/bytes", () => {
   describe("base64ToBytes / bytesToBase64", () => {
@@ -85,11 +86,13 @@ describe("story-api/bytes", () => {
     it("rejects odd-length hex", () => {
       expect(() => hexToBytes("abc")).toThrow(/odd-length/);
       expect(() => hexToBytes("0xabc")).toThrow(/odd-length/);
+      expect(() => hexToBytes("abc")).toThrow(InvalidHexError);
     });
 
     it("rejects invalid hex characters", () => {
       expect(() => hexToBytes("xx")).toThrow(/invalid hex character/);
       expect(() => hexToBytes("a!")).toThrow(/invalid hex character/);
+      expect(() => hexToBytes("xx")).toThrow(InvalidHexError);
     });
 
     it("encodes empty bytes to empty string", () => {

--- a/packages/sdk/__tests__/uploader.test.ts
+++ b/packages/sdk/__tests__/uploader.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { encodeAbiParameters, keccak256, toBytes } from "viem";
 
 // Mock @piplabs/cdr-crypto before importing Uploader so the WASM loader is never executed.
@@ -9,7 +9,11 @@ vi.mock("@piplabs/cdr-crypto", () => ({
 
 import { Uploader } from "../src/uploader.js";
 import { tdh2Encrypt } from "@piplabs/cdr-crypto";
-import { ContentSizeExceededError } from "../src/errors.js";
+import {
+  ContentSizeExceededError,
+  InvalidParamsError,
+  VaultAllocatedEventNotFoundError,
+} from "../src/errors.js";
 import type { Observer } from "../src/observer.js";
 
 /**
@@ -83,6 +87,10 @@ describe("Uploader", () => {
     vi.clearAllMocks();
   });
 
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it("allocate sends tx with correct fee and returns uuid from event", async () => {
     const { publicClient, walletClient } = mockClients();
     publicClient.readContract.mockResolvedValueOnce(1000n);
@@ -140,6 +148,45 @@ describe("Uploader", () => {
     expect(callArgs.value).toBe(500n);
     expect(publicClient.readContract).not.toHaveBeenCalled();
     expect(result.uuid).toBe(7);
+  });
+
+  it("retries receipt waits for structurally named viem receipt errors", async () => {
+    vi.useFakeTimers();
+
+    const { publicClient, walletClient } = mockClients();
+    walletClient.writeContract.mockResolvedValueOnce("0xtxhash" as `0x${string}`);
+    const receiptError = new Error("receipt not found");
+    receiptError.name = "TransactionReceiptNotFoundError";
+    publicClient.waitForTransactionReceipt
+      .mockRejectedValueOnce(receiptError)
+      .mockResolvedValueOnce({
+        logs: [makeVaultAllocatedLog(43)],
+      });
+
+    const uploader = new Uploader({
+      network: "testnet",
+      publicClient,
+      walletClient,
+      observer: fakeObserver(),
+    });
+
+    const resultPromise = uploader.allocate({
+      updatable: false,
+      writeConditionAddr: "0x1111111111111111111111111111111111111111",
+      readConditionAddr: "0x2222222222222222222222222222222222222222",
+      writeConditionData: "0x",
+      readConditionData: "0x",
+      feeOverride: 0n,
+      skipConditionValidation: true,
+    });
+
+    await vi.advanceTimersByTimeAsync(2000);
+
+    await expect(resultPromise).resolves.toEqual({
+      txHash: "0xtxhash",
+      uuid: 43,
+    });
+    expect(publicClient.waitForTransactionReceipt).toHaveBeenCalledTimes(2);
   });
 
   it("write sends tx with correct fee", async () => {
@@ -212,7 +259,32 @@ describe("Uploader", () => {
         feeOverride: 0n,
         skipConditionValidation: true,
       }),
-    ).rejects.toThrow("VaultAllocated event not found in transaction logs");
+    ).rejects.toThrow(VaultAllocatedEventNotFoundError);
+  });
+
+  it("requires simulateContract for condition validation", async () => {
+    const { publicClient, walletClient } = mockClients();
+    delete publicClient.simulateContract;
+
+    const uploader = new Uploader({
+      network: "testnet",
+      publicClient,
+      walletClient,
+      observer: fakeObserver(),
+    });
+
+    await expect(
+      uploader.allocate({
+        updatable: false,
+        writeConditionAddr: "0x1111111111111111111111111111111111111111",
+        readConditionAddr: "0x2222222222222222222222222222222222222222",
+        writeConditionData: "0x",
+        readConditionData: "0x",
+        feeOverride: 0n,
+      }),
+    ).rejects.toThrow(InvalidParamsError);
+
+    expect(walletClient.writeContract).not.toHaveBeenCalled();
   });
 
   it("encryptDataKey delegates to tdh2Encrypt with correct args (explicit globalPubKey)", async () => {

--- a/packages/sdk/src/attestation.ts
+++ b/packages/sdk/src/attestation.ts
@@ -1,4 +1,5 @@
 import { toHex } from "viem";
+import { AttestationQuoteError } from "./errors.js";
 
 /** Configuration for SGX attestation verification. */
 export interface AttestationConfig {
@@ -54,7 +55,8 @@ const ISV_SVN_SIZE = 2;
  *
  * @param report - Raw SGX quote bytes (from DKG Registered event `enclaveReport`)
  * @returns Parsed fields: mrEnclave, mrSigner, securityVersion
- * @throws {Error} If the report is too short to be a valid SGX quote
+ * @throws {AttestationQuoteError} If the report is too short or has an
+ *   unsupported quote version. Inspect `.reason` to distinguish.
  *
  * @example
  * ```ts
@@ -68,9 +70,10 @@ export function parseSgxQuote(report: Uint8Array): {
   securityVersion: number;
 } {
   if (report.length < SGX_MIN_QUOTE_SIZE) {
-    throw new Error(
-      `Invalid SGX quote: ${report.length} bytes, minimum ${SGX_MIN_QUOTE_SIZE} required`,
-    );
+    throw new AttestationQuoteError("TOO_SHORT", {
+      actualLength: report.length,
+      minLength: SGX_MIN_QUOTE_SIZE,
+    });
   }
 
   // Validate quote version (bytes 0-1, little-endian). DCAP v3 = 0x0003.
@@ -78,9 +81,10 @@ export function parseSgxQuote(report: Uint8Array): {
   // produce incorrect MRENCLAVE/MRSIGNER if parsed with v3 offsets.
   const quoteVersion = report[0] | (report[1] << 8);
   if (quoteVersion !== SGX_DCAP_V3_VERSION) {
-    throw new Error(
-      `Unsupported SGX quote version: ${quoteVersion} (expected ${SGX_DCAP_V3_VERSION} for DCAP v3)`,
-    );
+    throw new AttestationQuoteError("UNSUPPORTED_VERSION", {
+      version: quoteVersion,
+      expectedVersion: SGX_DCAP_V3_VERSION,
+    });
   }
 
   const mrEnclave = toHex(report.slice(MRENCLAVE_OFFSET, MRENCLAVE_OFFSET + MRENCLAVE_SIZE));

--- a/packages/sdk/src/client-types.ts
+++ b/packages/sdk/src/client-types.ts
@@ -1,0 +1,59 @@
+/**
+ * Structural subsets of viem's `PublicClient` / `WalletClient` — only the
+ * methods + fields this SDK actually invokes.
+ *
+ * Public API surface accepts these types instead of viem's concrete clients
+ * to avoid dual-version nominal-type breakage when a consuming app and the
+ * SDK resolve to different `viem` releases under `node_modules/.pnpm/...`.
+ * Any client (viem, wagmi wrapper, custom) that satisfies the shape works.
+ *
+ * Method args/results are intentionally permissive; call sites cast results
+ * to the concrete type they expect. Optional methods are only required by
+ * the flows that call them.
+ */
+
+export interface CDRPublicClient {
+  readContract(args: unknown): Promise<unknown>;
+  waitForTransactionReceipt(args: {
+    hash: `0x${string}`;
+    timeout?: number;
+    pollingInterval?: number;
+    retryCount?: number;
+  }): Promise<{ logs: unknown[] }>;
+  simulateContract?(args: unknown): Promise<unknown>;
+  getBalance?(args: { address: `0x${string}` }): Promise<bigint>;
+}
+
+/**
+ * The wallet's `account` is shaped loosely on purpose: viem accepts either a
+ * raw address (`0x...`) or an `Account` object with `address`. We accept
+ * either form, plus `null` / `undefined` for unconnected wallets.
+ */
+export interface CDRWalletClient {
+  account?: { address: `0x${string}` } | `0x${string}` | null;
+  chain?: unknown;
+  writeContract(args: unknown): Promise<`0x${string}`>;
+}
+
+/**
+ * Extract a hex address from the loosely-typed `account` field. Returns
+ * `undefined` if the account is missing or its shape is unrecognized.
+ *
+ * Used by balance-preflight and other helpers that need the sender address
+ * before submitting a transaction.
+ */
+export function getWalletAddress(
+  account: CDRWalletClient["account"],
+): `0x${string}` | undefined {
+  if (!account) return undefined;
+  if (typeof account === "string") {
+    return account.startsWith("0x") ? (account as `0x${string}`) : undefined;
+  }
+  if (typeof account === "object" && "address" in account) {
+    const addr = account.address;
+    return typeof addr === "string" && addr.startsWith("0x")
+      ? (addr as `0x${string}`)
+      : undefined;
+  }
+  return undefined;
+}

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -1,8 +1,9 @@
-import { type PublicClient, type WalletClient } from "viem";
 import type { Network } from "@piplabs/cdr-contracts";
 import { Uploader } from "./uploader.js";
 import { Consumer } from "./consumer.js";
 import { Observer } from "./observer.js";
+import type { CDRPublicClient, CDRWalletClient } from "./client-types.js";
+import { type CDRLogger, noopLogger } from "./logger.js";
 import { WalletClientRequiredError } from "./errors.js";
 
 export class CDRClient {
@@ -12,20 +13,24 @@ export class CDRClient {
 
   constructor(params: {
     network: Network;
-    publicClient: PublicClient;
-    walletClient?: WalletClient;
+    publicClient: CDRPublicClient;
+    walletClient?: CDRWalletClient;
     /** Story-API REST base URL, e.g. `"http://node:1317"`. */
     apiUrl: string;
     /** Minimum threshold ratio override (0-1). The effective threshold is max(source threshold, ceil(participants * minThresholdRatio)). */
     minThresholdRatio?: number;
+    /** Optional structured logger; defaults to a no-op. See {@link CDRLogger}. */
+    logger?: CDRLogger;
   }) {
     const { network, publicClient, walletClient, apiUrl } = params;
+    const logger = params.logger ?? noopLogger;
 
     this.observer = new Observer({
       network,
       publicClient,
       apiUrl,
       minThresholdRatio: params.minThresholdRatio,
+      logger,
     });
 
     if (walletClient) {
@@ -34,6 +39,7 @@ export class CDRClient {
         publicClient,
         walletClient,
         observer: this.observer,
+        logger,
       });
       this._consumer = new Consumer({
         network,
@@ -41,6 +47,7 @@ export class CDRClient {
         walletClient,
         observer: this.observer,
         apiUrl,
+        logger,
       });
     } else {
       this._uploader = null;

--- a/packages/sdk/src/consumer.ts
+++ b/packages/sdk/src/consumer.ts
@@ -1,4 +1,4 @@
-import { toBytes, toHex, fromHex, type PublicClient, type WalletClient } from "viem";
+import { toBytes, toHex, fromHex } from "viem";
 import { cdrAbi, contractAddresses, type Network } from "@piplabs/cdr-contracts";
 import {
   decryptPartial as eciesDecrypt,
@@ -13,7 +13,11 @@ import {
   InvalidParamsError,
   CidIntegrityError,
   EmptyVaultError,
+  InvalidPartialError,
+  InsufficientBalanceError,
 } from "./errors.js";
+import { type CDRPublicClient, type CDRWalletClient, getWalletAddress } from "./client-types.js";
+import { type CDRLogger, noopLogger, errorMessage } from "./logger.js";
 import type { PartialDecryptionEvent } from "./types.js";
 import { uuidToLabel } from "./label.js";
 import type { StorageProvider } from "./storage/types.js";
@@ -21,6 +25,8 @@ import { Observer } from "./observer.js";
 import { verifyAttestation, type AttestationConfig } from "./attestation.js";
 import { queryCDRPartials } from "./story-api/client.js";
 import type { DKGPartialDecryptionSubmission } from "./story-api/types.js";
+
+export type RegistryStatus = "unbuilt" | "building" | "ready" | "failed";
 
 /**
  * Consumer reads encrypted vault data from the CDR contract and recovers the
@@ -53,11 +59,13 @@ import type { DKGPartialDecryptionSubmission } from "./story-api/types.js";
  * un-trusted validator's partial is reported via `onInvalidPartial`.
  */
 export class Consumer {
-  private publicClient: PublicClient;
-  private walletClient: WalletClient;
+  private publicClient: CDRPublicClient;
+  private walletClient: CDRWalletClient;
   private network: Network;
   private observer: Observer;
   private apiUrl: string;
+  private logger: CDRLogger;
+  private _registryStatus: RegistryStatus = "unbuilt";
 
   /** Alias for {@link accessCDR} */
   readVault: Consumer["accessCDR"];
@@ -66,20 +74,38 @@ export class Consumer {
 
   constructor(params: {
     network: Network;
-    publicClient: PublicClient;
-    walletClient: WalletClient;
+    publicClient: CDRPublicClient;
+    walletClient: CDRWalletClient;
     /** Observer instance — required. Provides round-keyed registrations / attestations cache. */
     observer: Observer;
     /** Story-API REST base URL, e.g. `"http://node:1317"`. */
     apiUrl: string;
+    /** Optional structured logger; defaults to a no-op. */
+    logger?: CDRLogger;
   }) {
     this.publicClient = params.publicClient;
     this.walletClient = params.walletClient;
     this.network = params.network;
     this.observer = params.observer;
     this.apiUrl = params.apiUrl;
+    this.logger = params.logger ?? noopLogger;
     this.readVault = this.accessCDR.bind(this);
     this.readFileVault = this.downloadFile.bind(this);
+  }
+
+  /**
+   * Current state of {@link prefetchRegistry}:
+   *   - `"unbuilt"`: never called.
+   *   - `"building"`: a prefetch is in flight.
+   *   - `"ready"`: the most recent prefetch resolved successfully.
+   *   - `"failed"`: the most recent prefetch rejected. Re-calling
+   *     `prefetchRegistry` moves status back to `"building"`.
+   *
+   * Useful for UIs that want to show a "preparing verifier" chip without
+   * holding on to the Promise.
+   */
+  get registryStatus(): RegistryStatus {
+    return this._registryStatus;
   }
 
   /**
@@ -99,7 +125,17 @@ export class Consumer {
    * ```
    */
   async prefetchRegistry(): Promise<void> {
-    await this.observer.getRegisteredValidators();
+    this._registryStatus = "building";
+    this.logger.debug("registry.prefetch.start");
+    try {
+      await this.observer.getRegisteredValidators();
+      this._registryStatus = "ready";
+      this.logger.debug("registry.prefetch.ready");
+    } catch (err) {
+      this._registryStatus = "failed";
+      this.logger.warn("registry.prefetch.failed", { reason: errorMessage(err) });
+      throw err;
+    }
   }
 
   /**
@@ -130,23 +166,82 @@ export class Consumer {
   }): Promise<{ txHash: `0x${string}` }> {
     const cdrAddress = contractAddresses[this.network].cdr;
 
-    const fee = params.feeOverride ?? await this.publicClient.readContract({
-      address: cdrAddress,
-      abi: cdrAbi,
-      functionName: "readFee",
-    });
+    const fee =
+      params.feeOverride ??
+      ((await this.publicClient.readContract({
+        address: cdrAddress,
+        abi: cdrAbi,
+        functionName: "readFee",
+      })) as bigint);
 
-    const txHash = await this.walletClient.writeContract({
-      chain: this.walletClient.chain ?? null,
-      account: this.walletClient.account ?? null,
-      address: cdrAddress,
-      abi: cdrAbi,
-      functionName: "read",
-      args: [params.uuid, params.accessAuxData, params.requesterPubKey],
-      value: fee,
-    });
+    // Catch the obvious insufficient-fee case before submitting the tx.
+    // Gas cost is intentionally left to the wallet/RPC because not every
+    // structural client exposes reliable gas estimation.
+    await this.preflightBalance(fee);
 
-    return { txHash };
+    try {
+      const txHash = await this.walletClient.writeContract({
+        chain: this.walletClient.chain ?? null,
+        account: this.walletClient.account ?? null,
+        address: cdrAddress,
+        abi: cdrAbi,
+        functionName: "read",
+        args: [params.uuid, params.accessAuxData, params.requesterPubKey],
+        value: fee,
+      });
+
+      this.logger.debug("read.tx.sent", {
+        uuid: params.uuid,
+        txHash,
+        fee: fee.toString(),
+      });
+      return { txHash };
+    } catch (err) {
+      this.logger.warn("read.tx.failed", {
+        uuid: params.uuid,
+        reason: errorMessage(err),
+      });
+      throw err;
+    }
+  }
+
+  /** Compare wallet balance against the read fee when the client can do so. */
+  private async preflightBalance(fee: bigint): Promise<void> {
+    const address = getWalletAddress(this.walletClient.account);
+    if (!address || !this.publicClient.getBalance) {
+      this.logger.debug("read.preflight.skipped", {
+        hasAddress: Boolean(address),
+        hasGetBalance: Boolean(this.publicClient.getBalance),
+      });
+      return;
+    }
+    this.logger.debug("read.preflight.start", {
+      address,
+      fee: fee.toString(),
+    });
+    let balance: bigint;
+    try {
+      balance = await this.publicClient.getBalance({ address });
+    } catch (err) {
+      this.logger.warn("read.preflight.failed", {
+        address,
+        reason: errorMessage(err),
+      });
+      throw err;
+    }
+    if (balance < fee) {
+      this.logger.warn("read.preflight.insufficient_balance", {
+        address,
+        balance: balance.toString(),
+        required: fee.toString(),
+      });
+      throw new InsufficientBalanceError(balance, fee);
+    }
+    this.logger.debug("read.preflight.ok", {
+      address,
+      balance: balance.toString(),
+      fee: fee.toString(),
+    });
   }
 
   /**
@@ -264,7 +359,11 @@ export class Consumer {
           uuid,
           requesterPubKeyHex,
         });
-      } catch {
+      } catch (err) {
+        this.logger.debug("partial.poll.retry", {
+          uuid,
+          reason: errorMessage(err),
+        });
         // Transient REST error — retry on next poll tick.
       }
 
@@ -299,13 +398,28 @@ export class Consumer {
               const dedupeKey = `${sub.validator}-${sub.pid}`;
               if (!reported.has(dedupeKey)) {
                 reported.add(dedupeKey);
-                onInvalidPartial?.(
-                  event,
-                  new Error(`attestation rejected for validator ${sub.validator}`),
+                const err = new InvalidPartialError(
+                  sub.validator,
+                  sub.pid,
+                  "attestation rejected",
                 );
+                this.logger.debug("partial.dropped", {
+                  validator: sub.validator,
+                  pid: sub.pid,
+                  uuid,
+                  round: group.round,
+                  reason: "attestation_rejected",
+                });
+                onInvalidPartial?.(event, err);
               }
               continue;
             }
+            this.logger.debug("partial.accepted", {
+              validator: sub.validator,
+              pid: sub.pid,
+              uuid,
+              round: group.round,
+            });
             accepted.push(event);
           }
 
@@ -321,6 +435,12 @@ export class Consumer {
       await sleep(pollIntervalMs);
     }
 
+    this.logger.warn("partial.collection.timeout", {
+      uuid,
+      seen: lastSeen,
+      needed: lastNeeded,
+      timeoutMs,
+    });
     throw new PartialCollectionTimeoutError(lastSeen, lastNeeded, timeoutMs);
   }
 

--- a/packages/sdk/src/errors.ts
+++ b/packages/sdk/src/errors.ts
@@ -101,3 +101,117 @@ export class EmptyVaultError extends CDRError {
     this.uuid = uuid;
   }
 }
+
+export class VaultAllocatedEventNotFoundError extends CDRError {
+  constructor() {
+    super(
+      "VaultAllocated event not found in transaction logs",
+      "VAULT_ALLOCATED_EVENT_NOT_FOUND",
+    );
+  }
+}
+
+/**
+ * Thrown by `hexToBytes` when the input is malformed. `reason` discriminates
+ * the failure mode so callers can branch without parsing the message:
+ *   - `"ODD_LENGTH"`: hex digit count was odd — `length` carries the count.
+ *   - `"INVALID_CHAR"`: a non-hex character was encountered — `offset` is
+ *     the position (0-based, after the optional `0x` prefix).
+ */
+export class InvalidHexError extends CDRError {
+  reason: "ODD_LENGTH" | "INVALID_CHAR";
+  length?: number;
+  offset?: number;
+  constructor(reason: "ODD_LENGTH", details: { length: number });
+  constructor(reason: "INVALID_CHAR", details: { offset: number });
+  constructor(
+    reason: "ODD_LENGTH" | "INVALID_CHAR",
+    details: { length?: number; offset?: number },
+  ) {
+    const msg =
+      reason === "ODD_LENGTH"
+        ? `hexToBytes: odd-length hex string (length ${details.length})`
+        : `hexToBytes: invalid hex character at offset ${details.offset}`;
+    super(msg, "INVALID_HEX");
+    this.reason = reason;
+    this.length = details.length;
+    this.offset = details.offset;
+  }
+}
+
+/**
+ * Thrown by `parseSgxQuote` when the report bytes can't be interpreted as
+ * an SGX DCAP v3 quote. `reason` discriminates:
+ *   - `"TOO_SHORT"`: byte length below the minimum quote size.
+ *   - `"UNSUPPORTED_VERSION"`: quote version header isn't DCAP v3.
+ */
+export class AttestationQuoteError extends CDRError {
+  reason: "TOO_SHORT" | "UNSUPPORTED_VERSION";
+  actualLength?: number;
+  minLength?: number;
+  version?: number;
+  expectedVersion?: number;
+  constructor(reason: "TOO_SHORT", details: { actualLength: number; minLength: number });
+  constructor(
+    reason: "UNSUPPORTED_VERSION",
+    details: { version: number; expectedVersion: number },
+  );
+  constructor(
+    reason: "TOO_SHORT" | "UNSUPPORTED_VERSION",
+    details: {
+      actualLength?: number;
+      minLength?: number;
+      version?: number;
+      expectedVersion?: number;
+    },
+  ) {
+    const msg =
+      reason === "TOO_SHORT"
+        ? `Invalid SGX quote: ${details.actualLength} bytes, minimum ${details.minLength} required`
+        : `Unsupported SGX quote version: ${details.version} (expected ${details.expectedVersion} for DCAP v3)`;
+    super(msg, "ATTESTATION_QUOTE");
+    this.reason = reason;
+    this.actualLength = details.actualLength;
+    this.minLength = details.minLength;
+    this.version = details.version;
+    this.expectedVersion = details.expectedVersion;
+  }
+}
+
+/**
+ * Surfaced to the `onInvalidPartial` callback when a validator's partial is
+ * rejected by an attestation-based trust set or other per-partial check.
+ * Callers can branch on `.reason` instead of pattern-matching the message.
+ */
+export class InvalidPartialError extends CDRError {
+  validator: string;
+  pid: number;
+  reason: string;
+  constructor(validator: string, pid: number, reason: string) {
+    super(
+      `Partial rejected for validator ${validator} (pid ${pid}): ${reason}`,
+      "INVALID_PARTIAL",
+    );
+    this.validator = validator;
+    this.pid = pid;
+    this.reason = reason;
+  }
+}
+
+/**
+ * Thrown by `Consumer.read()`'s preflight when the wallet's IP balance is
+ * below the configured fee. Raised before the fee-bearing `read` tx is
+ * submitted, so no gas is wasted on a tx that would revert on-chain.
+ */
+export class InsufficientBalanceError extends CDRError {
+  balance: bigint;
+  required: bigint;
+  constructor(balance: bigint, required: bigint) {
+    super(
+      `Insufficient balance for read fee: have ${balance}, need ${required}`,
+      "INSUFFICIENT_BALANCE",
+    );
+    this.balance = balance;
+    this.required = required;
+  }
+}

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -1,4 +1,6 @@
 export * from "./client.js";
+export * from "./client-types.js";
+export * from "./logger.js";
 export * from "./uploader.js";
 export * from "./consumer.js";
 export * from "./observer.js";

--- a/packages/sdk/src/logger.ts
+++ b/packages/sdk/src/logger.ts
@@ -1,0 +1,35 @@
+/**
+ * Optional logger surface for the SDK. Pass a `CDRLogger` into `CDRClient`
+ * to observe structured events (`registry.prefetch.start`,
+ * `partial.accepted`, `read.preflight.insufficient_balance`, etc.).
+ *
+ * Defaults to {@link noopLogger} — zero behavior change for callers that
+ * don't supply one. The SDK never logs sensitive material (private keys,
+ * decrypted bytes, data keys, file contents); contexts carry only
+ * identifiers, counts, reasons, and decimal-string amounts.
+ */
+export interface CDRLogger {
+  debug(message: string, ctx?: Record<string, unknown>): void;
+  info(message: string, ctx?: Record<string, unknown>): void;
+  warn(message: string, ctx?: Record<string, unknown>): void;
+  error(message: string, ctx?: Record<string, unknown>): void;
+}
+
+export const noopLogger: CDRLogger = {
+  debug() {},
+  info() {},
+  warn() {},
+  error() {},
+};
+
+/** Stable error-message extractor — used for `{ reason }` log fields without leaking stack frames. */
+export function errorMessage(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  if (typeof err === "string") return err;
+  try {
+    const json = JSON.stringify(err);
+    return json ?? String(err);
+  } catch {
+    return String(err);
+  }
+}

--- a/packages/sdk/src/observer.ts
+++ b/packages/sdk/src/observer.ts
@@ -1,8 +1,9 @@
-import { type PublicClient } from "viem";
 import { cdrAbi, dkgAbi, contractAddresses, type Network } from "@piplabs/cdr-contracts";
 import { CURVE_ED25519 } from "@piplabs/cdr-crypto";
 import type { Vault } from "./types.js";
 import { InvalidParamsError } from "./errors.js";
+import type { CDRPublicClient } from "./client-types.js";
+import { type CDRLogger, noopLogger, errorMessage } from "./logger.js";
 import {
   queryLatestActiveDKGNetwork,
   queryDKGNetwork,
@@ -45,10 +46,11 @@ const STATUS_FINALIZED = 2;
  *   single round-trip.
  */
 export class Observer {
-  private publicClient: PublicClient;
+  private publicClient: CDRPublicClient;
   private network: Network;
   private apiUrl: string;
   private minThresholdRatio?: number;
+  private logger: CDRLogger;
 
   /** Per-round network snapshot cache (Promise-valued for in-flight dedup). */
   private networkSnapshots = new Map<number, Promise<DKGNetwork>>();
@@ -64,7 +66,7 @@ export class Observer {
 
   constructor(params: {
     network: Network;
-    publicClient: PublicClient;
+    publicClient: CDRPublicClient;
     /** Story-API REST base URL, e.g. `"http://node:1317"`. */
     apiUrl: string;
     /**
@@ -74,6 +76,8 @@ export class Observer {
      * make `collectPartials` time out forever, so they are rejected.
      */
     minThresholdRatio?: number;
+    /** Optional structured logger; defaults to a no-op. */
+    logger?: CDRLogger;
   }) {
     if (params.minThresholdRatio !== undefined) {
       const r = params.minThresholdRatio;
@@ -87,6 +91,7 @@ export class Observer {
     this.network = params.network;
     this.apiUrl = params.apiUrl;
     this.minThresholdRatio = params.minThresholdRatio;
+    this.logger = params.logger ?? noopLogger;
   }
 
   // =========================================================================
@@ -102,40 +107,40 @@ export class Observer {
    * ```
    */
   async getVault(uuid: number): Promise<Vault> {
-    const result = await this.publicClient.readContract({
+    const result = (await this.publicClient.readContract({
       address: contractAddresses[this.network].cdr,
       abi: cdrAbi,
       functionName: "vaults",
       args: [uuid],
-    });
+    })) as Record<string, unknown>;
     return { uuid, ...result } as unknown as Vault;
   }
 
   /** Get current allocation fee. */
   async getAllocateFee(): Promise<bigint> {
-    return this.publicClient.readContract({
+    return (await this.publicClient.readContract({
       address: contractAddresses[this.network].cdr,
       abi: cdrAbi,
       functionName: "allocateFee",
-    });
+    })) as bigint;
   }
 
   /** Get current write fee. */
   async getWriteFee(): Promise<bigint> {
-    return this.publicClient.readContract({
+    return (await this.publicClient.readContract({
       address: contractAddresses[this.network].cdr,
       abi: cdrAbi,
       functionName: "writeFee",
-    });
+    })) as bigint;
   }
 
   /** Get current read fee. */
   async getReadFee(): Promise<bigint> {
-    return this.publicClient.readContract({
+    return (await this.publicClient.readContract({
       address: contractAddresses[this.network].cdr,
       abi: cdrAbi,
       functionName: "readFee",
-    });
+    })) as bigint;
   }
 
   /**
@@ -151,6 +156,7 @@ export class Observer {
           abi: cdrAbi,
           functionName: "maxEncryptedDataSize",
         })
+        .then((v) => v as bigint)
         .catch((e) => {
           this.maxEncryptedDataSizePromise = null;
           throw e;
@@ -161,11 +167,11 @@ export class Observer {
 
   /** Get DKG operational threshold (basis-points constant from the DKG contract). */
   async getOperationalThreshold(): Promise<bigint> {
-    return this.publicClient.readContract({
+    return (await this.publicClient.readContract({
       address: contractAddresses[this.network].dkg,
       abi: dkgAbi,
       functionName: "operationalThreshold",
-    });
+    })) as bigint;
   }
 
   // =========================================================================
@@ -334,16 +340,23 @@ export class Observer {
     if (cached) return cached;
 
     const networkPromise = this.loadNetwork(round);
+    this.logger.debug("registry.load.start", { round });
     const regsPromise = queryAllRegistrations({ apiUrl: this.apiUrl, round });
 
     const promise = regsPromise.then(
-      (allRegs) =>
-        new Map<string, DKGRegistration>(
+      (allRegs) => {
+        const finalized = new Map<string, DKGRegistration>(
           allRegs
             .filter((r) => r.status === STATUS_FINALIZED)
             .map((r) => [r.validatorAddr.toLowerCase(), r]),
-        ),
-    );
+        );
+        this.logger.debug("registry.load.ready", { round, count: finalized.size });
+        return finalized;
+      },
+    ).catch((err) => {
+      this.logger.warn("registry.load.failed", { round, reason: errorMessage(err) });
+      throw err;
+    });
 
     this.registrationSnapshots.set(round, promise);
 

--- a/packages/sdk/src/story-api/bytes.ts
+++ b/packages/sdk/src/story-api/bytes.ts
@@ -3,6 +3,8 @@
  * Web APIs only (no Node `Buffer`) for browser compatibility.
  */
 
+import { InvalidHexError } from "../errors.js";
+
 export function base64ToBytes(b64: string): Uint8Array {
   const binary = atob(b64);
   const bytes = new Uint8Array(binary.length);
@@ -19,13 +21,13 @@ export function bytesToBase64(bytes: Uint8Array): string {
 export function hexToBytes(hex: string): Uint8Array {
   const clean = hex.startsWith("0x") || hex.startsWith("0X") ? hex.slice(2) : hex;
   if (clean.length % 2 !== 0) {
-    throw new Error(`hexToBytes: odd-length hex string (length ${clean.length})`);
+    throw new InvalidHexError("ODD_LENGTH", { length: clean.length });
   }
   const out = new Uint8Array(clean.length / 2);
   for (let i = 0; i < out.length; i++) {
     const pair = clean.slice(i * 2, i * 2 + 2);
     if (!/^[0-9a-fA-F]{2}$/.test(pair)) {
-      throw new Error(`hexToBytes: invalid hex character at offset ${i * 2}`);
+      throw new InvalidHexError("INVALID_CHAR", { offset: i * 2 });
     }
     out[i] = parseInt(pair, 16);
   }

--- a/packages/sdk/src/uploader.ts
+++ b/packages/sdk/src/uploader.ts
@@ -1,10 +1,18 @@
-import { parseEventLogs, toHex, toBytes, TransactionReceiptNotFoundError, WaitForTransactionReceiptTimeoutError, type Hash, type PublicClient, type WalletClient } from "viem";
+import { parseEventLogs, toHex, toBytes, TransactionReceiptNotFoundError, WaitForTransactionReceiptTimeoutError, type Log } from "viem";
 import { cdrAbi, contractAddresses, type Network } from "@piplabs/cdr-contracts";
 import { tdh2Encrypt, encryptFile, getWasm, type TDH2Ciphertext } from "@piplabs/cdr-crypto";
 import { uuidToLabel } from "./label.js";
-import { ContentSizeExceededError, LabelMismatchError, InvalidConditionContractError } from "./errors.js";
+import {
+  ContentSizeExceededError,
+  LabelMismatchError,
+  InvalidConditionContractError,
+  InvalidParamsError,
+  VaultAllocatedEventNotFoundError,
+} from "./errors.js";
 import type { StorageProvider } from "./storage/types.js";
 import { Observer } from "./observer.js";
+import type { CDRPublicClient, CDRWalletClient } from "./client-types.js";
+import { type CDRLogger, noopLogger } from "./logger.js";
 
 /**
  * Wraps `publicClient.waitForTransactionReceipt` for public RPC endpoints
@@ -34,7 +42,7 @@ import { Observer } from "./observer.js";
  * `packages/sdk/__integration__/_rpc-resilience.ts`; the duplication is
  * intentional — the SDK shouldn't take a dependency on test-only files.
  */
-async function waitForReceiptResilient(publicClient: PublicClient, hash: Hash) {
+async function waitForReceiptResilient(publicClient: CDRPublicClient, hash: `0x${string}`) {
   const deadlineMs = Date.now() + 5 * 60 * 1000;
   let lastError: unknown;
   while (Date.now() < deadlineMs) {
@@ -46,10 +54,7 @@ async function waitForReceiptResilient(publicClient: PublicClient, hash: Hash) {
         retryCount: 10,
       });
     } catch (err) {
-      if (
-        !(err instanceof TransactionReceiptNotFoundError) &&
-        !(err instanceof WaitForTransactionReceiptTimeoutError)
-      ) {
+      if (!isRetryableReceiptWaitError(err)) {
         throw err;
       }
       lastError = err;
@@ -62,11 +67,29 @@ async function waitForReceiptResilient(publicClient: PublicClient, hash: Hash) {
   throw lastError ?? new Error("waitForReceiptResilient: receipt wait deadline exceeded");
 }
 
+function isRetryableReceiptWaitError(err: unknown): boolean {
+  if (
+    err instanceof TransactionReceiptNotFoundError ||
+    err instanceof WaitForTransactionReceiptTimeoutError
+  ) {
+    return true;
+  }
+  const name =
+    err && typeof err === "object" && "name" in err
+      ? (err as { name?: unknown }).name
+      : undefined;
+  return (
+    name === "TransactionReceiptNotFoundError" ||
+    name === "WaitForTransactionReceiptTimeoutError"
+  );
+}
+
 export class Uploader {
-  private publicClient: PublicClient;
-  private walletClient: WalletClient;
+  private publicClient: CDRPublicClient;
+  private walletClient: CDRWalletClient;
   private network: Network;
   private observer: Observer;
+  private logger: CDRLogger;
 
   /** Alias for {@link uploadCDR} */
   createVault: Uploader["uploadCDR"];
@@ -75,15 +98,18 @@ export class Uploader {
 
   constructor(params: {
     network: Network;
-    publicClient: PublicClient;
-    walletClient: WalletClient;
+    publicClient: CDRPublicClient;
+    walletClient: CDRWalletClient;
     /** Observer instance — required. Used by `write` to look up `maxEncryptedDataSize` (cached for the Observer's lifetime). */
     observer: Observer;
+    /** Optional structured logger; defaults to a no-op. */
+    logger?: CDRLogger;
   }) {
     this.publicClient = params.publicClient;
     this.walletClient = params.walletClient;
     this.network = params.network;
     this.observer = params.observer;
+    this.logger = params.logger ?? noopLogger;
     this.createVault = this.uploadCDR.bind(this);
     this.createFileVault = this.uploadFile.bind(this);
   }
@@ -156,11 +182,13 @@ export class Uploader {
 
     const cdrAddress = contractAddresses[this.network].cdr;
 
-    const fee = params.feeOverride ?? await this.publicClient.readContract({
-      address: cdrAddress,
-      abi: cdrAbi,
-      functionName: "allocateFee",
-    });
+    const fee =
+      params.feeOverride ??
+      ((await this.publicClient.readContract({
+        address: cdrAddress,
+        abi: cdrAbi,
+        functionName: "allocateFee",
+      })) as bigint);
 
     const txHash = await this.walletClient.writeContract({
       chain: this.walletClient.chain ?? null,
@@ -181,6 +209,7 @@ export class Uploader {
     const receipt = await waitForReceiptResilient(this.publicClient, txHash);
     const uuid = this.parseVaultAllocatedUuid(receipt.logs);
 
+    this.logger.debug("allocate.tx.mined", { txHash, uuid });
     return { txHash, uuid };
   }
 
@@ -238,11 +267,13 @@ export class Uploader {
 
     const cdrAddress = contractAddresses[this.network].cdr;
 
-    const fee = params.feeOverride ?? await this.publicClient.readContract({
-      address: cdrAddress,
-      abi: cdrAbi,
-      functionName: "writeFee",
-    });
+    const fee =
+      params.feeOverride ??
+      ((await this.publicClient.readContract({
+        address: cdrAddress,
+        abi: cdrAbi,
+        functionName: "writeFee",
+      })) as bigint);
 
     const txHash = await this.walletClient.writeContract({
       chain: this.walletClient.chain ?? null,
@@ -256,6 +287,7 @@ export class Uploader {
 
     await waitForReceiptResilient(this.publicClient, txHash);
 
+    this.logger.debug("write.tx.mined", { uuid: params.uuid, txHash });
     return { txHash };
   }
 
@@ -433,6 +465,12 @@ export class Uploader {
       stateMutability: "view" as const,
     }];
 
+    if (!this.publicClient.simulateContract) {
+      throw new InvalidParamsError(
+        "publicClient.simulateContract is required for condition validation",
+      );
+    }
+
     try {
       await this.publicClient.simulateContract({
         address,
@@ -454,14 +492,14 @@ export class Uploader {
     }
   }
 
-  private parseVaultAllocatedUuid(logs: any[]): number {
+  private parseVaultAllocatedUuid(logs: unknown[]): number {
     const parsed = parseEventLogs({
       abi: cdrAbi,
-      logs,
+      logs: logs as Log[],
       eventName: "VaultAllocated",
     });
     if (parsed.length === 0) {
-      throw new Error("VaultAllocated event not found in transaction logs");
+      throw new VaultAllocatedEventNotFoundError();
     }
     return parsed[0].args.uuid;
   }


### PR DESCRIPTION
Fixes #56.

## Summary
This PR addresses issue #56 as a robustness and SDK ergonomics pass. The implementation is organized around the six subissues from #56 so reviewers can verify each concern directly.

## Issue #56 Subissue Map

### 2.1 WASM warning on normal init paths
- Audited the current crypto loader and SDK call sites. The exact warning from the issue, `Could not inject WASM into cdr-crypto loader`, is no longer present on current `main`.
- WASM-required TDH2 paths already fail with `WasmNotInitializedError` when WASM has not been initialized.
- No source change was needed in this PR for 2.1; this subissue is treated as no longer applicable on the current codebase.

### 2.2 Typed error hierarchy
- Added typed SDK errors with stable `code` fields for the applicable caller-visible raw-error paths:
  - `VaultAllocatedEventNotFoundError`
  - `InvalidHexError`
  - `AttestationQuoteError`
  - `InvalidPartialError`
  - `InsufficientBalanceError`
- Replaced raw/stringly errors in SGX quote parsing, Story-API hex decoding, allocation receipt parsing, attestation-rejected partial callbacks, and read-fee balance preflight.
- Added regression coverage in `errors.test.ts`, `attestation.test.ts`, `story-api-bytes.test.ts`, `consumer.test.ts`, and `uploader.test.ts`.
- The older observer/cosmos raw-error examples cited in #56 are not present in the current SDK source on this branch.

### 2.3 Logger / telemetry hook
- Added the public `CDRLogger` interface and `noopLogger` default.
- Added optional `logger` support to `CDRClient`, with plumbing through `Observer`, `Uploader`, and `Consumer`.
- Added structured events for registry loading/prefetching, read tx submission/failure, read balance preflight, partial polling retries, partial acceptance/drop, collection timeout, and upload/write receipt completion.
- Log contexts avoid sensitive values and stringify bigint amounts.
- Hardened `errorMessage()` so logger reason fields always receive a string.

### 2.4 Structural viem client typing
- Added `CDRPublicClient` and `CDRWalletClient` structural interfaces and exported them from the SDK.
- Changed `CDRClient`, `Observer`, `Uploader`, and `Consumer` to depend on these structural subsets instead of full nominal viem client types.
- Added `getWalletAddress()` for wallet-account shapes used by balance preflight.
- Adapted the rebased `waitForReceiptResilient` uploader helper to the structural client surface.
- Hardened retryable receipt-error detection to work across duplicate viem installs by accepting both same-package `instanceof` errors and structurally named viem errors.

### 2.5 `prefetchRegistry()` queryable status
- Added `RegistryStatus = "unbuilt" | "building" | "ready" | "failed"`.
- Added `consumer.registryStatus` as a synchronous getter.
- Updated `prefetchRegistry()` to transition through `building`, `ready`, and `failed`, with logger events for each outcome.
- Added tests for the status state machine and retry behavior after a failed prefetch.

### 2.6 `readFee` balance preflight
- Added `Consumer.read()` balance preflight after resolving `readFee` and before sending the fee-bearing tx.
- When `publicClient.getBalance` and a wallet address are available, the SDK now checks `balance >= readFee` and throws `InsufficientBalanceError` before submitting an impossible tx.
- The preflight skips cleanly for custom structural clients without `getBalance` or without a resolvable wallet address.
- Balance-check failures are logged and propagated; insufficient balance prevents `writeContract` from being called.
- Added tests for skipped preflight, success, insufficient balance, and `getBalance` failure.

## Additional cleanup
- Updated SDK README and user guide to document the new structural client types, logger hook, registry status, typed errors, and read preflight.
- Removed stale user-guide references to old consumer parameters such as `threshold`, `fromBlock`, and `minPartials`.
- Added regression coverage for duplicate-viem receipt retry behavior.