### PR TITLE
fix(cdr-monitor): reword success headline to 'round N activated'

### DIFF
--- a/.github/workflows/cdr-monitor-per-round.yml
+++ b/.github/workflows/cdr-monitor-per-round.yml
@@ -291,7 +291,7 @@ jobs:
             # control the headline trigger line; CONCLUSION drives the
             # emoji + status word.
             case "$TEST_RESULT" in
-              success)   emoji="✅"; status="passed"    ;;
+              success)   emoji="✅"; status="activated" ;;
               failure)   emoji="❌"; status="FAILED"    ;;
               cancelled) emoji="⚠️"; status="cancelled" ;;
               *)         emoji="❓"; status="$TEST_RESULT" ;;


### PR DESCRIPTION
## What

The aeneid CDR monitor Slack success headline currently reads:

```
✅ CDR monitor (aeneid) — round 14 passed
```

Reword the success-case status word from `passed` to `activated`:

```
✅ CDR monitor (aeneid) — round 14 activated
```

## Why

"round N passed" conflates two distinct things: the DKG round becoming **active** (the watcher trigger) and the integration **test outcome**. The headline describes the trigger, so "activated" is the accurate word. The actual pass/fail result is already carried by the `• *Test outcome*: *success*` body line, which is unchanged.

## Scope

- Single-line change in `.github/workflows/cdr-monitor-per-round.yml` (success branch only).
- Failure (`❌ FAILED`), cancelled (`⚠️ cancelled`), chain-reset (`🔄`), and watcher-fault (`🚨`) variants are untouched.