### PR TITLE
feat(ci): aeneid DKG round monitor with per-stage Slack notifications

### DIFF
--- a/.github/workflows/dkg-round-monitor-aeneid.yml
+++ b/.github/workflows/dkg-round-monitor-aeneid.yml
@@ -1,0 +1,171 @@
+name: DKG round monitor (aeneid)
+
+run-name: dkg-round-monitor-aeneid${{ github.event.inputs.start_round != '' && format(' (reseed→{0})', github.event.inputs.start_round) || '' }}
+
+# Cron-fired watcher that follows ONE DKG round at a time on aeneid and posts a
+# Slack message on every stage transition of the round it is currently watching.
+#
+# Single-pointer state machine (NOT a range scan). State is a tiny JSON blob
+# kept across runs via actions/cache:
+#
+#   ./state.json = { "watch_round": <uint>, "last_stage": <0-6> }
+#
+# Each run:
+#   1. query /dkg/dkg_network?round=<watch_round> -> stage S
+#   2. if S != last_stage -> post a Slack notification for S, set last_stage=S
+#   3. if S is terminal (5 FAILED / 6 ENDED) -> watch_round += 1, last_stage = 0,
+#      and re-check the next round in the same run (so "Round N ENDED" and
+#      "Round N+1 → REGISTRATION" can fire back-to-back). Bounded per run.
+#   4. otherwise stop until the next tick (the round is still progressing).
+#
+# Stage codes (story x/dkg DKGStage): 1=REGISTRATION 2=DEALING 3=FINALIZATION
+#   4=ACTIVE 5=FAILED 6=ENDED. A status of 5 always raises a WARNING.
+#
+# aeneid stages are ~34,560 blocks (~17h) each, active ~138,240 (~69h), so
+# transitions are slow; */15 min easily catches every edge.
+#
+# Secret required: DKG_MONITOR_SLACK_WEBHOOK_URL (incoming webhook for the
+# target Slack channel).
+
+on:
+  schedule:
+    - cron: '*/15 * * * *'
+  workflow_dispatch:
+    inputs:
+      start_round:
+        description: "Re-seed the watch pointer to this round (blank = keep cached state)"
+        required: false
+        type: string
+        default: ''
+
+permissions:
+  contents: read
+
+concurrency:
+  # Serialize runs so two firings can't both advance/notify on the same state.
+  group: dkg-round-monitor-aeneid
+  cancel-in-progress: false
+
+env:
+  AENEID_REST: http://172.192.41.96:1317
+  DEFAULT_START_ROUND: '24'
+  MAX_ADVANCES_PER_RUN: '6'
+
+jobs:
+  monitor:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Restore watch state from cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ./state.json
+          key: dkg-round-monitor-aeneid-state-${{ github.run_id }}
+          restore-keys: |
+            dkg-round-monitor-aeneid-state-
+
+      - name: Step the state machine and notify on transitions
+        id: run
+        env:
+          WEBHOOK: ${{ secrets.DKG_MONITOR_SLACK_WEBHOOK_URL }}
+          # Read the dispatch input via env to keep it out of the run-script
+          # interpolation (avoids shell injection from the free-text input).
+          RESEED: ${{ github.event.inputs.start_round }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "${WEBHOOK:-}" ]; then
+            echo "::error::DKG_MONITOR_SLACK_WEBHOOK_URL secret is not set"
+            exit 1
+          fi
+
+          stage_name() {
+            case "$1" in
+              1) echo "REGISTRATION" ;;
+              2) echo "DEALING" ;;
+              3) echo "FINALIZATION" ;;
+              4) echo "ACTIVE" ;;
+              5) echo "FAILED" ;;
+              6) echo "ENDED" ;;
+              *) echo "UNSPECIFIED" ;;
+            esac
+          }
+          stage_emoji() {
+            case "$1" in
+              1) printf '\xF0\x9F\x94\xB5' ;;   # blue circle
+              2) printf '\xF0\x9F\x9F\xA1' ;;   # yellow circle
+              3) printf '\xF0\x9F\x9F\xA1' ;;   # yellow circle
+              4) printf '\xE2\x9C\x85' ;;       # check mark
+              5) printf '\xE2\x9D\x8C' ;;       # cross mark
+              6) printf '\xE2\x9A\xAA' ;;       # white circle
+              *) printf '\xE2\x96\xAB' ;;       # small square
+            esac
+          }
+          notify() {
+            local text="$1"
+            local payload
+            payload=$(jq -n --arg t "$text" '{text: $t}')
+            curl -fsS --max-time 10 -X POST -H 'Content-type: application/json' \
+              --data "$payload" "$WEBHOOK" >/dev/null
+            echo "notified: $text"
+          }
+
+          # --- initialize watch pointer ---
+          if [ -n "${RESEED:-}" ]; then
+            if ! [[ "$RESEED" =~ ^[0-9]+$ ]]; then
+              echo "::error::start_round input must be an integer, got '$RESEED'"; exit 1
+            fi
+            WR="$RESEED"; LS=0
+            echo "re-seeded from dispatch input: watch_round=$WR"
+          elif [ -f ./state.json ]; then
+            WR=$(jq -r '.watch_round // empty' ./state.json)
+            LS=$(jq -r '.last_stage // 0' ./state.json)
+          else
+            WR="$DEFAULT_START_ROUND"; LS=0
+            echo "no cached state; starting at default watch_round=$WR"
+          fi
+          [[ "$WR" =~ ^[0-9]+$ ]] || { echo "::error::bad watch_round='$WR'"; exit 1; }
+          [[ "$LS" =~ ^[0-6]$ ]] || LS=0
+
+          changed=0
+          i=0
+          while [ "$i" -lt "$MAX_ADVANCES_PER_RUN" ]; do
+            i=$((i + 1))
+            resp=$(curl -fsS --max-time 10 "$AENEID_REST/dkg/dkg_network?round=$WR" 2>/dev/null || echo '{}')
+            S=$(echo "$resp" | jq -r '.msg.network.stage // 0')
+            [[ "$S" =~ ^[0-9]+$ ]] || S=0
+            echo "watch_round=$WR observed stage=$S (last_stage=$LS)"
+
+            # stage 0 = not created yet / unspecified -> wait for the next tick
+            if [ "$S" = "0" ]; then
+              break
+            fi
+
+            if [ "$S" != "$LS" ]; then
+              if [ "$S" = "5" ]; then
+                notify "$(stage_emoji 5) WARNING: Round $WR -> FAILED (was $(stage_name "$LS"))"
+              else
+                notify "$(stage_emoji "$S") Round $WR -> $(stage_name "$S")"
+              fi
+              LS="$S"; changed=1
+            fi
+
+            # terminal stage -> advance the pointer and re-check the next round
+            if [ "$S" = "5" ] || [ "$S" = "6" ]; then
+              WR=$((WR + 1)); LS=0; changed=1
+              continue
+            fi
+
+            break
+          done
+
+          printf '{"watch_round":%s,"last_stage":%s}\n' "$WR" "$LS" > ./state.json
+          echo "new state: $(cat ./state.json)"
+          echo "changed=$changed" >> "$GITHUB_OUTPUT"
+
+      - name: Persist watch state (only when it changed)
+        if: steps.run.outputs.changed == '1'
+        uses: actions/cache/save@v4
+        with:
+          path: ./state.json
+          key: dkg-round-monitor-aeneid-state-${{ github.run_id }}

--- a/.github/workflows/dkg-round-monitor-aeneid.yml
+++ b/.github/workflows/dkg-round-monitor-aeneid.yml
@@ -47,7 +47,9 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  AENEID_REST: http://172.192.41.96:1317
+  # Public aeneid REST endpoint. Overridable via repo variable so the node can
+  # be reprovisioned without editing the workflow (falls back to the default).
+  AENEID_REST: ${{ vars.AENEID_REST || 'http://172.192.41.96:1317' }}
   DEFAULT_START_ROUND: '24'
   MAX_ADVANCES_PER_RUN: '6'
 
@@ -111,6 +113,7 @@ jobs:
           }
 
           # --- initialize watch pointer ---
+          UNREACH=0
           if [ -n "${RESEED:-}" ]; then
             if ! [[ "$RESEED" =~ ^[0-9]+$ ]]; then
               echo "::error::start_round input must be an integer, got '$RESEED'"; exit 1
@@ -120,18 +123,29 @@ jobs:
           elif [ -f ./state.json ]; then
             WR=$(jq -r '.watch_round // empty' ./state.json)
             LS=$(jq -r '.last_stage // 0' ./state.json)
+            UNREACH=$(jq -r '.unreachable // 0' ./state.json)
           else
             WR="$DEFAULT_START_ROUND"; LS=0
             echo "no cached state; starting at default watch_round=$WR"
           fi
           [[ "$WR" =~ ^[0-9]+$ ]] || { echo "::error::bad watch_round='$WR'"; exit 1; }
           [[ "$LS" =~ ^[0-6]$ ]] || LS=0
+          [[ "${UNREACH:-0}" =~ ^[01]$ ]] || UNREACH=0
 
           changed=0
+          rest_down=0
           i=0
           while [ "$i" -lt "$MAX_ADVANCES_PER_RUN" ]; do
             i=$((i + 1))
-            resp=$(curl -fsS --max-time 10 "$AENEID_REST/dkg/dkg_network?round=$WR" 2>/dev/null || echo '{}')
+            # Distinguish a real REST failure (network/HTTP error -> curl -f
+            # non-zero) from a valid response for a not-yet-created round
+            # (stage 0). A swallowed failure would let monitoring go dark
+            # silently, so we surface it as an alert below.
+            if ! resp=$(curl -fsS --max-time 10 "$AENEID_REST/dkg/dkg_network?round=$WR" 2>/dev/null); then
+              echo "REST query failed for round=$WR"
+              rest_down=1
+              break
+            fi
             S=$(echo "$resp" | jq -r '.msg.network.stage // 0')
             [[ "$S" =~ ^[0-9]+$ ]] || S=0
             echo "watch_round=$WR observed stage=$S (last_stage=$LS)"
@@ -159,7 +173,17 @@ jobs:
             break
           done
 
-          printf '{"watch_round":%s,"last_stage":%s}\n' "$WR" "$LS" > ./state.json
+          # Edge-triggered reachability alerts (no spam): one warning when the
+          # REST endpoint goes dark, one all-clear when it recovers.
+          if [ "$rest_down" = "1" ] && [ "${UNREACH:-0}" = "0" ]; then
+            notify "$(stage_emoji 5) WARNING: DKG monitor cannot reach aeneid REST ($AENEID_REST); round notifications are paused"
+            UNREACH=1; changed=1
+          elif [ "$rest_down" = "0" ] && [ "${UNREACH:-0}" = "1" ]; then
+            notify "$(stage_emoji 4) DKG monitor: aeneid REST reachable again; resuming (watching round $WR)"
+            UNREACH=0; changed=1
+          fi
+
+          printf '{"watch_round":%s,"last_stage":%s,"unreachable":%s}\n' "$WR" "$LS" "${UNREACH:-0}" > ./state.json
           echo "new state: $(cat ./state.json)"
           echo "changed=$changed" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
Cron `*/15` watcher that follows one DKG round at a time on aeneid (`/dkg/dkg_network`) and posts a Slack message on every stage transition.

**Single-pointer state machine** (not a range scan), state in actions/cache (`{watch_round, last_stage}`):
- `1 REGISTRATION` 🔵 / `2 DEALING` 🟡 / `3 FINALIZATION` 🟡 / `4 ACTIVE` ✅ / `6 ENDED` ⚪
- `5 FAILED` ❌ raises a **WARNING** (with the stage it failed from)
- on terminal stage (FAILED/ENDED) the pointer advances to the next round and re-checks in the same run

Starts at round 24 (current aeneid round, in FINALIZATION). Posts to `DKG_MONITOR_SLACK_WEBHOOK_URL` (already set). `workflow_dispatch` accepts a `start_round` input to re-seed the pointer.