### PR TITLE
chore: release v0.2.2 (retry: pin npm@11 for Node 20)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -247,8 +247,9 @@ jobs:
           cache: pnpm
 
       # npm 11+ is required for the OIDC Trusted Publisher token exchange.
+      # Pinned to the 11 line: npm 12 dropped Node 20 support.
       - name: Upgrade npm to support OIDC Trusted Publisher
-        run: npm install -g npm@latest
+        run: npm install -g npm@11
 
       # Record the previous release tag before adding the new one, for notes.
       - name: Capture previous release tag


### PR DESCRIPTION
## Summary

The v0.2.2 publish run failed at the "Upgrade npm" step: `npm install -g npm@latest` now resolves to npm 12, which dropped Node 20 support (v0.2.1 published back when `latest` was still 11.x). 

Fix: pin the upgrade to `npm@11` (11.18.0: engines `^20.17.0 || >=22.9.0`, and OIDC trusted publishing needs only ≥11).

**Squash-merge with this PR title as-is** — the `chore: release v` prefix is the publish marker. The version bump already landed via #132, so on merge `detect` sees 0.2.2 ahead of npm + marker and fires the publish job with the fixed workflow file (a re-run of the failed run would use the old workflow; a re-dispatch of phase 1 would no-op on the already-bumped manifests).

## Test plan

- [x] `npm view npm@11`: 11.18.0, engines compatible with the runner's Node 20
- [x] YAML parses; no other `npm@latest` in workflows
- [ ] Publish job passes the npm upgrade step and completes the v0.2.2 release