### PR TITLE
fix(release): run audit step on Node 22 (pnpm 11 engine requirement)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,8 +94,14 @@ jobs:
       - run: pnpm install --frozen-lockfile
 
       # Supply-chain pre-flight: fail on high+ severity vulns in shipped deps.
-      # pnpm 11 would self-delegate back to the `packageManager` pin, so audit a 
-      # pin-stripped copy of the lockfile in a temp dir instead.
+      # pnpm >=11 is the only line that speaks npm's current bulk advisory
+      # endpoint (older endpoints return HTTP 410), and it needs Node >=22.13
+      # (node:sqlite) — switch Node for this step only; restored right after.
+      # pnpm 11 would also self-delegate back to the `packageManager` pin, so
+      # audit a pin-stripped copy of the lockfile in a temp dir instead.
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
       - name: Audit production dependencies
         run: |
           AUDIT_DIR="$(mktemp -d)"
@@ -119,6 +125,12 @@ jobs:
             exit 1
           fi
           echo "No high+ severity vulnerabilities in production deps."
+
+      # Restore the release build environment (deps were already installed
+      # under Node 20 above; no cache param needed here).
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
 
       - run: pnpm -r run build
 


### PR DESCRIPTION
## Summary

The release run failed at the audit step: pnpm ≥11 requires Node ≥22.13 for `node:sqlite`, and the runner is on Node 20, so `npx pnpm@11` crashed before producing JSON.

Fix: switch to Node 22 for the audit step only (`actions/setup-node` before, restored to 20 right after). The rest of the release — install, build, tarball dry-run, publish — stays on Node 20 like every other workflow in the repo.

## Test plan

- [x] Exact step script run locally under Node 22.21.1 (what `setup-node: '22'` resolves) against main's lockfile: pnpm 11 audits via the bulk endpoint, 0 high+critical, exit 0
- [x] YAML parses; step order verified: install (20) → audit (22) → restore (20) → build → dry-run
- [x] `pnpm -r publish --dry-run` with versions bumped to 0.2.2 packs all four packages
- [ ] Audit gate passes on the next `0.2.2` dispatch

## Context

Follow-up to #130; unblocks the v0.2.2 release. Repo-wide Node 20 → 22 bump (Node 20 is past EOL) is a separate follow-up that would remove this Node-swap entirely.