### PR TITLE
fix(ci): DKG round monitor — only alert REST-unreachable on connection failure, not HTTP errors

### DIFF
--- a/.github/workflows/dkg-round-monitor-aeneid.yml
+++ b/.github/workflows/dkg-round-monitor-aeneid.yml
@@ -139,6 +139,11 @@ jobs:
 
           changed=0
           rest_down=0
+          # got_ok=1 only after a genuine 2xx response was processed this run.
+          # The "reachable again; resuming" all-clear keys off this, NOT off
+          # rest_down=0, so an HTTP-error (non-2xx) tick — which skips without
+          # processing a round — does not prematurely claim we resumed.
+          got_ok=0
           i=0
           while [ "$i" -lt "$MAX_ADVANCES_PER_RUN" ]; do
             i=$((i + 1))
@@ -163,6 +168,7 @@ jobs:
               break
             fi
             resp=$(cat /tmp/dkg_resp.json)
+            got_ok=1   # genuine 2xx: round data actually processed this run
             S=$(echo "$resp" | jq -r '.msg.network.stage // 0')
             [[ "$S" =~ ^[0-9]+$ ]] || S=0
             echo "watch_round=$WR observed stage=$S (last_stage=$LS)"
@@ -199,7 +205,7 @@ jobs:
           if [ "$rest_down" = "1" ] && [ "${UNREACH:-0}" = "0" ]; then
             notify "$(stage_emoji 5) WARNING: DKG monitor cannot reach aeneid REST ($AENEID_REST); round notifications are paused"
             UNREACH=1; changed=1
-          elif [ "$rest_down" = "0" ] && [ "${UNREACH:-0}" = "1" ]; then
+          elif [ "$got_ok" = "1" ] && [ "${UNREACH:-0}" = "1" ]; then
             notify "$(stage_emoji 4) DKG monitor: aeneid REST reachable again; resuming (watching round $WR)"
             UNREACH=0; changed=1
           fi

--- a/.github/workflows/dkg-round-monitor-aeneid.yml
+++ b/.github/workflows/dkg-round-monitor-aeneid.yml
@@ -142,15 +142,27 @@ jobs:
           i=0
           while [ "$i" -lt "$MAX_ADVANCES_PER_RUN" ]; do
             i=$((i + 1))
-            # Distinguish a real REST failure (network/HTTP error -> curl -f
-            # non-zero) from a valid response for a not-yet-created round
-            # (stage 0). A swallowed failure would let monitoring go dark
-            # silently, so we surface it as an alert below.
-            if ! resp=$(curl -fsS --max-time 10 "$AENEID_REST/dkg/dkg_network?round=$WR" 2>/dev/null); then
-              echo "REST query failed for round=$WR"
+            # Probe the REAL DKG API endpoint. Distinguish a genuine connection
+            # failure (host down / DNS / timeout -> curl exits non-zero, no HTTP
+            # response) from an HTTP error (server reachable but returns non-2xx,
+            # e.g. a transient 5xx or a 404 on an odd path/round). ONLY a
+            # connection failure means "REST unreachable". The old `curl -f`
+            # conflated the two and fired a false "cannot reach REST" alert while
+            # the API was actually up (bare `/` 404s, but /dkg/* serves fine).
+            rc=0
+            http=$(curl -sS -o /tmp/dkg_resp.json -w '%{http_code}' --max-time 10 "$AENEID_REST/dkg/dkg_network?round=$WR" 2>/tmp/dkg_err) || rc=$?
+            if [ "$rc" -ne 0 ]; then
+              echo "REST connection failed (curl rc=$rc) for round=$WR: $(cat /tmp/dkg_err 2>/dev/null)"
               rest_down=1
               break
             fi
+            if ! [[ "$http" =~ ^2 ]]; then
+              # Server is UP (returned HTTP $http) but this query errored — not an
+              # unreachability condition. Skip this tick without a false alert.
+              echo "REST reachable (HTTP $http) but round=$WR query non-2xx; skipping tick"
+              break
+            fi
+            resp=$(cat /tmp/dkg_resp.json)
             S=$(echo "$resp" | jq -r '.msg.network.stage // 0')
             [[ "$S" =~ ^[0-9]+$ ]] || S=0
             echo "watch_round=$WR observed stage=$S (last_stage=$LS)"


### PR DESCRIPTION
## Problem

The aeneid DKG round monitor posted a false alert to Slack:

> ❌ WARNING: DKG monitor cannot reach aeneid REST (http://172.192.41.96:1317); round notifications are paused

…while the REST API was actually **up and serving** (`/dkg/dkg_network?round=N` returned 200 with data; only the bare `/` path 404s).

## Root cause

The reachability probe used `curl -fsS`. The `-f` flag makes curl exit non-zero on **any** non-2xx HTTP response, so a server that is reachable but returns a transient 5xx (or a 404 on an odd path/round) was treated as **REST-unreachable** and fired the false "cannot reach REST; notifications paused" alert.

## Fix

Drop `-f` and read the HTTP status code explicitly, distinguishing a genuine connection failure from an HTTP error:

- **curl exits non-zero** (DNS / connection refused / timeout — no HTTP response) → genuine connection failure → `rest_down=1` (the real unreachable alert + pause, as intended).
- **HTTP non-2xx** (server reachable, this query errored) → skip the tick, **no false alert**.
- **HTTP 2xx** → parse the response as before.

## Notes

- Branch is cut fresh off `main` (the prior `feat/dkg-round-monitor-aeneid` branch is stale — it predates the merged advance-on-ACTIVE fix and would have reverted it). This PR touches **only** the reachability probe; the pointer-advance logic is untouched.
- Trade-off: a *persistent* non-2xx now skips silently rather than alerting. If desired, a follow-up can add an "N consecutive HTTP errors → alert" counter.