### PR TITLE
ci(post-release): add force_e2e dispatch input to run E2E despite ver…

### DIFF
--- a/.github/workflows/post-release-integration.yml
+++ b/.github/workflows/post-release-integration.yml
@@ -22,6 +22,11 @@ on:
         description: 'Version to verify (empty = resolve from npm latest)'
         required: false
         default: ''
+      force_e2e:
+        description: 'Run e2e-aeneid even if verify failed (burns ~0.1 IP; use only when the verify failures are known to be non-functional)'
+        required: false
+        type: boolean
+        default: false
 
 # Coalesce concurrent runs that target the same version. We don't
 # cancel-in-progress — a manual rerun while the auto-run is still going
@@ -445,7 +450,13 @@ jobs:
     # Sequential after `verify` (not parallel): if the install / audit /
     # smoke gates already failed, the artifact is known-broken and we
     # don't want to burn Aeneid test IP confirming the obvious.
+    # Exception: a human dispatch with force_e2e=true runs E2E despite a
+    # failed `verify` — for releases where the verify failures are known
+    # to be non-functional 
     needs: [prepare, verify]
+    if: >
+      always() && needs.prepare.result == 'success' &&
+      (needs.verify.result == 'success' || inputs.force_e2e == true)
     runs-on: ubuntu-latest
     timeout-minutes: 15
     env:


### PR DESCRIPTION
## Summary

`e2e-aeneid` skips whenever `verify` fails — by design, to avoid burning Aeneid test IP on known-broken artifacts. But v0.2.2 showed `verify` can fail on **non-functional** issues (#134 stale CLI version label, #135 CJS smoke-gate conflict) that don't touch the on-chain path, leaving the release with no E2E evidence.

This adds a `force_e2e` boolean dispatch input (default `false`): a human dispatch with it set runs `e2e-aeneid` even when `verify` failed (`prepare` must still succeed). The Release workflow's automatic dispatch never sets it, so fail-fast behavior for real releases is unchanged.

## Test plan

- [x] YAML parses; gate condition verified: `always() && prepare == success && (verify == success || force_e2e)`
- [ ] Post-merge: dispatch with `version: 0.2.2` + `force_e2e: true` — expect `verify` red on the two known checks, `e2e-aeneid` runs and passes