### PR TITLE
feat(monitor): CDR partial-decryption threshold-shortfall monitor

### DIFF
--- a/.github/workflows/cdr-monitor-per-round.yml
+++ b/.github/workflows/cdr-monitor-per-round.yml
@@ -100,17 +100,19 @@ jobs:
 
       - name: Query aeneid /dkg/latest_active
         id: query
-        # Story-API is HTTP-only (same host integration.yml's CDR_API_URL
-        # uses on aeneid). The strict regex validation below limits the
-        # blast radius of a hostile / corrupted response: any value that
-        # doesn't match the expected shape exits the step instead of
+        # Story-API base URL is read from the CDR_API_URL secret (passed via
+        # env, not interpolated inline). The strict regex validation below
+        # limits the blast radius of a hostile / corrupted response: any value
+        # that doesn't match the expected shape exits the step instead of
         # flowing into downstream shells. Combined with the env-var
         # pass-through in later steps this closes the
         # `${{ steps.x.outputs.y }}` → bash injection vector flagged on
         # PR #111.
+        env:
+          CDR_API_URL: ${{ secrets.CDR_API_URL }}
         run: |
           set -euo pipefail
-          API=http://172.192.41.96:1317
+          API="$CDR_API_URL"
           resp=$(curl -fsS --max-time 10 "$API/dkg/latest_active")
           echo "$resp" | jq '.msg.network | {round, total, threshold, stage, start_block_height, gpk: (.global_public_key[:20])}'
           round=$(echo "$resp" | jq -r '.msg.network.round')

--- a/.github/workflows/cdr-threshold-monitor.yml
+++ b/.github/workflows/cdr-threshold-monitor.yml
@@ -1,0 +1,100 @@
+name: CDR threshold-shortfall monitor (aeneid)
+
+run-name: cdr-threshold-monitor-aeneid
+
+# Cron-fired watcher that alerts when a CDR decrypt request expires without
+# reaching its partial-decryption threshold. Reads the chain only through
+# public interfaces (EVM JSON-RPC + Story-API REST) — no node-side code.
+#
+#   schedule (*/5 min) ─→ [monitor]
+#   workflow_dispatch ──┘     │
+#                             ├─ restore read_requests.json from actions/cache
+#                             ├─ run @piplabs/cdr-monitor:
+#                             │    1. sweep expired requests → query
+#                             │       /dkg/cdr_partials; threshold met → drop,
+#                             │       below threshold → collect
+#                             │    2. ingest new VaultRead logs (eth_getLogs)
+#                             │    3. post ONE batched Slack message, drop the
+#                             │       alerted requests so the next tick doesn't
+#                             │       repeat them
+#                             └─ save read_requests.json back to cache
+#
+# State: ./read_requests.json = {lastScannedBlock, requests[]}. Carried across
+# runs via actions/cache under its own key prefix (distinct from the
+# per-round monitor's `cdr-monitor-aeneid-state-`).
+#
+# Secrets (none hardcoded — endpoints are not exposed in this file):
+#   CDR_API_URL            Story-API REST base URL (required)
+#   CDR_RPC_URL            EVM JSON-RPC URL (optional; falls back to the public
+#                          aeneid RPC when unset)
+#   CDR_SLACK_WEBHOOK_URL  incoming webhook for the CDR channel; consulted only
+#                          when a shortfall is found
+# Set them with `gh secret set <NAME>`. Secret values are masked in logs.
+
+on:
+  schedule:
+    # Every 5 min. Decrypt timeout is 200 blocks (~7-10 min at Story block
+    # times), so a shortfall is alerted within ~one tick of the deadline.
+    - cron: '*/5 * * * *'
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+concurrency:
+  # Serialize runs so two cron firings can't both advance lastScannedBlock and
+  # race on the cached state file.
+  group: cdr-threshold-monitor-aeneid
+  cancel-in-progress: false
+
+jobs:
+  monitor:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      CDR_NETWORK: aeneid
+      # Endpoints come from secrets so the internal Story-API host is not
+      # exposed in the repo. CDR_RPC_URL is optional (public aeneid RPC default).
+      CDR_API_URL: ${{ secrets.CDR_API_URL }}
+      CDR_RPC_URL: ${{ secrets.CDR_RPC_URL }}
+      CDR_SLACK_WEBHOOK_URL: ${{ secrets.CDR_SLACK_WEBHOOK_URL }}
+      READ_REQUESTS_PATH: ./read_requests.json
+      RUN_URL: ${{ format('{0}/{1}/actions/runs/{2}', github.server_url, github.repository, github.run_id) }}
+    steps:
+      - uses: actions/checkout@v4
+
+      # State file shared across runs via actions/cache (run-unique save key,
+      # shared restore-keys prefix — most recent entry wins on restore).
+      - name: Restore read_requests.json from cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ./read_requests.json
+          key: cdr-threshold-read-requests-${{ github.run_id }}
+          restore-keys: |
+            cdr-threshold-read-requests-
+
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: pnpm
+      - run: pnpm install
+      - run: pnpm build
+
+      - name: Verify required secrets are set
+        run: |
+          if [ -z "$CDR_API_URL" ]; then
+            echo "::error::CDR_API_URL is empty (set the repo secret: gh secret set CDR_API_URL)"
+            exit 1
+          fi
+
+      - name: Run threshold monitor
+        run: pnpm --filter @piplabs/cdr-monitor partials-threshold
+
+      - name: Save read_requests.json to cache
+        # Always save: lastScannedBlock advances almost every run.
+        if: always()
+        uses: actions/cache/save@v4
+        with:
+          path: ./read_requests.json
+          key: cdr-threshold-read-requests-${{ github.run_id }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules/
 dist/
+coverage/
 .turbo/
 *.tsbuildinfo
 .env*
@@ -7,3 +8,6 @@ dist/
 .DS_Store
 docs/superpowers
 package-lock.json
+
+# cdr-monitor runtime state (carried via actions/cache in CI)
+read_requests.json

--- a/apps/monitor/README.md
+++ b/apps/monitor/README.md
@@ -1,0 +1,72 @@
+# @piplabs/cdr-monitor
+
+Off-chain CDR monitors. Each monitor lives in its own `src/<name>/` directory so
+more can be added without entangling them.
+
+| Monitor | Directory | Run |
+|---------|-----------|-----|
+| Partial-decryption threshold shortfall | `src/partials-threshold/` | `pnpm --filter @piplabs/cdr-monitor partials-threshold` |
+
+---
+
+## partials-threshold
+
+Off-chain watcher that alerts when a CDR (threshold-decryption) request expires
+without collecting enough partial decryptions to meet its round threshold.
+
+It does **not** touch the chain: it reads the same data the on-chain keeper does,
+purely through public interfaces.
+
+### How it works
+
+Run on a cron (every 5 min). Each tick:
+
+1. **Sweep** — for every request in `read_requests.json` whose deadline has
+   passed (`head > block + DECRYPT_TIMEOUT_BLOCKS`), query Story-API
+   `/dkg/cdr_partials`:
+   - threshold met → drop it, no alert;
+   - threshold **not** met → collect for a batched alert, then drop it (so the
+     next tick does not re-alert).
+2. **Ingest** — `eth_getLogs` for new CDR `VaultRead` events since the last
+   scanned block; record each `(uuid, requesterPubKey, ciphertext, block)` plus
+   the active `round`/`threshold` (captured once via `/dkg/latest_active`, used
+   for the zero-partial case).
+3. **Alert** — if any shortfalls, post a **single** batched Slack message, then
+   persist state. State is saved only after a successful post, so a failed post
+   re-detects and re-alerts next run rather than dropping silently.
+
+No reorg buffer: CometBFT finalizes on commit, so the latest block is final.
+Block deadlines use EL block numbers; since Story produces one EL block per CL
+block the 200-block interval is identical either way.
+
+`partials` count and `thresholdMet` come from `/dkg/cdr_partials` (the keeper's
+accepted set), not raw logs — this is already correct for duplicate submissions
+and invalidated-validator rejections.
+
+### Configuration (env)
+
+| Var | Required | Default | Notes |
+|-----|----------|---------|-------|
+| `CDR_API_URL` | yes | — | Story-API REST base URL (in CI: repo secret, masked in logs) |
+| `CDR_RPC_URL` | no | network default | EVM JSON-RPC (aeneid: `https://aeneid.storyrpc.io`); in CI: optional secret |
+| `CDR_SLACK_WEBHOOK_URL` | when alerting | — | required only if a shortfall is found |
+| `CDR_NETWORK` | no | `aeneid` | network label (`aeneid` \| `mainnet`); selects the default RPC and labels the alert |
+| `READ_REQUESTS_PATH` | no | `./read_requests.json` | state file |
+| `DECRYPT_TIMEOUT_BLOCKS` | no | `200` | matches keeper `DefaultDecryptTimeout` |
+| `RUN_URL` | no | — | adds a "View workflow run" button to the Slack message |
+
+### Run
+
+```bash
+pnpm --filter @piplabs/cdr-monitor partials-threshold
+```
+
+State (`read_requests.json`) persists across runs; in CI it is carried via
+`actions/cache`. In CI the endpoints are supplied as repo secrets
+(`CDR_API_URL`, optional `CDR_RPC_URL`) rather than hardcoded, so the internal
+Story-API host is not exposed in the workflow file:
+
+```bash
+gh secret set CDR_API_URL
+gh secret set CDR_RPC_URL   # optional; omit to use the public aeneid RPC
+```

--- a/apps/monitor/package.json
+++ b/apps/monitor/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@piplabs/cdr-monitor",
+  "version": "0.2.1",
+  "type": "module",
+  "private": true,
+  "license": "MIT",
+  "scripts": {
+    "build": "tsc",
+    "partials-threshold": "tsx src/partials-threshold/index.ts",
+    "clean": "rm -rf dist",
+    "lint": "tsc --noEmit",
+    "test": "vitest run --exclude '**/node_modules/**' --exclude '**/dist/**'",
+    "test:coverage": "vitest run --coverage --exclude '**/node_modules/**' --exclude '**/dist/**'"
+  },
+  "dependencies": {
+    "@piplabs/cdr-sdk": "workspace:*",
+    "viem": "^2.47.6"
+  },
+  "devDependencies": {
+    "@types/node": "^20",
+    "@vitest/coverage-v8": "^2",
+    "tsx": "^4",
+    "typescript": "^5.5",
+    "vitest": "^2"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/piplabs/cdr-sdk.git",
+    "directory": "apps/monitor"
+  }
+}

--- a/apps/monitor/src/partials-threshold/index.ts
+++ b/apps/monitor/src/partials-threshold/index.ts
@@ -1,0 +1,193 @@
+import { createPublicClient, http, bytesToHex, type Address, type PublicClient } from "viem";
+import {
+  cdrAbi,
+  contractAddresses,
+  queryCDRPartials,
+  queryLatestActiveDKGNetwork,
+  StoryApiError,
+  StoryApiNotFoundError,
+} from "@piplabs/cdr-sdk";
+import { loadState, saveState, type PendingRequest, type ReadRequestsState } from "./state.js";
+import {
+  buildSlackPayload,
+  classifyExpired,
+  isExpired,
+  nextScanFrom,
+  requestKey,
+  type Outcome,
+  type PartialGroup,
+} from "./logic.js";
+
+// Network label as used across the cdr-sdk workflows (aeneid/mainnet). Selects
+// the default RPC when CDR_RPC_URL is unset and labels the Slack message.
+const DEFAULT_RPC_URLS: Record<string, string> = {
+  aeneid: "https://aeneid.storyrpc.io",
+  mainnet: "https://mainnet.storyrpc.io",
+};
+
+// CDR is a Story predeploy at the same address on every network.
+const CDR_ADDRESS_BY_NETWORK: Record<string, Address> = {
+  aeneid: contractAddresses.mainnet.cdr,
+  mainnet: contractAddresses.mainnet.cdr,
+};
+
+/** Chunk getLogs to stay under RPC block-range limits (matters only after long downtime). */
+const MAX_LOG_RANGE = 1000;
+
+function requireEnv(name: string): string {
+  const v = process.env[name];
+  if (!v) throw new Error(`${name} is required`);
+  return v;
+}
+
+type VaultReadArgs = { uuid: number; ciphertext: `0x${string}`; requesterPubKey: `0x${string}` };
+
+// "No partials for this request" is the most important shortfall case, but the
+// Story-API reports it as HTTP 500 with a NotFound message (not a 404), so the
+// SDK surfaces it as a StoryApiError rather than [] / StoryApiNotFoundError.
+// Treat it as zero partials so it alerts instead of being mistaken for a
+// transient REST error and retried forever.
+function isPartialsNotFound(err: unknown): boolean {
+  if (err instanceof StoryApiNotFoundError) return true;
+  return err instanceof StoryApiError && /not found/i.test(err.message);
+}
+
+async function getVaultReadLogs(
+  client: PublicClient,
+  address: Address,
+  fromBlock: number,
+  toBlock: number,
+): Promise<Array<{ args: VaultReadArgs; blockNumber: bigint }>> {
+  const out: Array<{ args: VaultReadArgs; blockNumber: bigint }> = [];
+  for (let start = fromBlock; start <= toBlock; start += MAX_LOG_RANGE) {
+    const end = Math.min(start + MAX_LOG_RANGE - 1, toBlock);
+    const logs = await client.getContractEvents({
+      address,
+      abi: cdrAbi,
+      eventName: "VaultRead",
+      fromBlock: BigInt(start),
+      toBlock: BigInt(end),
+    });
+    for (const log of logs) {
+      out.push({ args: log.args as VaultReadArgs, blockNumber: log.blockNumber });
+    }
+  }
+  return out;
+}
+
+async function main(): Promise<void> {
+  const networkLabel = process.env.CDR_NETWORK ?? "aeneid";
+  // `||` (not `??`) so an unset/empty CDR_RPC_URL secret falls back to the default.
+  const rpcUrl = process.env.CDR_RPC_URL || DEFAULT_RPC_URLS[networkLabel] || DEFAULT_RPC_URLS.aeneid;
+  const apiUrl = requireEnv("CDR_API_URL");
+  const webhook = process.env.CDR_SLACK_WEBHOOK_URL;
+  const statePath = process.env.READ_REQUESTS_PATH ?? "./read_requests.json";
+  const timeout = Number(process.env.DECRYPT_TIMEOUT_BLOCKS ?? "200");
+  const runUrl = process.env.RUN_URL;
+
+  const cdr = CDR_ADDRESS_BY_NETWORK[networkLabel] ?? contractAddresses.mainnet.cdr;
+  const client = createPublicClient({ transport: http(rpcUrl) }) as PublicClient;
+
+  const head = Number(await client.getBlockNumber());
+  const state = await loadState(statePath);
+
+  // ── Step 1: sweep requests whose deadline has passed ──────────────────────
+  const expired = state.requests.filter((r) => isExpired(r, head));
+  const remaining = state.requests.filter((r) => !isExpired(r, head));
+
+  const shortfalls: Array<Extract<Outcome, { kind: "shortfall" }>> = [];
+  for (const req of expired) {
+    let groups: PartialGroup[];
+    try {
+      const raw = await queryCDRPartials({
+        apiUrl,
+        uuid: req.uuid,
+        requesterPubKeyHex: req.requesterPubKeyHex,
+      });
+      groups = raw.map((g) => ({
+        round: g.round,
+        ciphertextHex: bytesToHex(g.ciphertext),
+        submitted: g.submissions.length,
+        threshold: g.threshold,
+        thresholdMet: g.thresholdMet,
+      }));
+    } catch (err) {
+      if (isPartialsNotFound(err)) {
+        // No partials were ever submitted → definitively below threshold.
+        groups = [];
+      } else {
+        // Genuine transient error: keep the request so it is retried next run.
+        remaining.push(req);
+        console.error(`queryCDRPartials failed for uuid=${req.uuid}; retry next run`, err);
+        continue;
+      }
+    }
+    const outcome = classifyExpired(req, groups);
+    if (outcome.kind === "shortfall") shortfalls.push(outcome);
+    // met → silently dropped (not re-added to remaining)
+  }
+
+  // ── Step 2: ingest new VaultRead requests ─────────────────────────────────
+  const fromBlock = nextScanFrom(state.lastScannedBlock, head, timeout);
+  const seen = new Set(remaining.map((r) => requestKey(r.uuid, r.ciphertextHex)));
+  if (fromBlock <= head) {
+    const logs = await getVaultReadLogs(client, cdr, fromBlock, head);
+    let active: { round: number; threshold: number } | null = null;
+    for (const log of logs) {
+      const ciphertextHex = log.args.ciphertext.toLowerCase() as `0x${string}`;
+      const key = requestKey(log.args.uuid, ciphertextHex);
+      if (seen.has(key)) continue;
+      // Capture the active round/threshold once, only if there is anything to ingest.
+      if (active === null) {
+        const net = await queryLatestActiveDKGNetwork({ apiUrl });
+        active = { round: net.round, threshold: net.threshold };
+      }
+      const block = Number(log.blockNumber);
+      const req: PendingRequest = {
+        uuid: log.args.uuid,
+        requesterPubKeyHex: log.args.requesterPubKey.toLowerCase(),
+        ciphertextHex,
+        block,
+        deadline: block + timeout,
+        round: active.round,
+        threshold: active.threshold,
+      };
+      remaining.push(req);
+      seen.add(key);
+    }
+  }
+
+  const newState: ReadRequestsState = { lastScannedBlock: head, requests: remaining };
+
+  // ── Step 3: alert (batched) then persist ──────────────────────────────────
+  // Persist only after a successful Slack post so a post failure re-detects and
+  // re-alerts next run instead of silently dropping the shortfalls.
+  if (shortfalls.length > 0) {
+    if (!webhook) {
+      throw new Error(
+        `${shortfalls.length} threshold shortfall(s) detected but CDR_SLACK_WEBHOOK_URL is not set`,
+      );
+    }
+    const payload = buildSlackPayload(shortfalls, { network: networkLabel, head, runUrl });
+    const res = await fetch(webhook, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+    });
+    if (!res.ok) {
+      throw new Error(`Slack POST failed: ${res.status} ${await res.text()}`);
+    }
+  }
+
+  await saveState(statePath, newState);
+
+  console.log(
+    `head=${head} scanned_from=${fromBlock} expired=${expired.length} ` +
+      `shortfalls=${shortfalls.length} pending=${remaining.length}`,
+  );
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/apps/monitor/src/partials-threshold/logic.test.ts
+++ b/apps/monitor/src/partials-threshold/logic.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildSlackPayload,
+  classifyExpired,
+  isExpired,
+  matchGroup,
+  nextScanFrom,
+  requestKey,
+  type Outcome,
+  type PartialGroup,
+} from "./logic.js";
+import type { PendingRequest } from "./state.js";
+
+const req = (over: Partial<PendingRequest> = {}): PendingRequest => ({
+  uuid: 1,
+  requesterPubKeyHex: "0xab",
+  ciphertextHex: "0xdead",
+  block: 100,
+  deadline: 300,
+  round: 5,
+  threshold: 3,
+  ...over,
+});
+
+const grp = (over: Partial<PartialGroup> = {}): PartialGroup => ({
+  round: 5,
+  ciphertextHex: "0xdead",
+  submitted: 3,
+  threshold: 3,
+  thresholdMet: true,
+  ...over,
+});
+
+describe("isExpired", () => {
+  it("is not expired exactly at the deadline (strict >)", () => {
+    expect(isExpired(req({ deadline: 300 }), 300)).toBe(false);
+  });
+  it("is expired one block past the deadline", () => {
+    expect(isExpired(req({ deadline: 300 }), 301)).toBe(true);
+  });
+});
+
+describe("nextScanFrom", () => {
+  it("scans one timeout window back on first run", () => {
+    expect(nextScanFrom(null, 1000, 200)).toBe(800);
+  });
+  it("clamps to 0 when head is within the first window", () => {
+    expect(nextScanFrom(null, 50, 200)).toBe(0);
+  });
+  it("resumes right after the last scanned block", () => {
+    expect(nextScanFrom(500, 1000, 200)).toBe(501);
+  });
+});
+
+describe("matchGroup", () => {
+  it("matches by ciphertext and prefers the newest round", () => {
+    const g = matchGroup(req(), [grp({ round: 4 }), grp({ round: 6 }), grp({ ciphertextHex: "0xbeef", round: 9 })]);
+    expect(g?.round).toBe(6);
+  });
+  it("ignores zero-submission groups", () => {
+    expect(matchGroup(req(), [grp({ submitted: 0 })])).toBeUndefined();
+  });
+  it("returns undefined when no ciphertext matches", () => {
+    expect(matchGroup(req(), [grp({ ciphertextHex: "0xbeef" })])).toBeUndefined();
+  });
+  it("matches case-insensitively", () => {
+    expect(matchGroup(req({ ciphertextHex: "0xDEAD" }), [grp({ ciphertextHex: "0xdead" })])).toBeDefined();
+  });
+});
+
+describe("classifyExpired", () => {
+  it("is met when thresholdMet and submitted >= threshold", () => {
+    expect(classifyExpired(req(), [grp({ submitted: 3, threshold: 3, thresholdMet: true })]).kind).toBe("met");
+  });
+  it("is shortfall when below threshold", () => {
+    expect(classifyExpired(req(), [grp({ submitted: 2, threshold: 3, thresholdMet: false })])).toMatchObject({
+      kind: "shortfall",
+      submitted: 2,
+      threshold: 3,
+    });
+  });
+  it("is shortfall (0 submitted) using the ingest-time threshold when no partials exist", () => {
+    expect(classifyExpired(req({ threshold: 4 }), [])).toMatchObject({
+      kind: "shortfall",
+      submitted: 0,
+      threshold: 4,
+    });
+  });
+  it("is shortfall when thresholdMet is false even if submitted >= threshold", () => {
+    expect(classifyExpired(req(), [grp({ submitted: 3, threshold: 3, thresholdMet: false })]).kind).toBe("shortfall");
+  });
+});
+
+describe("requestKey", () => {
+  it("combines uuid and lowercased ciphertext", () => {
+    expect(requestKey(7, "0xDEAD")).toBe("7:0xdead");
+  });
+});
+
+describe("buildSlackPayload", () => {
+  const shortfall = (over: Partial<PendingRequest> = {}, submitted = 1, threshold = 3) =>
+    ({ kind: "shortfall", req: req(over), submitted, threshold }) as Extract<Outcome, { kind: "shortfall" }>;
+
+  it("batches every shortfall into a single message", () => {
+    const payload = buildSlackPayload(
+      [shortfall({ uuid: 1, block: 100 }, 1, 3), shortfall({ uuid: 2, block: 120 }, 0, 3)],
+      { network: "aeneid", head: 500, runUrl: "http://x" },
+    ) as { text: string; blocks: Array<{ type: string; text?: { text: string } }> };
+    expect(payload.text).toContain("2 requests");
+    expect(payload.blocks[1].text?.text).toContain("uuid `1`");
+    expect(payload.blocks[1].text?.text).toContain("uuid `2`");
+    expect(payload.blocks[2].type).toBe("actions");
+  });
+
+  it("uses singular wording and omits the run button when no runUrl", () => {
+    const payload = buildSlackPayload([shortfall()], { network: "aeneid", head: 500 }) as {
+      text: string;
+      blocks: unknown[];
+    };
+    expect(payload.text).toContain("1 request ");
+    expect(payload.blocks).toHaveLength(2);
+  });
+});

--- a/apps/monitor/src/partials-threshold/logic.ts
+++ b/apps/monitor/src/partials-threshold/logic.ts
@@ -1,0 +1,101 @@
+import type { PendingRequest } from "./state.js";
+
+/** A `/dkg/cdr_partials` group reduced to the scalars the monitor needs. */
+export interface PartialGroup {
+  round: number;
+  ciphertextHex: string;
+  submitted: number;
+  threshold: number;
+  thresholdMet: boolean;
+}
+
+export type Outcome =
+  | { kind: "met"; req: PendingRequest; submitted: number; threshold: number }
+  | { kind: "shortfall"; req: PendingRequest; submitted: number; threshold: number };
+
+/** Stable identity for a decrypt request: (uuid, ciphertext). */
+export function requestKey(uuid: number, ciphertextHex: string): string {
+  return `${uuid}:${ciphertextHex.toLowerCase()}`;
+}
+
+/**
+ * A request has passed its on-chain decrypt timeout once head is strictly past
+ * its deadline. Strict `>` mirrors the keeper's
+ * `currentHeight - reqHeight > DefaultDecryptTimeout`, so a partial accepted
+ * exactly at block+timeout is not falsely flagged.
+ */
+export function isExpired(req: PendingRequest, head: number): boolean {
+  return head > req.deadline;
+}
+
+/**
+ * First run scans one timeout window back (only requests that could still be
+ * open); later runs resume right after the last scanned block. No reorg buffer:
+ * CometBFT finalizes on commit, so head is final.
+ */
+export function nextScanFrom(lastScannedBlock: number | null, head: number, timeout: number): number {
+  if (lastScannedBlock === null) return Math.max(0, head - timeout);
+  return lastScannedBlock + 1;
+}
+
+/** Pick the group matching this request's ciphertext, preferring the newest round. */
+export function matchGroup(req: PendingRequest, groups: PartialGroup[]): PartialGroup | undefined {
+  const target = req.ciphertextHex.toLowerCase();
+  return groups
+    .filter((g) => g.submitted > 0 && g.ciphertextHex.toLowerCase() === target)
+    .sort((a, b) => b.round - a.round)[0];
+}
+
+/**
+ * Classify an expired request. `met` when the keeper reports the threshold
+ * reached; otherwise `shortfall`. For the zero-partial case (no matching group)
+ * the threshold recorded at ingest is used.
+ */
+export function classifyExpired(req: PendingRequest, groups: PartialGroup[]): Outcome {
+  const g = matchGroup(req, groups);
+  if (g && g.thresholdMet && g.submitted >= g.threshold) {
+    return { kind: "met", req, submitted: g.submitted, threshold: g.threshold };
+  }
+  return {
+    kind: "shortfall",
+    req,
+    submitted: g?.submitted ?? 0,
+    threshold: g?.threshold ?? req.threshold,
+  };
+}
+
+export interface SlackContext {
+  network: string;
+  head: number;
+  runUrl?: string;
+}
+
+/** Build a single batched Slack message for all shortfalls in this run. */
+export function buildSlackPayload(
+  shortfalls: Array<Extract<Outcome, { kind: "shortfall" }>>,
+  ctx: SlackContext,
+): unknown {
+  const n = shortfalls.length;
+  const headline = `🚨 CDR threshold shortfall (${ctx.network}) — ${n} request${n === 1 ? "" : "s"} expired below threshold`;
+  // Slack mrkdwn bold is single `*…*`.
+  const lines = shortfalls
+    .map(
+      (s) =>
+        `• round *${s.req.round}* · uuid \`${s.req.uuid}\` · *${s.submitted}/${s.threshold}* partials · req block ${s.req.block}`,
+    )
+    .join("\n");
+
+  const blocks: unknown[] = [
+    { type: "section", text: { type: "mrkdwn", text: `*${headline}*` } },
+    { type: "section", text: { type: "mrkdwn", text: lines } },
+  ];
+  if (ctx.runUrl) {
+    blocks.push({
+      type: "actions",
+      elements: [
+        { type: "button", text: { type: "plain_text", text: "View workflow run" }, url: ctx.runUrl },
+      ],
+    });
+  }
+  return { text: headline, blocks };
+}

--- a/apps/monitor/src/partials-threshold/state.test.ts
+++ b/apps/monitor/src/partials-threshold/state.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { EMPTY_STATE, loadState, saveState, type ReadRequestsState } from "./state.js";
+
+let dir: string;
+let path: string;
+
+beforeEach(async () => {
+  dir = await mkdtemp(join(tmpdir(), "cdr-monitor-"));
+  path = join(dir, "read_requests.json");
+});
+
+afterEach(async () => {
+  await rm(dir, { recursive: true, force: true });
+});
+
+describe("loadState", () => {
+  it("returns empty state when the file is absent (first run)", async () => {
+    expect(await loadState(path)).toEqual(EMPTY_STATE);
+  });
+
+  it("returns empty state when the file is malformed JSON", async () => {
+    await writeFile(path, "not-json", "utf8");
+    expect(await loadState(path)).toEqual(EMPTY_STATE);
+  });
+
+  it("returns empty state when the shape is wrong (missing requests array)", async () => {
+    await writeFile(path, JSON.stringify({ lastScannedBlock: 5 }), "utf8");
+    expect(await loadState(path)).toEqual(EMPTY_STATE);
+  });
+
+  it("coerces a non-numeric lastScannedBlock to null", async () => {
+    await writeFile(path, JSON.stringify({ lastScannedBlock: "oops", requests: [] }), "utf8");
+    expect(await loadState(path)).toEqual({ lastScannedBlock: null, requests: [] });
+  });
+});
+
+describe("saveState / loadState round-trip", () => {
+  it("persists and reloads state unchanged", async () => {
+    const state: ReadRequestsState = {
+      lastScannedBlock: 1234,
+      requests: [
+        {
+          uuid: 7,
+          requesterPubKeyHex: "0xabcd",
+          ciphertextHex: "0xdead",
+          block: 1000,
+          deadline: 1200,
+          round: 5,
+          threshold: 3,
+        },
+      ],
+    };
+    await saveState(path, state);
+    expect(await loadState(path)).toEqual(state);
+  });
+});

--- a/apps/monitor/src/partials-threshold/state.ts
+++ b/apps/monitor/src/partials-threshold/state.ts
@@ -1,0 +1,59 @@
+import { readFile, writeFile } from "node:fs/promises";
+
+/**
+ * A decrypt request seen via a CDR `VaultRead` log and not yet resolved.
+ * `block`/`deadline` are EL block numbers; `round`/`threshold` are captured
+ * from the active DKG network at ingest so a zero-partial expiry can still be
+ * judged against the right threshold (the keeper returns no group to read it
+ * from when nothing was submitted).
+ */
+export interface PendingRequest {
+  uuid: number;
+  /** Requester uncompressed pubkey, 0x-hex (the bytes the CDR `read()` carried). */
+  requesterPubKeyHex: string;
+  /** TDH2 ciphertext, 0x-hex lowercase. */
+  ciphertextHex: string;
+  /** EL block the VaultRead was emitted at. */
+  block: number;
+  /** block + DECRYPT_TIMEOUT_BLOCKS — request is expired once head passes this. */
+  deadline: number;
+  /** Active DKG round at ingest. */
+  round: number;
+  /** Active threshold at ingest (fallback for the zero-partial case). */
+  threshold: number;
+}
+
+export interface ReadRequestsState {
+  /** Highest EL block already scanned for VaultRead logs; null on first run. */
+  lastScannedBlock: number | null;
+  requests: PendingRequest[];
+}
+
+export const EMPTY_STATE: ReadRequestsState = { lastScannedBlock: null, requests: [] };
+
+/** Load state, tolerating an absent or malformed file by returning empty state. */
+export async function loadState(path: string): Promise<ReadRequestsState> {
+  let raw: string;
+  try {
+    raw = await readFile(path, "utf8");
+  } catch {
+    return { ...EMPTY_STATE };
+  }
+  try {
+    const parsed = JSON.parse(raw) as Partial<ReadRequestsState>;
+    if (typeof parsed !== "object" || parsed === null || !Array.isArray(parsed.requests)) {
+      return { ...EMPTY_STATE };
+    }
+    return {
+      lastScannedBlock:
+        typeof parsed.lastScannedBlock === "number" ? parsed.lastScannedBlock : null,
+      requests: parsed.requests as PendingRequest[],
+    };
+  } catch {
+    return { ...EMPTY_STATE };
+  }
+}
+
+export async function saveState(path: string, state: ReadRequestsState): Promise<void> {
+  await writeFile(path, `${JSON.stringify(state, null, 2)}\n`, "utf8");
+}

--- a/apps/monitor/tsconfig.json
+++ b/apps/monitor/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "types": ["node"]
+  },
+  "include": ["src"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -85,6 +85,31 @@ importers:
         specifier: ^2
         version: 2.1.9(@types/node@20.19.37)(terser@5.46.1)
 
+  apps/monitor:
+    dependencies:
+      '@piplabs/cdr-sdk':
+        specifier: workspace:*
+        version: link:../../packages/sdk
+      viem:
+        specifier: ^2.47.6
+        version: 2.47.6(typescript@5.9.3)(zod@4.3.6)
+    devDependencies:
+      '@types/node':
+        specifier: ^20
+        version: 20.19.37
+      '@vitest/coverage-v8':
+        specifier: ^2
+        version: 2.1.9(vitest@2.1.9(@types/node@20.19.37)(terser@5.46.1))
+      tsx:
+        specifier: ^4
+        version: 4.21.0
+      typescript:
+        specifier: ^5.5
+        version: 5.9.3
+      vitest:
+        specifier: ^2
+        version: 2.1.9(@types/node@20.19.37)(terser@5.46.1)
+
   packages/contracts:
     devDependencies:
       typescript:


### PR DESCRIPTION
## What

Adds an off-chain monitor that alerts (Slack) when a CDR threshold-decryption request expires without collecting enough partial decryptions to meet its round threshold. New workspace app `apps/monitor` (`src/partials-threshold/`) plus a scheduled workflow.

## How it works

Runs on a cron (every 5 min); state in `read_requests.json`, carried across runs via `actions/cache`. Each run:

  1. **Sweep** — for each tracked request past its 200-block deadline, query Story-API `/dkg/cdr_partials`: threshold met → drop, below threshold → collect.
  2. **Ingest** — `eth_getLogs` for new CDR `VaultRead` events since the last scanned block; record `(uuid, requesterPubKey, ciphertext, block)` plus the active `round`/`threshold`.
  3. **Alert** — post a single batched Slack message for all shortfalls, then drop them so the next run doesn't repeat. State is persisted only after a successful post.
