### PR TITLE
fix(ci): advance DKG round monitor on ACTIVE so it never goes blind to later rounds

### DIFF
--- a/.github/workflows/dkg-round-monitor-aeneid.yml
+++ b/.github/workflows/dkg-round-monitor-aeneid.yml
@@ -13,9 +13,14 @@ run-name: dkg-round-monitor-aeneid${{ github.event.inputs.start_round != '' && f
 # Each run:
 #   1. query /dkg/dkg_network?round=<watch_round> -> stage S
 #   2. if S != last_stage -> post a Slack notification for S, set last_stage=S
-#   3. if S is terminal (5 FAILED / 6 ENDED) -> watch_round += 1, last_stage = 0,
-#      and re-check the next round in the same run (so "Round N ENDED" and
-#      "Round N+1 → REGISTRATION" can fire back-to-back). Bounded per run.
+#   3. if S means the round is done (4 ACTIVE / 5 FAILED / 6 ENDED) ->
+#      watch_round += 1, last_stage = 0, and re-check the next round in the same
+#      run (so "Round N → ACTIVE" and "Round N+1 → REGISTRATION" can fire
+#      back-to-back). Bounded per run. ACTIVE must advance the pointer: a
+#      resharing round begins forming while the previous round is still ACTIVE,
+#      and a *failed* forming round never evicts the ACTIVE one -> a pointer
+#      parked on ACTIVE would never see the next round's REGISTRATION/DEALING/
+#      FINALIZATION or report a FAILED round.
 #   4. otherwise stop until the next tick (the round is still progressing).
 #
 # Stage codes (story x/dkg DKGStage): 1=REGISTRATION 2=DEALING 3=FINALIZATION
@@ -164,8 +169,12 @@ jobs:
               LS="$S"; changed=1
             fi
 
-            # terminal stage -> advance the pointer and re-check the next round
-            if [ "$S" = "5" ] || [ "$S" = "6" ]; then
+            # round done -> advance the pointer and follow the next forming round.
+            # ACTIVE (4) advances too: the next resharing round forms while this
+            # one is still ACTIVE, and a failed forming round never evicts the
+            # ACTIVE one, so a pointer left on ACTIVE would go blind to every
+            # later round (REG/DEAL/FIN and, critically, FAILED).
+            if [ "$S" = "4" ] || [ "$S" = "5" ] || [ "$S" = "6" ]; then
               WR=$((WR + 1)); LS=0; changed=1
               continue
             fi


### PR DESCRIPTION
## Problem

The aeneid DKG round monitor (`dkg-round-monitor-aeneid.yml`) is a single-pointer state machine that only advanced `watch_round` on a **terminal** stage (`5 FAILED` / `6 ENDED`). `ACTIVE (4)` was not treated as advancing.

That parks the pointer on whichever round last activated:

- `ACTIVE` persists for the whole active period (~69h on aeneid) with no stage change, so the monitor sits silent.
- The next resharing round forms (REGISTRATION/DEALING/FINALIZATION) **while the previous round is still ACTIVE** — the monitor isn't watching it, so those transitions are missed.
- **A failed forming round never evicts the ACTIVE one** (the active committee stays on the last good round). A pointer parked on ACTIVE therefore never observes — or reports — a `FAILED` round. That is exactly the aeneid scenario this monitor exists to catch.

Observed live: cache state stuck at `{watch_round: 24, last_stage: 4}` while aeneid round 25 was already in REGISTRATION — monitor posting nothing.

## Fix

Treat `ACTIVE (4)` like the other round-complete stages: post `Round N -> ACTIVE`, then advance the pointer to `N+1` and follow the next forming round in the same run. `last_stage` resets to 0 so the next round's REGISTRATION fires.

- Self-heals from a parked-on-ACTIVE cache state on the next tick (sees 24=ACTIVE, no dup post, advances to 25, reports REGISTRATION).
- Bounded by `MAX_ADVANCES_PER_RUN` as before.
- Comment/doc updated to reflect the new advance condition.

Logic-only change to the advance condition; no change to notification formatting, reachability alerts, or state schema.