### PR TITLE
fix(sdk): idempotent tx submission to survive shared-RPC retry self-collision

### DIFF
--- a/packages/sdk/__tests__/_tx-submit.test.ts
+++ b/packages/sdk/__tests__/_tx-submit.test.ts
@@ -63,18 +63,28 @@ function rpcErrLike(opts: { details?: string; message?: string; cause?: unknown 
   });
 }
 
+// Invoke safeWriteContract with the common writeContract-shape boilerplate.
+// account defaults to the local ACCOUNT and chain to CHAIN; pass overrides
+// (e.g. a JSON-RPC account, or null) to exercise the other paths.
+function callPing(
+  wallet: any,
+  publicClient: any = PUBLIC,
+  overrides: { account?: unknown; chain?: unknown } = {},
+) {
+  return safeWriteContract(wallet, publicClient, {
+    account: ("account" in overrides ? overrides.account : ACCOUNT) as any,
+    chain: ("chain" in overrides ? overrides.chain : CHAIN) as any,
+    address: ADDRESS,
+    abi: SAMPLE_ABI as any,
+    functionName: "ping",
+    args: [42n],
+  });
+}
+
 describe("safeWriteContract", () => {
   it("happy path: returns the hash from sendRawTransaction", async () => {
     const wallet = mockWallet({ sendImpl: async () => EXPECTED_HASH });
-    const hash = await safeWriteContract(wallet, PUBLIC, {
-      account: ACCOUNT,
-      chain: CHAIN,
-      address: ADDRESS,
-      abi: SAMPLE_ABI as any,
-      functionName: "ping",
-      args: [42n],
-      value: 0n,
-    });
+    const hash = await callPing(wallet);
     expect(hash).toBe(EXPECTED_HASH);
     expect(wallet.prepareTransactionRequest).toHaveBeenCalledTimes(1);
     expect(wallet.signTransaction).toHaveBeenCalledTimes(1);
@@ -90,15 +100,7 @@ describe("safeWriteContract", () => {
         });
       },
     });
-    const hash = await safeWriteContract(wallet, PUBLIC, {
-      account: ACCOUNT,
-      chain: CHAIN,
-      address: ADDRESS,
-      abi: SAMPLE_ABI as any,
-      functionName: "ping",
-      args: [42n],
-    });
-    expect(hash).toBe(EXPECTED_HASH);
+    expect(await callPing(wallet)).toBe(EXPECTED_HASH);
   });
 
   it("recovers from `already known`", async () => {
@@ -107,15 +109,7 @@ describe("safeWriteContract", () => {
         throw rpcErrLike({ details: "already known" });
       },
     });
-    const hash = await safeWriteContract(wallet, PUBLIC, {
-      account: ACCOUNT,
-      chain: CHAIN,
-      address: ADDRESS,
-      abi: SAMPLE_ABI as any,
-      functionName: "ping",
-      args: [42n],
-    });
-    expect(hash).toBe(EXPECTED_HASH);
+    expect(await callPing(wallet)).toBe(EXPECTED_HASH);
   });
 
   it("rethrows `nonce too low` (ambiguous — a different tx may have consumed the nonce)", async () => {
@@ -124,16 +118,7 @@ describe("safeWriteContract", () => {
         throw rpcErrLike({ details: "nonce too low" });
       },
     });
-    await expect(
-      safeWriteContract(wallet, PUBLIC, {
-        account: ACCOUNT,
-        chain: CHAIN,
-        address: ADDRESS,
-        abi: SAMPLE_ABI as any,
-        functionName: "ping",
-        args: [42n],
-      }),
-    ).rejects.toThrow(/Missing or invalid parameters|nonce too low/);
+    await expect(callPing(wallet)).rejects.toThrow(/Missing or invalid parameters|nonce too low/);
   });
 
   it("walks the `cause` chain to find the real error", async () => {
@@ -153,15 +138,7 @@ describe("safeWriteContract", () => {
         throw outer;
       },
     });
-    const hash = await safeWriteContract(wallet, PUBLIC, {
-      account: ACCOUNT,
-      chain: CHAIN,
-      address: ADDRESS,
-      abi: SAMPLE_ABI as any,
-      functionName: "ping",
-      args: [42n],
-    });
-    expect(hash).toBe(EXPECTED_HASH);
+    expect(await callPing(wallet)).toBe(EXPECTED_HASH);
   });
 
   it("rethrows unrelated errors (e.g. revert / out of gas)", async () => {
@@ -173,16 +150,7 @@ describe("safeWriteContract", () => {
         });
       },
     });
-    await expect(
-      safeWriteContract(wallet, PUBLIC, {
-        account: ACCOUNT,
-        chain: CHAIN,
-        address: ADDRESS,
-        abi: SAMPLE_ABI as any,
-        functionName: "ping",
-        args: [42n],
-      }),
-    ).rejects.toThrow(/ContractFunctionExecutionError/);
+    await expect(callPing(wallet)).rejects.toThrow(/ContractFunctionExecutionError/);
   });
 
   it("falls back to writeContract for a JSON-RPC account (cannot pre-sign locally)", async () => {
@@ -190,14 +158,7 @@ describe("safeWriteContract", () => {
     // signTransaction would hit eth_signTransaction (unsupported on public
     // RPCs). The helper must defer to writeContract instead of pre-signing.
     const wallet = mockWallet({ sendImpl: async () => EXPECTED_HASH });
-    const hash = await safeWriteContract(wallet, PUBLIC, {
-      account: JSON_RPC_ACCOUNT,
-      chain: CHAIN,
-      address: ADDRESS,
-      abi: SAMPLE_ABI as any,
-      functionName: "ping",
-      args: [42n],
-    });
+    const hash = await callPing(wallet, PUBLIC, { account: JSON_RPC_ACCOUNT });
     expect(hash).toBe(EXPECTED_HASH);
     expect(wallet.writeContract).toHaveBeenCalledTimes(1);
     expect(wallet.signTransaction).not.toHaveBeenCalled();
@@ -214,14 +175,7 @@ describe("safeWriteContract", () => {
     // With no resolvable local account the helper defers to writeContract,
     // exactly as the pre-existing call path did.
     const wallet = mockWallet({ sendImpl: async () => EXPECTED_HASH });
-    const hash = await safeWriteContract(wallet, PUBLIC, {
-      account: null,
-      chain: null,
-      address: ADDRESS,
-      abi: SAMPLE_ABI as any,
-      functionName: "ping",
-      args: [42n],
-    });
+    const hash = await callPing(wallet, PUBLIC, { account: null, chain: null });
     expect(hash).toBe(EXPECTED_HASH);
     expect(wallet.writeContract).toHaveBeenCalledTimes(1);
     const wcArg = wallet.writeContract.mock.calls[0][0];
@@ -260,14 +214,7 @@ describe("safeWriteContract", () => {
       .mockResolvedValueOnce(100n)
       .mockResolvedValue(101n);
 
-    const hash = await safeWriteContract(wallet, publicClient, {
-      account: JSON_RPC_ACCOUNT,
-      chain: CHAIN,
-      address: ADDRESS,
-      abi: SAMPLE_ABI as any,
-      functionName: "ping",
-      args: [42n],
-    });
+    const hash = await callPing(wallet, publicClient, { account: JSON_RPC_ACCOUNT });
     expect(hash).toBe(RECOVERED);
     expect(publicClient.getTransactionCount).toHaveBeenCalledWith({ address: FROM, blockTag: "pending" });
   });

--- a/packages/sdk/__tests__/_tx-submit.test.ts
+++ b/packages/sdk/__tests__/_tx-submit.test.ts
@@ -1,0 +1,234 @@
+import { describe, it, expect, vi } from "vitest";
+import { keccak256 } from "viem";
+
+import { safeWriteContract, isAlreadySubmittedError } from "../src/_tx-submit.js";
+
+const SAMPLE_ABI = [
+  {
+    type: "function",
+    name: "ping",
+    inputs: [{ name: "n", type: "uint256" }],
+    outputs: [],
+    stateMutability: "payable",
+  },
+] as const;
+
+const ACCOUNT = {
+  address: "0x5B07483b0D1235a399A483aC8cCE665eCB5E3a75" as const,
+  type: "json-rpc" as const,
+};
+
+const CHAIN = { id: 1315 } as any;
+
+const ADDRESS = "0xcccccc0000000000000000000000000000000005" as const;
+
+const SAMPLE_SERIALIZED =
+  "0x02f868018203118080825208808080c080a04012522854168b27e5dc3d5839bab5e6b39e1a0ffd343901ce1622e3d64b48f1a04e00902ae0502c4728cbf12156290df99c3ed7de85b1dbfe20b5c36931733a33" as const;
+
+const EXPECTED_HASH = keccak256(SAMPLE_SERIALIZED);
+
+function mockWallet(opts: {
+  sendImpl: () => Promise<`0x${string}`>;
+}) {
+  const wallet = {
+    prepareTransactionRequest: vi.fn(async (_args: unknown) => ({
+      to: ADDRESS,
+      data: "0xdeadbeef",
+      chainId: 1315,
+      type: "eip1559",
+      account: ACCOUNT,
+    })),
+    signTransaction: vi.fn(async () => SAMPLE_SERIALIZED),
+    sendRawTransaction: vi.fn(opts.sendImpl),
+  } as any;
+  return wallet;
+}
+
+function rpcErrLike(opts: { details?: string; message?: string; cause?: unknown } = {}) {
+  return Object.assign(new Error(opts.message ?? "Missing or invalid parameters."), {
+    details: opts.details,
+    cause: opts.cause,
+    code: -32000,
+  });
+}
+
+describe("safeWriteContract", () => {
+  it("happy path: returns the hash from sendRawTransaction", async () => {
+    const wallet = mockWallet({ sendImpl: async () => EXPECTED_HASH });
+    const hash = await safeWriteContract(wallet, {
+      account: ACCOUNT,
+      chain: CHAIN,
+      address: ADDRESS,
+      abi: SAMPLE_ABI as any,
+      functionName: "ping",
+      args: [42n],
+      value: 0n,
+    });
+    expect(hash).toBe(EXPECTED_HASH);
+    expect(wallet.prepareTransactionRequest).toHaveBeenCalledTimes(1);
+    expect(wallet.signTransaction).toHaveBeenCalledTimes(1);
+    expect(wallet.sendRawTransaction).toHaveBeenCalledTimes(1);
+  });
+
+  it("recovers from `replacement transaction underpriced` and returns the precomputed hash", async () => {
+    const wallet = mockWallet({
+      sendImpl: async () => {
+        throw rpcErrLike({
+          details: "replacement transaction underpriced",
+          message: "Missing or invalid parameters.",
+        });
+      },
+    });
+    const hash = await safeWriteContract(wallet, {
+      account: ACCOUNT,
+      chain: CHAIN,
+      address: ADDRESS,
+      abi: SAMPLE_ABI as any,
+      functionName: "ping",
+      args: [42n],
+    });
+    expect(hash).toBe(EXPECTED_HASH);
+  });
+
+  it("recovers from `already known`", async () => {
+    const wallet = mockWallet({
+      sendImpl: async () => {
+        throw rpcErrLike({ details: "already known" });
+      },
+    });
+    const hash = await safeWriteContract(wallet, {
+      account: ACCOUNT,
+      chain: CHAIN,
+      address: ADDRESS,
+      abi: SAMPLE_ABI as any,
+      functionName: "ping",
+      args: [42n],
+    });
+    expect(hash).toBe(EXPECTED_HASH);
+  });
+
+  it("rethrows `nonce too low` (ambiguous — a different tx may have consumed the nonce)", async () => {
+    const wallet = mockWallet({
+      sendImpl: async () => {
+        throw rpcErrLike({ details: "nonce too low" });
+      },
+    });
+    await expect(
+      safeWriteContract(wallet, {
+        account: ACCOUNT,
+        chain: CHAIN,
+        address: ADDRESS,
+        abi: SAMPLE_ABI as any,
+        functionName: "ping",
+        args: [42n],
+      }),
+    ).rejects.toThrow(/Missing or invalid parameters|nonce too low/);
+  });
+
+  it("walks the `cause` chain to find the real error", async () => {
+    const wallet = mockWallet({
+      sendImpl: async () => {
+        const inner = rpcErrLike({ details: "replacement transaction underpriced" });
+        const middle = rpcErrLike({
+          details: "RPC Request failed.",
+          message: "Missing or invalid parameters.",
+          cause: inner,
+        });
+        const outer = rpcErrLike({
+          details: undefined,
+          message: "ContractFunctionExecutionError",
+          cause: middle,
+        });
+        throw outer;
+      },
+    });
+    const hash = await safeWriteContract(wallet, {
+      account: ACCOUNT,
+      chain: CHAIN,
+      address: ADDRESS,
+      abi: SAMPLE_ABI as any,
+      functionName: "ping",
+      args: [42n],
+    });
+    expect(hash).toBe(EXPECTED_HASH);
+  });
+
+  it("rethrows unrelated errors (e.g. revert / out of gas)", async () => {
+    const wallet = mockWallet({
+      sendImpl: async () => {
+        throw rpcErrLike({
+          details: "execution reverted: Invalid fee amount",
+          message: "ContractFunctionExecutionError",
+        });
+      },
+    });
+    await expect(
+      safeWriteContract(wallet, {
+        account: ACCOUNT,
+        chain: CHAIN,
+        address: ADDRESS,
+        abi: SAMPLE_ABI as any,
+        functionName: "ping",
+        args: [42n],
+      }),
+    ).rejects.toThrow(/ContractFunctionExecutionError/);
+  });
+
+  it("passes account=null / chain=null through to viem unchanged (matches writeContract)", async () => {
+    // Historical writeContract usage in this SDK is
+    //   account: walletClient.account ?? null,
+    //   chain:   walletClient.chain   ?? null,
+    // so the helper must accept null without throwing of its own accord and
+    // let viem do the same validation the old call path did.
+    const wallet = mockWallet({ sendImpl: async () => EXPECTED_HASH });
+    const hash = await safeWriteContract(wallet, {
+      account: null,
+      chain: null,
+      address: ADDRESS,
+      abi: SAMPLE_ABI as any,
+      functionName: "ping",
+      args: [42n],
+    });
+    expect(hash).toBe(EXPECTED_HASH);
+    const prepArg = wallet.prepareTransactionRequest.mock.calls[0][0];
+    expect(prepArg.account).toBeUndefined();
+    expect(prepArg.chain).toBeUndefined();
+  });
+});
+
+describe("isAlreadySubmittedError", () => {
+  it.each([
+    "replacement transaction underpriced",
+    "already known",
+    "Replacement Transaction Underpriced",
+    "Already Known",
+  ])("detects %q in details", (detailsText) => {
+    expect(isAlreadySubmittedError({ details: detailsText })).toBe(true);
+  });
+
+  it.each([
+    "nonce too low",
+    "NONCE TOO LOW",
+    "execution reverted",
+    "insufficient funds",
+    "intrinsic gas too low",
+    "",
+    "Missing or invalid parameters.",
+  ])("returns false for %q", (detailsText) => {
+    expect(isAlreadySubmittedError({ details: detailsText })).toBe(false);
+  });
+
+  it("returns false for null / undefined / non-objects", () => {
+    expect(isAlreadySubmittedError(null)).toBe(false);
+    expect(isAlreadySubmittedError(undefined)).toBe(false);
+    expect(isAlreadySubmittedError("replacement transaction underpriced")).toBe(false);
+    expect(isAlreadySubmittedError(42)).toBe(false);
+  });
+
+  it("guards against cyclic cause chains", () => {
+    const a: any = { details: "wrap" };
+    const b: any = { details: "wrap", cause: a };
+    a.cause = b;
+    expect(isAlreadySubmittedError(a)).toBe(false);
+  });
+});

--- a/packages/sdk/__tests__/_tx-submit.test.ts
+++ b/packages/sdk/__tests__/_tx-submit.test.ts
@@ -15,6 +15,11 @@ const SAMPLE_ABI = [
 
 const ACCOUNT = {
   address: "0x5B07483b0D1235a399A483aC8cCE665eCB5E3a75" as const,
+  type: "local" as const,
+};
+
+const JSON_RPC_ACCOUNT = {
+  address: "0x5B07483b0D1235a399A483aC8cCE665eCB5E3a75" as const,
   type: "json-rpc" as const,
 };
 
@@ -40,6 +45,7 @@ function mockWallet(opts: {
     })),
     signTransaction: vi.fn(async () => SAMPLE_SERIALIZED),
     sendRawTransaction: vi.fn(opts.sendImpl),
+    writeContract: vi.fn(async () => EXPECTED_HASH),
   } as any;
   return wallet;
 }
@@ -174,12 +180,34 @@ describe("safeWriteContract", () => {
     ).rejects.toThrow(/ContractFunctionExecutionError/);
   });
 
-  it("passes account=null / chain=null through to viem unchanged (matches writeContract)", async () => {
+  it("falls back to writeContract for a JSON-RPC account (cannot pre-sign locally)", async () => {
+    // A node-managed account (MetaMask / json-rpc) has no in-process key, so
+    // signTransaction would hit eth_signTransaction (unsupported on public
+    // RPCs). The helper must defer to writeContract instead of pre-signing.
+    const wallet = mockWallet({ sendImpl: async () => EXPECTED_HASH });
+    const hash = await safeWriteContract(wallet, {
+      account: JSON_RPC_ACCOUNT,
+      chain: CHAIN,
+      address: ADDRESS,
+      abi: SAMPLE_ABI as any,
+      functionName: "ping",
+      args: [42n],
+    });
+    expect(hash).toBe(EXPECTED_HASH);
+    expect(wallet.writeContract).toHaveBeenCalledTimes(1);
+    expect(wallet.signTransaction).not.toHaveBeenCalled();
+    expect(wallet.sendRawTransaction).not.toHaveBeenCalled();
+    const wcArg = wallet.writeContract.mock.calls[0][0];
+    expect(wcArg.functionName).toBe("ping");
+    expect(wcArg.account).toBe(JSON_RPC_ACCOUNT);
+  });
+
+  it("falls back to writeContract when account is null (node-managed, matches old call path)", async () => {
     // Historical writeContract usage in this SDK is
     //   account: walletClient.account ?? null,
     //   chain:   walletClient.chain   ?? null,
-    // so the helper must accept null without throwing of its own accord and
-    // let viem do the same validation the old call path did.
+    // With no resolvable local account the helper defers to writeContract,
+    // exactly as the pre-existing call path did.
     const wallet = mockWallet({ sendImpl: async () => EXPECTED_HASH });
     const hash = await safeWriteContract(wallet, {
       account: null,
@@ -190,9 +218,10 @@ describe("safeWriteContract", () => {
       args: [42n],
     });
     expect(hash).toBe(EXPECTED_HASH);
-    const prepArg = wallet.prepareTransactionRequest.mock.calls[0][0];
-    expect(prepArg.account).toBeUndefined();
-    expect(prepArg.chain).toBeUndefined();
+    expect(wallet.writeContract).toHaveBeenCalledTimes(1);
+    const wcArg = wallet.writeContract.mock.calls[0][0];
+    expect(wcArg.account).toBeNull();
+    expect(wcArg.chain).toBeNull();
   });
 });
 

--- a/packages/sdk/__tests__/_tx-submit.test.ts
+++ b/packages/sdk/__tests__/_tx-submit.test.ts
@@ -25,6 +25,11 @@ const JSON_RPC_ACCOUNT = {
 
 const CHAIN = { id: 1315 } as any;
 
+// Minimal publicClient stub. The local (pre-sign) path never touches it; the
+// json-rpc path reads getTransactionCount/getBlockNumber best-effort (failures
+// are swallowed). Tests that exercise nonce recovery build their own.
+const PUBLIC = {} as any;
+
 const ADDRESS = "0xcccccc0000000000000000000000000000000005" as const;
 
 const SAMPLE_SERIALIZED =
@@ -61,7 +66,7 @@ function rpcErrLike(opts: { details?: string; message?: string; cause?: unknown 
 describe("safeWriteContract", () => {
   it("happy path: returns the hash from sendRawTransaction", async () => {
     const wallet = mockWallet({ sendImpl: async () => EXPECTED_HASH });
-    const hash = await safeWriteContract(wallet, {
+    const hash = await safeWriteContract(wallet, PUBLIC, {
       account: ACCOUNT,
       chain: CHAIN,
       address: ADDRESS,
@@ -85,7 +90,7 @@ describe("safeWriteContract", () => {
         });
       },
     });
-    const hash = await safeWriteContract(wallet, {
+    const hash = await safeWriteContract(wallet, PUBLIC, {
       account: ACCOUNT,
       chain: CHAIN,
       address: ADDRESS,
@@ -102,7 +107,7 @@ describe("safeWriteContract", () => {
         throw rpcErrLike({ details: "already known" });
       },
     });
-    const hash = await safeWriteContract(wallet, {
+    const hash = await safeWriteContract(wallet, PUBLIC, {
       account: ACCOUNT,
       chain: CHAIN,
       address: ADDRESS,
@@ -120,7 +125,7 @@ describe("safeWriteContract", () => {
       },
     });
     await expect(
-      safeWriteContract(wallet, {
+      safeWriteContract(wallet, PUBLIC, {
         account: ACCOUNT,
         chain: CHAIN,
         address: ADDRESS,
@@ -148,7 +153,7 @@ describe("safeWriteContract", () => {
         throw outer;
       },
     });
-    const hash = await safeWriteContract(wallet, {
+    const hash = await safeWriteContract(wallet, PUBLIC, {
       account: ACCOUNT,
       chain: CHAIN,
       address: ADDRESS,
@@ -169,7 +174,7 @@ describe("safeWriteContract", () => {
       },
     });
     await expect(
-      safeWriteContract(wallet, {
+      safeWriteContract(wallet, PUBLIC, {
         account: ACCOUNT,
         chain: CHAIN,
         address: ADDRESS,
@@ -185,7 +190,7 @@ describe("safeWriteContract", () => {
     // signTransaction would hit eth_signTransaction (unsupported on public
     // RPCs). The helper must defer to writeContract instead of pre-signing.
     const wallet = mockWallet({ sendImpl: async () => EXPECTED_HASH });
-    const hash = await safeWriteContract(wallet, {
+    const hash = await safeWriteContract(wallet, PUBLIC, {
       account: JSON_RPC_ACCOUNT,
       chain: CHAIN,
       address: ADDRESS,
@@ -209,7 +214,7 @@ describe("safeWriteContract", () => {
     // With no resolvable local account the helper defers to writeContract,
     // exactly as the pre-existing call path did.
     const wallet = mockWallet({ sendImpl: async () => EXPECTED_HASH });
-    const hash = await safeWriteContract(wallet, {
+    const hash = await safeWriteContract(wallet, PUBLIC, {
       account: null,
       chain: null,
       address: ADDRESS,
@@ -222,6 +227,49 @@ describe("safeWriteContract", () => {
     const wcArg = wallet.writeContract.mock.calls[0][0];
     expect(wcArg.account).toBeNull();
     expect(wcArg.chain).toBeNull();
+  });
+
+  it("JSON-RPC account: recovers the hash by (sender,nonce) block scan on a retry collision", async () => {
+    // The node-managed send collides (already in mempool) but writeContract
+    // never gave us the hash. We captured the pending nonce before sending and
+    // recover the hash by finding the mined tx with that (sender, nonce).
+    const FROM = JSON_RPC_ACCOUNT.address;
+    const RECOVERED = "0xdecafbad" as `0x${string}`;
+    const wallet = mockWallet({ sendImpl: async () => EXPECTED_HASH });
+    wallet.writeContract = vi.fn(async () => {
+      throw rpcErrLike({ details: "replacement transaction underpriced" });
+    });
+    const publicClient = {
+      getTransactionCount: vi.fn(async () => 7),
+      getBlockNumber: vi.fn(async () => 100n),
+      getBlock: vi.fn(async ({ blockNumber }: { blockNumber: bigint }) => {
+        // tx with (FROM, nonce 7) lands in block 101
+        if (blockNumber === 101n) {
+          return {
+            transactions: [
+              { from: "0x0000000000000000000000000000000000000001", nonce: 3, hash: "0xother" },
+              { from: FROM.toLowerCase(), nonce: 7, hash: RECOVERED },
+            ],
+          };
+        }
+        return { transactions: [] };
+      }),
+    } as any;
+    // head advances to 101 on the second poll
+    publicClient.getBlockNumber
+      .mockResolvedValueOnce(100n)
+      .mockResolvedValue(101n);
+
+    const hash = await safeWriteContract(wallet, publicClient, {
+      account: JSON_RPC_ACCOUNT,
+      chain: CHAIN,
+      address: ADDRESS,
+      abi: SAMPLE_ABI as any,
+      functionName: "ping",
+      args: [42n],
+    });
+    expect(hash).toBe(RECOVERED);
+    expect(publicClient.getTransactionCount).toHaveBeenCalledWith({ address: FROM, blockTag: "pending" });
   });
 });
 

--- a/packages/sdk/__tests__/_write-contract-mock.ts
+++ b/packages/sdk/__tests__/_write-contract-mock.ts
@@ -1,0 +1,35 @@
+import { vi } from "vitest";
+import { decodeFunctionData, type Abi } from "viem";
+
+/**
+ * Build a mock walletClient that supports `safeWriteContract`'s flow
+ * (`prepareTransactionRequest` → `signTransaction` → `sendRawTransaction`).
+ * Queue the broadcast hash via `walletClient.sendRawTransaction.mockResolvedValueOnce(...)`.
+ */
+export function makeWalletMock() {
+  return {
+    account: { address: "0xaaaa" } as const,
+    prepareTransactionRequest: vi.fn(async (args: any) => ({
+      ...args,
+      type: "eip1559",
+      nonce: 0,
+      gas: 21000n,
+      maxFeePerGas: 1n,
+      maxPriorityFeePerGas: 1n,
+    })),
+    signTransaction: vi.fn(async () => "0xsigned" as `0x${string}`),
+    sendRawTransaction: vi.fn(),
+  };
+}
+
+/**
+ * Decode a `safeWriteContract` invocation back into the writeContract-shape
+ * args `{ address, functionName, args, value }` so legacy assertions on
+ * `functionName` / `args` still work after the helper's encode/sign path.
+ */
+export function decodeWriteCalls(walletClient: any, abi: Abi) {
+  return (walletClient.prepareTransactionRequest.mock.calls as any[][]).map(([prep]) => {
+    const { functionName, args } = decodeFunctionData({ abi, data: prep.data });
+    return { address: prep.to, value: prep.value, functionName, args };
+  });
+}

--- a/packages/sdk/__tests__/_write-contract-mock.ts
+++ b/packages/sdk/__tests__/_write-contract-mock.ts
@@ -8,7 +8,9 @@ import { decodeFunctionData, type Abi } from "viem";
  */
 export function makeWalletMock() {
   return {
-    account: { address: "0xaaaa" } as const,
+    // type: "local" so safeWriteContract takes the pre-sign path these mocks
+    // exercise (prepareTransactionRequest → signTransaction → sendRawTransaction).
+    account: { address: "0xaaaa", type: "local" } as const,
     prepareTransactionRequest: vi.fn(async (args: any) => ({
       ...args,
       type: "eip1559",

--- a/packages/sdk/__tests__/consumer.test.ts
+++ b/packages/sdk/__tests__/consumer.test.ts
@@ -149,7 +149,7 @@ function mockClients(opts: { vaultEncryptedData?: `0x${string}` } = {}) {
   };
   const walletClient = {
     ...makeWalletMock(),
-    account: { address: "0xfeed" },
+    account: { address: "0xfeed", type: "local" },
     chain: { id: 1 },
   };
   walletClient.sendRawTransaction.mockResolvedValue("0xtxhash" as `0x${string}`);

--- a/packages/sdk/__tests__/consumer.test.ts
+++ b/packages/sdk/__tests__/consumer.test.ts
@@ -42,6 +42,8 @@ import {
 import { toHex } from "viem";
 import type { Observer } from "../src/observer.js";
 import type { DKGPartialDecryptionSubmission } from "../src/story-api/types.js";
+import { cdrAbi } from "@piplabs/cdr-contracts";
+import { makeWalletMock, decodeWriteCalls } from "./_write-contract-mock.js";
 
 const API_URL = "http://test:1317";
 const VALIDATOR_A = "0x0000000000000000000000000000000000000001" as const;
@@ -146,10 +148,11 @@ function mockClients(opts: { vaultEncryptedData?: `0x${string}` } = {}) {
     getBlockNumber: vi.fn().mockResolvedValue(1000n),
   };
   const walletClient = {
-    writeContract: vi.fn().mockResolvedValue("0xtxhash" as `0x${string}`),
+    ...makeWalletMock(),
     account: { address: "0xfeed" },
     chain: { id: 1 },
   };
+  walletClient.sendRawTransaction.mockResolvedValue("0xtxhash" as `0x${string}`);
   return { publicClient: publicClient as any, walletClient: walletClient as any };
 }
 
@@ -201,13 +204,12 @@ describe("Consumer", () => {
       expect(publicClient.readContract).toHaveBeenCalledWith(
         expect.objectContaining({ functionName: "readFee" }),
       );
-      expect(walletClient.writeContract).toHaveBeenCalledWith(
-        expect.objectContaining({
-          functionName: "read",
-          args: [42, "0x", "0x04abcd"],
-          value: 5n,
-        }),
-      );
+      const [call] = decodeWriteCalls(walletClient, cdrAbi);
+      expect(call).toMatchObject({
+        functionName: "read",
+        args: [42, "0x", "0x04abcd"],
+        value: 5n,
+      });
       expect(result.txHash).toBe("0xtxhash");
     });
 
@@ -220,9 +222,8 @@ describe("Consumer", () => {
         feeOverride: 99n,
       });
       expect(publicClient.readContract).not.toHaveBeenCalled();
-      expect(walletClient.writeContract).toHaveBeenCalledWith(
-        expect.objectContaining({ value: 99n }),
-      );
+      const [call] = decodeWriteCalls(walletClient, cdrAbi);
+      expect(call.value).toBe(99n);
     });
   });
 
@@ -700,7 +701,7 @@ describe("Consumer", () => {
       // Critical regression assertion: the preflight must run BEFORE any
       // fee-bearing read tx is submitted. If `read()` is called before the
       // empty check, the user pays for a request that can never succeed.
-      expect(walletClient.writeContract).not.toHaveBeenCalled();
+      expect(walletClient.sendRawTransaction).not.toHaveBeenCalled();
       // Also: the partial poll must never start.
       expect(queryCDRPartials).not.toHaveBeenCalled();
     });

--- a/packages/sdk/__tests__/upload-file.test.ts
+++ b/packages/sdk/__tests__/upload-file.test.ts
@@ -10,6 +10,7 @@ vi.mock("@piplabs/cdr-crypto", () => ({
 import { Uploader } from "../src/uploader.js";
 import { tdh2Encrypt, encryptFile } from "@piplabs/cdr-crypto";
 import { ContentSizeExceededError } from "../src/errors.js";
+import { makeWalletMock } from "./_write-contract-mock.js";
 import type { StorageProvider } from "../src/storage/types.js";
 import type { Observer } from "../src/observer.js";
 
@@ -60,10 +61,7 @@ function mockClients() {
     waitForTransactionReceipt: vi.fn(),
     simulateContract: vi.fn().mockRejectedValue({ cause: { name: "ContractFunctionRevertedError" } }),
   } as any;
-  const walletClient = {
-    writeContract: vi.fn(),
-    account: { address: "0xaaaa" },
-  } as any;
+  const walletClient = makeWalletMock() as any;
   return { publicClient, walletClient };
 }
 
@@ -102,14 +100,14 @@ describe("Uploader.uploadFile", () => {
 
     // allocateFee
     publicClient.readContract.mockResolvedValueOnce(1000n);
-    walletClient.writeContract.mockResolvedValueOnce("0xalloctx" as `0x${string}`);
+    walletClient.sendRawTransaction.mockResolvedValueOnce("0xalloctx" as `0x${string}`);
     publicClient.waitForTransactionReceipt.mockResolvedValueOnce({
       logs: [makeVaultAllocatedLog(42)],
     });
     // maxEncryptedDataSize check is now in `write`, served by Observer (mocked).
     // writeFee
     publicClient.readContract.mockResolvedValueOnce(200n);
-    walletClient.writeContract.mockResolvedValueOnce("0xwritetx" as `0x${string}`);
+    walletClient.sendRawTransaction.mockResolvedValueOnce("0xwritetx" as `0x${string}`);
     publicClient.waitForTransactionReceipt.mockResolvedValueOnce({});
 
     const uploader = new Uploader({
@@ -157,7 +155,7 @@ describe("Uploader.uploadFile", () => {
 
     // allocateFee
     publicClient.readContract.mockResolvedValueOnce(1000n);
-    walletClient.writeContract.mockResolvedValueOnce("0xalloctx" as `0x${string}`);
+    walletClient.sendRawTransaction.mockResolvedValueOnce("0xalloctx" as `0x${string}`);
     publicClient.waitForTransactionReceipt.mockResolvedValueOnce({
       logs: [makeVaultAllocatedLog(42)],
     });
@@ -178,6 +176,6 @@ describe("Uploader.uploadFile", () => {
     ).rejects.toThrow(ContentSizeExceededError);
 
     // Allocate happened (size check is in `write`, after allocate); write was NOT.
-    expect(walletClient.writeContract).toHaveBeenCalledOnce(); // allocate only
+    expect(walletClient.sendRawTransaction).toHaveBeenCalledOnce(); // allocate only
   });
 });

--- a/packages/sdk/__tests__/uploader.test.ts
+++ b/packages/sdk/__tests__/uploader.test.ts
@@ -11,6 +11,8 @@ import { Uploader } from "../src/uploader.js";
 import { tdh2Encrypt } from "@piplabs/cdr-crypto";
 import { ContentSizeExceededError } from "../src/errors.js";
 import type { Observer } from "../src/observer.js";
+import { cdrAbi } from "@piplabs/cdr-contracts";
+import { makeWalletMock, decodeWriteCalls } from "./_write-contract-mock.js";
 
 /**
  * Minimal Observer stub for Uploader unit tests. Uploader consults Observer
@@ -71,10 +73,7 @@ function mockClients() {
     getTransactionReceipt: vi.fn(),
     simulateContract: vi.fn().mockRejectedValue({ cause: { name: "ContractFunctionRevertedError" } }),
   } as any;
-  const walletClient = {
-    writeContract: vi.fn(),
-    account: { address: "0xaaaa" },
-  } as any;
+  const walletClient = makeWalletMock() as any;
   return { publicClient, walletClient };
 }
 
@@ -86,7 +85,7 @@ describe("Uploader", () => {
   it("allocate sends tx with correct fee and returns uuid from event", async () => {
     const { publicClient, walletClient } = mockClients();
     publicClient.readContract.mockResolvedValueOnce(1000n);
-    walletClient.writeContract.mockResolvedValueOnce("0xtxhash" as `0x${string}`);
+    walletClient.sendRawTransaction.mockResolvedValueOnce("0xtxhash" as `0x${string}`);
     publicClient.waitForTransactionReceipt.mockResolvedValueOnce({
       logs: [makeVaultAllocatedLog(42)],
     });
@@ -106,16 +105,17 @@ describe("Uploader", () => {
       readConditionData: "0x",
     });
 
-    expect(walletClient.writeContract).toHaveBeenCalledOnce();
-    const callArgs = walletClient.writeContract.mock.calls[0][0];
-    expect(callArgs.value).toBe(1000n);
+    expect(walletClient.sendRawTransaction).toHaveBeenCalledOnce();
+    const [call] = decodeWriteCalls(walletClient, cdrAbi);
+    expect(call.value).toBe(1000n);
+    expect(call.functionName).toBe("allocate");
     expect(result.uuid).toBe(42);
     expect(result.txHash).toBe("0xtxhash");
   });
 
   it("allocate uses feeOverride when provided and skips readContract", async () => {
     const { publicClient, walletClient } = mockClients();
-    walletClient.writeContract.mockResolvedValueOnce("0xtxhash2" as `0x${string}`);
+    walletClient.sendRawTransaction.mockResolvedValueOnce("0xtxhash2" as `0x${string}`);
     publicClient.waitForTransactionReceipt.mockResolvedValueOnce({
       logs: [makeVaultAllocatedLog(7)],
     });
@@ -136,8 +136,8 @@ describe("Uploader", () => {
       feeOverride: 500n,
     });
 
-    const callArgs = walletClient.writeContract.mock.calls[0][0];
-    expect(callArgs.value).toBe(500n);
+    const [call] = decodeWriteCalls(walletClient, cdrAbi);
+    expect(call.value).toBe(500n);
     expect(publicClient.readContract).not.toHaveBeenCalled();
     expect(result.uuid).toBe(7);
   });
@@ -145,7 +145,7 @@ describe("Uploader", () => {
   it("write sends tx with correct fee", async () => {
     const { publicClient, walletClient } = mockClients();
     publicClient.readContract.mockResolvedValueOnce(200n);
-    walletClient.writeContract.mockResolvedValueOnce("0xwritetx" as `0x${string}`);
+    walletClient.sendRawTransaction.mockResolvedValueOnce("0xwritetx" as `0x${string}`);
 
     const uploader = new Uploader({
       network: "testnet",
@@ -160,16 +160,16 @@ describe("Uploader", () => {
       encryptedData: "0xdeadbeef",
     });
 
-    expect(walletClient.writeContract).toHaveBeenCalledOnce();
-    const callArgs = walletClient.writeContract.mock.calls[0][0];
-    expect(callArgs.value).toBe(200n);
-    expect(callArgs.functionName).toBe("write");
+    expect(walletClient.sendRawTransaction).toHaveBeenCalledOnce();
+    const [call] = decodeWriteCalls(walletClient, cdrAbi);
+    expect(call.value).toBe(200n);
+    expect(call.functionName).toBe("write");
     expect(result.txHash).toBe("0xwritetx");
   });
 
   it("write uses feeOverride when provided and skips readContract", async () => {
     const { publicClient, walletClient } = mockClients();
-    walletClient.writeContract.mockResolvedValueOnce("0xwritetx2" as `0x${string}`);
+    walletClient.sendRawTransaction.mockResolvedValueOnce("0xwritetx2" as `0x${string}`);
 
     const uploader = new Uploader({
       network: "testnet",
@@ -185,14 +185,14 @@ describe("Uploader", () => {
       feeOverride: 99n,
     });
 
-    const callArgs = walletClient.writeContract.mock.calls[0][0];
-    expect(callArgs.value).toBe(99n);
+    const [call] = decodeWriteCalls(walletClient, cdrAbi);
+    expect(call.value).toBe(99n);
     expect(publicClient.readContract).not.toHaveBeenCalled();
   });
 
   it("parseVaultAllocatedUuid throws when no VaultAllocated event in logs", async () => {
     const { publicClient, walletClient } = mockClients();
-    walletClient.writeContract.mockResolvedValueOnce("0xtxhash" as `0x${string}`);
+    walletClient.sendRawTransaction.mockResolvedValueOnce("0xtxhash" as `0x${string}`);
     publicClient.waitForTransactionReceipt.mockResolvedValueOnce({ logs: [] });
 
     const uploader = new Uploader({
@@ -288,14 +288,14 @@ describe("Uploader", () => {
     ).rejects.toThrow(ContentSizeExceededError);
 
     // No tx ever submitted — fail-fast before writeContract.
-    expect(walletClient.writeContract).not.toHaveBeenCalled();
+    expect(walletClient.sendRawTransaction).not.toHaveBeenCalled();
     expect(observer.getMaxEncryptedDataSize).toHaveBeenCalledOnce();
   });
 
   it("write passes when encryptedData is within maxEncryptedDataSize", async () => {
     const { publicClient, walletClient } = mockClients();
     const observer = fakeObserver({ maxSize: 100n });
-    walletClient.writeContract.mockResolvedValueOnce("0xtxh" as `0x${string}`);
+    walletClient.sendRawTransaction.mockResolvedValueOnce("0xtxh" as `0x${string}`);
 
     const uploader = new Uploader({
       network: "testnet",
@@ -311,6 +311,6 @@ describe("Uploader", () => {
       feeOverride: 0n,
     });
 
-    expect(walletClient.writeContract).toHaveBeenCalledOnce();
+    expect(walletClient.sendRawTransaction).toHaveBeenCalledOnce();
   });
 });

--- a/packages/sdk/src/_rpc-resilience.ts
+++ b/packages/sdk/src/_rpc-resilience.ts
@@ -1,0 +1,62 @@
+import {
+  TransactionReceiptNotFoundError,
+  WaitForTransactionReceiptTimeoutError,
+  type Hash,
+  type PublicClient,
+} from "viem";
+
+/**
+ * Wraps `publicClient.waitForTransactionReceipt` for public RPC endpoints
+ * (e.g. `https://aeneid.storyrpc.io`) where receipt propagation can lag
+ * block production by tens of seconds for a small tail of txs.
+ *
+ * The key failure this guards against: viem observes the tx included in a
+ * block, immediately calls `eth_getTransactionReceipt`, and the pool node
+ * serving that call hasn't surfaced the receipt yet → viem throws
+ * `TransactionReceiptNotFoundError` out of its block-watcher callback. That
+ * throw does NOT respect the `timeout` / `retryCount` options — those cover
+ * the overall deadline and transport-level errors, not a receipt that is
+ * momentarily null after the block is seen. So bumping `timeout`/`retryCount`
+ * alone (the previous approach) still failed on this race:
+ *   - run 26379164817 wallet idx=29: allocate 0x914c3c... mined block
+ *     0x11d2547 status=1, viem gave up first (1/100 fail in 100w-fresh-aeneid)
+ *   - run 26501253421: uploadCDR write 0x8d1ae... committed block 0x11eb8d2
+ *     status=1, threw TransactionReceiptNotFoundError after ~8s, failing the
+ *     consumer feeOverride test (which itself never waits on a receipt — the
+ *     throw came from its uploadCDR preamble)
+ *
+ * Fix: re-poll the whole `waitForTransactionReceipt` on
+ * `TransactionReceiptNotFoundError` / `WaitForTransactionReceiptTimeoutError`,
+ * bounded by an overall 5 min deadline. A genuinely reverted tx returns a
+ * receipt with `status: "reverted"` (it does NOT throw), so this never masks
+ * a real revert. Test code has a mirror in
+ * `packages/sdk/__integration__/_rpc-resilience.ts`; the duplication is
+ * intentional — the SDK shouldn't take a dependency on test-only files.
+ */
+export async function waitForReceiptResilient(publicClient: PublicClient, hash: Hash) {
+  const deadlineMs = Date.now() + 5 * 60 * 1000;
+  let lastError: unknown;
+  while (Date.now() < deadlineMs) {
+    try {
+      return await publicClient.waitForTransactionReceipt({
+        hash,
+        timeout: 30_000,
+        pollingInterval: 2000,
+        retryCount: 10,
+      });
+    } catch (err) {
+      if (
+        !(err instanceof TransactionReceiptNotFoundError) &&
+        !(err instanceof WaitForTransactionReceiptTimeoutError)
+      ) {
+        throw err;
+      }
+      lastError = err;
+      await new Promise((resolve) => setTimeout(resolve, 2000));
+    }
+  }
+  // The loop always runs at least once (deadlineMs is now + 5 min), so
+  // lastError is always set here — the fallback is for the type-checker and
+  // to avoid a stackless `throw undefined` if the deadline logic ever changes.
+  throw lastError ?? new Error("waitForReceiptResilient: receipt wait deadline exceeded");
+}

--- a/packages/sdk/src/_tx-submit.ts
+++ b/packages/sdk/src/_tx-submit.ts
@@ -7,6 +7,7 @@ import {
   type Chain,
   type Hash,
   type Hex,
+  type PublicClient,
   type WalletClient,
 } from "viem";
 
@@ -20,63 +21,64 @@ export interface SafeWriteContractParams {
   value?: bigint;
 }
 
+// How long to keep looking for an already-broadcast tx (json-rpc recovery)
+// before giving up. The colliding tx is already in the pool, so it normally
+// mines within a few blocks; this is just a backstop.
+const NONCE_RECOVERY_DEADLINE_MS = 2 * 60 * 1000;
+const NONCE_RECOVERY_POLL_MS = 2000;
+
 /**
  * Idempotent replacement for `walletClient.writeContract(...)` against
  * shared/slow public RPCs.
  *
- * viem's default HTTP transport retries `eth_sendRawTransaction` on slow
- * acks. The first broadcast may have already landed in the mempool, so a
- * naive retry collides as a same-nonce non-bumped replacement and the
- * node rejects it with `replacement transaction underpriced` (surfaced
- * by viem as the misleading top-line `Missing or invalid parameters`).
- * See piplabs/cdr-sdk#122.
+ * viem's default HTTP transport retries `eth_sendRawTransaction` /
+ * `eth_sendTransaction` on slow acks. The first broadcast may have already
+ * landed in the mempool, so a naive retry collides as a same-nonce
+ * non-bumped replacement and the node rejects it with `replacement
+ * transaction underpriced` / `already known` (surfaced by viem as the
+ * misleading top-line `Missing or invalid parameters`). See
+ * piplabs/cdr-sdk#122. The error is not actionable — the tx really is in
+ * flight; the SDK just needs to learn its hash and wait on the receipt.
  *
- * The fix here pre-signs the tx so we know its hash up front, then
- * recognises the "already submitted" error family — `replacement
- * transaction underpriced` and `already known`, which unambiguously
- * mean *this exact tx* is already in flight — and returns the
- * precomputed hash so the caller can wait for the receipt as if the
- * original broadcast had succeeded. `nonce too low` is intentionally
- * NOT in this set: it can also mean a *different* tx consumed the
- * nonce, in which case ours never lands and the precomputed hash
- * would hang `waitForTransactionReceipt`.
+ * Two account types, two recovery mechanisms (both end at the real tx hash):
  *
- * Account types: only a LOCAL account (private key in-process, e.g.
- * `privateKeyToAccount`) can be signed without the node, which is what lets
- * us precompute the hash. A JSON-RPC account (browser wallet / MetaMask /
- * node-managed keystore) signs through the node (`eth_sendTransaction`) and
- * cannot be pre-signed locally — for those we fall back to viem's
- * `writeContract` (exactly the pre-existing call path). That fallback does
- * NOT get the retry-self-collision recovery, but it keeps JSON-RPC-account
- * wallets working.
+ * - LOCAL account (key in-process, e.g. `privateKeyToAccount`): we pre-sign
+ *   so we know the hash up front, then on an "already submitted" collision
+ *   return that precomputed hash.
+ * - JSON-RPC account (browser wallet / MetaMask / node-managed keystore): the
+ *   node signs via `eth_sendTransaction`, so we cannot pre-sign. We capture
+ *   the sender + pending nonce before sending, defer to `writeContract`, and
+ *   on a collision recover the hash by scanning for the mined tx with that
+ *   `(sender, nonce)`. There is no standard RPC to look a tx up by nonce, so
+ *   this is a bounded block scan — fine on a low-volume chain like aeneid.
+ *
+ * `nonce too low` is intentionally NOT treated as "already submitted": it can
+ * mean a *different* tx consumed the nonce, in which case ours never lands.
  */
 export async function safeWriteContract(
   walletClient: WalletClient,
+  publicClient: PublicClient,
   params: SafeWriteContractParams,
 ): Promise<Hash> {
-  // Decide whether we can sign locally (and thus precompute the hash). Only a
-  // local account (type === "local") holds the key in-process; a JSON-RPC
-  // account or bare address is signed by the node.
   const account = params.account ?? walletClient.account ?? null;
   const isLocalAccount =
     typeof account === "object" && account !== null && (account as Account).type === "local";
 
   if (!isLocalAccount) {
-    // Node-managed signer (MetaMask / JSON-RPC account / bare address): we
-    // cannot pre-sign to learn the hash, so defer to viem's writeContract —
-    // the same path the call sites used before this helper. No idempotent
-    // retry recovery on this path, but it keeps these wallets working.
-    return walletClient.writeContract({
-      account: params.account,
-      chain: params.chain,
-      address: params.address,
-      abi: params.abi,
-      functionName: params.functionName,
-      args: params.args as readonly unknown[],
-      value: params.value,
-    } as Parameters<typeof walletClient.writeContract>[0]);
+    return submitViaNode(walletClient, publicClient, params, account);
   }
 
+  return submitPreSigned(walletClient, params);
+}
+
+/**
+ * Local-account path: pre-sign to learn the hash, broadcast the raw tx, and
+ * return the precomputed hash on an already-submitted collision.
+ */
+async function submitPreSigned(
+  walletClient: WalletClient,
+  params: SafeWriteContractParams,
+): Promise<Hash> {
   const data: Hex = encodeFunctionData({
     abi: params.abi,
     functionName: params.functionName,
@@ -118,6 +120,105 @@ export async function safeWriteContract(
     }
     throw err;
   }
+}
+
+/**
+ * JSON-RPC-account path: the node signs, so we can't pre-sign. Capture the
+ * sender + pending nonce, defer to writeContract, and on an already-submitted
+ * collision recover the hash by finding the mined tx with that (sender, nonce).
+ */
+async function submitViaNode(
+  walletClient: WalletClient,
+  publicClient: PublicClient,
+  params: SafeWriteContractParams,
+  account: Account | Address | null,
+): Promise<Hash> {
+  const from = accountAddress(account);
+
+  // Capture (nonce, startBlock) BEFORE sending so a collision is recoverable.
+  // Best-effort: if these reads fail we still attempt the send and just can't
+  // recover a colliding hash (same as before this path existed).
+  let nonce: number | undefined;
+  let startBlock: bigint | undefined;
+  if (from) {
+    try {
+      nonce = await publicClient.getTransactionCount({ address: from, blockTag: "pending" });
+      startBlock = await publicClient.getBlockNumber();
+    } catch {
+      // ignore — recovery just won't be possible
+    }
+  }
+
+  try {
+    return await walletClient.writeContract({
+      account: params.account,
+      chain: params.chain,
+      address: params.address,
+      abi: params.abi,
+      functionName: params.functionName,
+      args: params.args as readonly unknown[],
+      value: params.value,
+    } as Parameters<typeof walletClient.writeContract>[0]);
+  } catch (err) {
+    if (
+      isAlreadySubmittedError(err) &&
+      from &&
+      nonce !== undefined &&
+      startBlock !== undefined
+    ) {
+      return recoverHashBySenderNonce(publicClient, from, nonce, startBlock);
+    }
+    throw err;
+  }
+}
+
+function accountAddress(account: Account | Address | null): Address | null {
+  if (typeof account === "string") return account;
+  if (account && typeof account === "object" && typeof (account as Account).address === "string") {
+    return (account as Account).address;
+  }
+  return null;
+}
+
+/**
+ * Find the hash of an already-broadcast tx by its (sender, nonce) — used to
+ * recover from a json-rpc retry self-collision where we never learned the
+ * hash. There is no standard RPC for nonce lookup, so we scan blocks from
+ * `fromBlock` forward (a given (sender, nonce) maps to at most one mined tx).
+ * Bounded by a deadline; throws if not found in time.
+ */
+async function recoverHashBySenderNonce(
+  publicClient: PublicClient,
+  from: Address,
+  nonce: number,
+  fromBlock: bigint,
+): Promise<Hash> {
+  const fromLc = from.toLowerCase();
+  const deadline = Date.now() + NONCE_RECOVERY_DEADLINE_MS;
+  let next = fromBlock;
+
+  while (Date.now() < deadline) {
+    const head = await publicClient.getBlockNumber();
+    for (; next <= head; next++) {
+      const block = await publicClient.getBlock({ blockNumber: next, includeTransactions: true });
+      for (const tx of block.transactions) {
+        if (
+          typeof tx === "object" &&
+          tx.from?.toLowerCase() === fromLc &&
+          tx.nonce === nonce
+        ) {
+          return tx.hash;
+        }
+      }
+    }
+    await new Promise((resolve) => setTimeout(resolve, NONCE_RECOVERY_POLL_MS));
+  }
+
+  throw new Error(
+    `safeWriteContract: tx was accepted by the node (already-in-mempool) but its hash ` +
+      `could not be recovered for sender ${from} nonce ${nonce} within ` +
+      `${NONCE_RECOVERY_DEADLINE_MS}ms`,
+  );
 }
 
 const ALREADY_SUBMITTED_PATTERNS = [

--- a/packages/sdk/src/_tx-submit.ts
+++ b/packages/sdk/src/_tx-submit.ts
@@ -40,11 +40,43 @@ export interface SafeWriteContractParams {
  * NOT in this set: it can also mean a *different* tx consumed the
  * nonce, in which case ours never lands and the precomputed hash
  * would hang `waitForTransactionReceipt`.
+ *
+ * Account types: only a LOCAL account (private key in-process, e.g.
+ * `privateKeyToAccount`) can be signed without the node, which is what lets
+ * us precompute the hash. A JSON-RPC account (browser wallet / MetaMask /
+ * node-managed keystore) signs through the node (`eth_sendTransaction`) and
+ * cannot be pre-signed locally — for those we fall back to viem's
+ * `writeContract` (exactly the pre-existing call path). That fallback does
+ * NOT get the retry-self-collision recovery, but it keeps JSON-RPC-account
+ * wallets working.
  */
 export async function safeWriteContract(
   walletClient: WalletClient,
   params: SafeWriteContractParams,
 ): Promise<Hash> {
+  // Decide whether we can sign locally (and thus precompute the hash). Only a
+  // local account (type === "local") holds the key in-process; a JSON-RPC
+  // account or bare address is signed by the node.
+  const account = params.account ?? walletClient.account ?? null;
+  const isLocalAccount =
+    typeof account === "object" && account !== null && (account as Account).type === "local";
+
+  if (!isLocalAccount) {
+    // Node-managed signer (MetaMask / JSON-RPC account / bare address): we
+    // cannot pre-sign to learn the hash, so defer to viem's writeContract —
+    // the same path the call sites used before this helper. No idempotent
+    // retry recovery on this path, but it keeps these wallets working.
+    return walletClient.writeContract({
+      account: params.account,
+      chain: params.chain,
+      address: params.address,
+      abi: params.abi,
+      functionName: params.functionName,
+      args: params.args as readonly unknown[],
+      value: params.value,
+    } as Parameters<typeof walletClient.writeContract>[0]);
+  }
+
   const data: Hex = encodeFunctionData({
     abi: params.abi,
     functionName: params.functionName,

--- a/packages/sdk/src/_tx-submit.ts
+++ b/packages/sdk/src/_tx-submit.ts
@@ -1,0 +1,122 @@
+import {
+  encodeFunctionData,
+  keccak256,
+  type Abi,
+  type Account,
+  type Address,
+  type Chain,
+  type Hash,
+  type Hex,
+  type WalletClient,
+} from "viem";
+
+export interface SafeWriteContractParams {
+  account: Account | Address | null;
+  chain: Chain | null;
+  address: Address;
+  abi: Abi;
+  functionName: string;
+  args: readonly unknown[];
+  value?: bigint;
+}
+
+/**
+ * Idempotent replacement for `walletClient.writeContract(...)` against
+ * shared/slow public RPCs.
+ *
+ * viem's default HTTP transport retries `eth_sendRawTransaction` on slow
+ * acks. The first broadcast may have already landed in the mempool, so a
+ * naive retry collides as a same-nonce non-bumped replacement and the
+ * node rejects it with `replacement transaction underpriced` (surfaced
+ * by viem as the misleading top-line `Missing or invalid parameters`).
+ * See piplabs/cdr-sdk#122.
+ *
+ * The fix here pre-signs the tx so we know its hash up front, then
+ * recognises the "already submitted" error family — `replacement
+ * transaction underpriced` and `already known`, which unambiguously
+ * mean *this exact tx* is already in flight — and returns the
+ * precomputed hash so the caller can wait for the receipt as if the
+ * original broadcast had succeeded. `nonce too low` is intentionally
+ * NOT in this set: it can also mean a *different* tx consumed the
+ * nonce, in which case ours never lands and the precomputed hash
+ * would hang `waitForTransactionReceipt`.
+ */
+export async function safeWriteContract(
+  walletClient: WalletClient,
+  params: SafeWriteContractParams,
+): Promise<Hash> {
+  const data: Hex = encodeFunctionData({
+    abi: params.abi,
+    functionName: params.functionName,
+    args: params.args as readonly unknown[],
+  });
+
+  // null is the historical writeContract sentinel for "no override" — viem
+  // accepts it (and validates internally). Coerce to undefined so the typed
+  // surface of prepareTransactionRequest matches.
+  const request = await walletClient.prepareTransactionRequest({
+    account: params.account ?? undefined,
+    chain: params.chain ?? undefined,
+    to: params.address,
+    data,
+    value: params.value,
+  } as Parameters<typeof walletClient.prepareTransactionRequest>[0]);
+
+  // `signTransaction` calls `assertCurrentChain`, which throws if no chain
+  // is in scope. `prepareTransactionRequest` only stores `chainId` on its
+  // result, not a Chain object — so we synthesize a minimal one from the
+  // request when the caller didn't supply chain explicitly. The full
+  // writeContract path does the equivalent internally.
+  const requestChainId = (request as { chainId?: number }).chainId;
+  const chainForSigning: Chain | undefined =
+    params.chain ??
+    (typeof requestChainId === "number" ? ({ id: requestChainId } as Chain) : undefined);
+
+  const serialized = await walletClient.signTransaction({
+    ...request,
+    chain: chainForSigning,
+  } as Parameters<typeof walletClient.signTransaction>[0]);
+  const expectedHash = keccak256(serialized);
+
+  try {
+    return await walletClient.sendRawTransaction({ serializedTransaction: serialized });
+  } catch (err) {
+    if (isAlreadySubmittedError(err)) {
+      return expectedHash;
+    }
+    throw err;
+  }
+}
+
+const ALREADY_SUBMITTED_PATTERNS = [
+  "replacement transaction underpriced",
+  "already known",
+];
+
+/**
+ * Recognise the JSON-RPC error family that means "the tx is already in
+ * flight" — i.e. the SDK should treat the submission as successful and
+ * proceed to wait for the receipt.
+ *
+ * viem maps the real `-32000` reason into a generic top-line
+ * `shortMessage`, so we walk the `cause` chain and match on `details` /
+ * `message` of every link.
+ */
+export function isAlreadySubmittedError(err: unknown): boolean {
+  let cur: unknown = err;
+  let depth = 0;
+  while (cur && typeof cur === "object" && depth < 10) {
+    const c = cur as { details?: unknown; message?: unknown; cause?: unknown };
+    const haystacks: string[] = [];
+    if (typeof c.details === "string") haystacks.push(c.details.toLowerCase());
+    if (typeof c.message === "string") haystacks.push(c.message.toLowerCase());
+    for (const h of haystacks) {
+      for (const pat of ALREADY_SUBMITTED_PATTERNS) {
+        if (h.includes(pat)) return true;
+      }
+    }
+    cur = c.cause;
+    depth++;
+  }
+  return false;
+}

--- a/packages/sdk/src/_tx-submit.ts
+++ b/packages/sdk/src/_tx-submit.ts
@@ -12,8 +12,11 @@ import {
 } from "viem";
 
 export interface SafeWriteContractParams {
-  account: Account | Address | null;
-  chain: Chain | null;
+  // account / chain default to the walletClient's own when omitted (matching
+  // the historical `walletClient.account ?? null` / `walletClient.chain ?? null`
+  // call sites). Pass explicitly only to override.
+  account?: Account | Address | null;
+  chain?: Chain | null;
   address: Address;
   abi: Abi;
   functionName: string;
@@ -60,15 +63,20 @@ export async function safeWriteContract(
   publicClient: PublicClient,
   params: SafeWriteContractParams,
 ): Promise<Hash> {
+  // Resolve account/chain from the walletClient when the caller omitted them,
+  // so every call site stops repeating `walletClient.account ?? null` etc.
   const account = params.account ?? walletClient.account ?? null;
+  const chain = params.chain ?? walletClient.chain ?? null;
+  const resolved: SafeWriteContractParams = { ...params, account, chain };
+
   const isLocalAccount =
     typeof account === "object" && account !== null && (account as Account).type === "local";
 
   if (!isLocalAccount) {
-    return submitViaNode(walletClient, publicClient, params, account);
+    return submitViaNode(walletClient, publicClient, resolved, account);
   }
 
-  return submitPreSigned(walletClient, params);
+  return submitPreSigned(walletClient, resolved);
 }
 
 /**

--- a/packages/sdk/src/consumer.ts
+++ b/packages/sdk/src/consumer.ts
@@ -138,8 +138,6 @@ export class Consumer {
     });
 
     const txHash = await safeWriteContract(this.walletClient, this.publicClient, {
-      chain: this.walletClient.chain ?? null,
-      account: this.walletClient.account ?? null,
       address: cdrAddress,
       abi: cdrAbi,
       functionName: "read",

--- a/packages/sdk/src/consumer.ts
+++ b/packages/sdk/src/consumer.ts
@@ -21,6 +21,7 @@ import { Observer } from "./observer.js";
 import { verifyAttestation, type AttestationConfig } from "./attestation.js";
 import { queryCDRPartials } from "./story-api/client.js";
 import type { DKGPartialDecryptionSubmission } from "./story-api/types.js";
+import { safeWriteContract } from "./_tx-submit.js";
 
 /**
  * Consumer reads encrypted vault data from the CDR contract and recovers the
@@ -136,7 +137,7 @@ export class Consumer {
       functionName: "readFee",
     });
 
-    const txHash = await this.walletClient.writeContract({
+    const txHash = await safeWriteContract(this.walletClient, {
       chain: this.walletClient.chain ?? null,
       account: this.walletClient.account ?? null,
       address: cdrAddress,

--- a/packages/sdk/src/consumer.ts
+++ b/packages/sdk/src/consumer.ts
@@ -137,7 +137,7 @@ export class Consumer {
       functionName: "readFee",
     });
 
-    const txHash = await safeWriteContract(this.walletClient, {
+    const txHash = await safeWriteContract(this.walletClient, this.publicClient, {
       chain: this.walletClient.chain ?? null,
       account: this.walletClient.account ?? null,
       address: cdrAddress,

--- a/packages/sdk/src/uploader.ts
+++ b/packages/sdk/src/uploader.ts
@@ -164,8 +164,6 @@ export class Uploader {
     });
 
     const txHash = await safeWriteContract(this.walletClient, this.publicClient, {
-      chain: this.walletClient.chain ?? null,
-      account: this.walletClient.account ?? null,
       address: cdrAddress,
       abi: cdrAbi,
       functionName: "allocate",
@@ -246,8 +244,6 @@ export class Uploader {
     });
 
     const txHash = await safeWriteContract(this.walletClient, this.publicClient, {
-      chain: this.walletClient.chain ?? null,
-      account: this.walletClient.account ?? null,
       address: cdrAddress,
       abi: cdrAbi,
       functionName: "write",

--- a/packages/sdk/src/uploader.ts
+++ b/packages/sdk/src/uploader.ts
@@ -5,6 +5,7 @@ import { uuidToLabel } from "./label.js";
 import { ContentSizeExceededError, LabelMismatchError, InvalidConditionContractError } from "./errors.js";
 import type { StorageProvider } from "./storage/types.js";
 import { Observer } from "./observer.js";
+import { safeWriteContract } from "./_tx-submit.js";
 
 /**
  * Wraps `publicClient.waitForTransactionReceipt` for public RPC endpoints
@@ -162,7 +163,7 @@ export class Uploader {
       functionName: "allocateFee",
     });
 
-    const txHash = await this.walletClient.writeContract({
+    const txHash = await safeWriteContract(this.walletClient, {
       chain: this.walletClient.chain ?? null,
       account: this.walletClient.account ?? null,
       address: cdrAddress,
@@ -244,7 +245,7 @@ export class Uploader {
       functionName: "writeFee",
     });
 
-    const txHash = await this.walletClient.writeContract({
+    const txHash = await safeWriteContract(this.walletClient, {
       chain: this.walletClient.chain ?? null,
       account: this.walletClient.account ?? null,
       address: cdrAddress,

--- a/packages/sdk/src/uploader.ts
+++ b/packages/sdk/src/uploader.ts
@@ -163,7 +163,7 @@ export class Uploader {
       functionName: "allocateFee",
     });
 
-    const txHash = await safeWriteContract(this.walletClient, {
+    const txHash = await safeWriteContract(this.walletClient, this.publicClient, {
       chain: this.walletClient.chain ?? null,
       account: this.walletClient.account ?? null,
       address: cdrAddress,
@@ -245,7 +245,7 @@ export class Uploader {
       functionName: "writeFee",
     });
 
-    const txHash = await safeWriteContract(this.walletClient, {
+    const txHash = await safeWriteContract(this.walletClient, this.publicClient, {
       chain: this.walletClient.chain ?? null,
       account: this.walletClient.account ?? null,
       address: cdrAddress,

--- a/packages/sdk/src/uploader.ts
+++ b/packages/sdk/src/uploader.ts
@@ -1,4 +1,4 @@
-import { parseEventLogs, toHex, toBytes, TransactionReceiptNotFoundError, WaitForTransactionReceiptTimeoutError, type Hash, type PublicClient, type WalletClient } from "viem";
+import { parseEventLogs, toHex, toBytes, type PublicClient, type WalletClient } from "viem";
 import { cdrAbi, contractAddresses, type Network } from "@piplabs/cdr-contracts";
 import { tdh2Encrypt, encryptFile, getWasm, type TDH2Ciphertext } from "@piplabs/cdr-crypto";
 import { uuidToLabel } from "./label.js";
@@ -6,62 +6,7 @@ import { ContentSizeExceededError, LabelMismatchError, InvalidConditionContractE
 import type { StorageProvider } from "./storage/types.js";
 import { Observer } from "./observer.js";
 import { safeWriteContract } from "./_tx-submit.js";
-
-/**
- * Wraps `publicClient.waitForTransactionReceipt` for public RPC endpoints
- * (e.g. `https://aeneid.storyrpc.io`) where receipt propagation can lag
- * block production by tens of seconds for a small tail of txs.
- *
- * The key failure this guards against: viem observes the tx included in a
- * block, immediately calls `eth_getTransactionReceipt`, and the pool node
- * serving that call hasn't surfaced the receipt yet → viem throws
- * `TransactionReceiptNotFoundError` out of its block-watcher callback. That
- * throw does NOT respect the `timeout` / `retryCount` options — those cover
- * the overall deadline and transport-level errors, not a receipt that is
- * momentarily null after the block is seen. So bumping `timeout`/`retryCount`
- * alone (the previous approach) still failed on this race:
- *   - run 26379164817 wallet idx=29: allocate 0x914c3c... mined block
- *     0x11d2547 status=1, viem gave up first (1/100 fail in 100w-fresh-aeneid)
- *   - run 26501253421: uploadCDR write 0x8d1ae... committed block 0x11eb8d2
- *     status=1, threw TransactionReceiptNotFoundError after ~8s, failing the
- *     consumer feeOverride test (which itself never waits on a receipt — the
- *     throw came from its uploadCDR preamble)
- *
- * Fix: re-poll the whole `waitForTransactionReceipt` on
- * `TransactionReceiptNotFoundError` / `WaitForTransactionReceiptTimeoutError`,
- * bounded by an overall 5 min deadline. A genuinely reverted tx returns a
- * receipt with `status: "reverted"` (it does NOT throw), so this never masks
- * a real revert. Test code has a mirror in
- * `packages/sdk/__integration__/_rpc-resilience.ts`; the duplication is
- * intentional — the SDK shouldn't take a dependency on test-only files.
- */
-async function waitForReceiptResilient(publicClient: PublicClient, hash: Hash) {
-  const deadlineMs = Date.now() + 5 * 60 * 1000;
-  let lastError: unknown;
-  while (Date.now() < deadlineMs) {
-    try {
-      return await publicClient.waitForTransactionReceipt({
-        hash,
-        timeout: 30_000,
-        pollingInterval: 2000,
-        retryCount: 10,
-      });
-    } catch (err) {
-      if (
-        !(err instanceof TransactionReceiptNotFoundError) &&
-        !(err instanceof WaitForTransactionReceiptTimeoutError)
-      ) {
-        throw err;
-      }
-      lastError = err;
-      await new Promise((resolve) => setTimeout(resolve, 2000));
-    }
-  }
-  // The loop always runs at least once (deadlineMs is now + 5 min), so
-  // lastError is always set here — the fallback is for the type-checker and
-  // to avoid a stackless `throw undefined` if the deadline logic ever changes.
-  throw lastError ?? new Error("waitForReceiptResilient: receipt wait deadline exceeded");
-}
+import { waitForReceiptResilient } from "./_rpc-resilience.js";
 
 export class Uploader {
   private publicClient: PublicClient;


### PR DESCRIPTION
## Summary

- Pre-sign + idempotent-recovery helper (`safeWriteContract`) replaces direct `walletClient.writeContract(...)` for the three SDK write sites (`Consumer.read`, `Uploader.allocate`, `Uploader.write`). Recovers from the `replacement transaction underpriced` / `already known` retry-self-collision family by returning the precomputed tx hash so the caller can still wait on the receipt. `nonce too low` is **not** in the recovery set — it can also mean a different tx consumed the nonce, in which case ours never lands and the precomputed hash would hang `waitForTransactionReceipt`; safer to surface the error.
- `waitForReceiptResilient` from #115 is preserved on the receipt-wait side — the two shared-RPC flakes (send retry self-collision vs receipt-not-found race) are now layered defenses.
- Existing unit-test mocks moved to the new `prepareTransactionRequest` + `signTransaction` + `sendRawTransaction` triplet via shared `_write-contract-mock.ts`; assertions on `functionName` / `args` decode the encoded `data` rather than reading `writeContract`'s args.
- Closes #122.

## Why

viem's default HTTP transport retries `eth_sendRawTransaction` on slow acks. The first broadcast can already be in the mempool, and the retry — same nonce, no gas bump — gets rejected as `replacement transaction underpriced` (surfaced misleadingly by viem as the top-line `Missing or invalid parameters`). On the shared aeneid public RPC this fires intermittently and fails `cdr-monitor` + `ACC-04c` runs (regression #79). The error itself is not actionable — the tx really is in flight; the SDK just doesn't know its hash to wait on.

`safeWriteContract` pre-signs locally to learn the hash up front, then walks the error `cause` chain and matches on `details` / `message` of every link to detect "already submitted" errors. On a match it returns the precomputed hash; on any other error it re-throws unchanged.

## Test plan

- [x] SDK unit suite: `pnpm -F sdk test` → 203 passed | 23 skipped
- [x] `__tests__/_tx-submit.test.ts` (new, 20 cases): happy path, recovery from each pattern, nested-cause walk, fatal re-throw, **explicit re-throw on `nonce too low`**, null chain/account pass-through, cyclic-cause guard
- [x] DevNet integration (`__integration__/uploader.test.ts`): 12/12 passed in 50s — `allocate` + `write` + `uploadCDR` full flow + `feeOverride` revert path all green through the new helper *and* `waitForReceiptResilient` from PR #115
- [ ] Aeneid `cdr-monitor` workflow: validate flake rate drops to 0 over the next ~24h after merge

## Notes

- `signTransaction`'s `assertCurrentChain` requires a Chain object; viem's writeContract threads it implicitly. We synthesise one from the prepared request's `chainId` when no explicit chain was supplied, so existing `chain: walletClient.chain ?? null` call sites keep working.
- Public SDK API surface unchanged. No new constructor params, no peer-dep bumps.