### PR TITLE
fix(post-release): use selector-aware open-condition fixture in e2e harness + add harness_ref input

### DIFF
--- a/.github/scripts/post-release-aeneid-e2e.mjs
+++ b/.github/scripts/post-release-aeneid-e2e.mjs
@@ -146,12 +146,8 @@ try {
     walletClient: subWallet,
     apiUrl: API_URL,
   });
-
-  // 10-byte returns-1 bytecode — open-condition fixture matching the
-  // examples / ephemeral-wallets suites. Always returns 1, so the
-  // upload/access flow is gated only by CDR contract logic itself.
   const openConditionBytecode =
-    "0x600a600c600039600a6000f3600160005260206000f3";
+    "0x602a600c600039602a6000f360003560e01c80635645dbbf14601f5780638db3eb1714601f5760006000fd5b600160005260206000f3";
   const deployTx = await subWallet.sendTransaction({
     data: openConditionBytecode,
     chain: subWallet.chain ?? null,

--- a/.github/workflows/post-release-integration.yml
+++ b/.github/workflows/post-release-integration.yml
@@ -27,6 +27,10 @@ on:
         required: false
         type: boolean
         default: false
+      harness_ref:
+        description: 'Git ref for the e2e harness checkout (empty = the vX.Y.Z tag under test). Set to main when the tagged harness has a test-only bug — tags are immutable, so harness fixes can never reach them.'
+        required: false
+        default: ''
 
 # Coalesce concurrent runs that target the same version. We don't
 # cancel-in-progress — a manual rerun while the auto-run is still going
@@ -469,10 +473,12 @@ jobs:
       # setup-node / install step environments.
     steps:
       # Pin checkout to the release revision so the harness file is
-      # always the one that shipped with the tarball under test. 
+      # always the one that shipped with the tarball under test.
+      # harness_ref overrides the pin for test-only harness fixes that
+      # postdate the (immutable) tag.
       - uses: actions/checkout@v4
         with:
-          ref: ${{ format('v{0}', needs.prepare.outputs.version) }}
+          ref: ${{ inputs.harness_ref || format('v{0}', needs.prepare.outputs.version) }}
       - uses: actions/setup-node@v4
         with:
           node-version: '20'


### PR DESCRIPTION
## Summary

Follow-up to #136. The forced E2E run for v0.2.2 ([run 29478737366](https://github.com/piplabs/cdr-sdk/actions/runs/29478737366)) failed at upload: the harness deploys a pre-#99 10-byte catch-all-fallback fixture as its open condition, which v0.2.2's condition preflight (#99) conservatively rejects — working as designed. #99 migrated the integration suites to a selector-aware fixture (`OPEN_CONDITION_BYTECODE` in `__integration__/_helpers.ts`) that answers only the real `checkWriteCondition`/`checkReadCondition` selectors and cleanly reverts otherwise; the harness (written in #105) copied the stale fixture instead.

The harness now uses the same selector-aware bytecode — so the E2E exercises the preflight-accept path exactly like a real consumer's condition contract, with no `skipConditionValidation` bypass.

Also adds a `harness_ref` dispatch input (empty = the version tag, unchanged default): the e2e job pins its harness checkout to the immutable version tag, so harness-only fixes like this one could otherwise never reach a run targeting an already-cut release.

## Test plan

- [x] Fixture selectors verified against the v0.2.2 preflight: `0x5645dbbf`/`0x8db3eb17` = `checkWriteCondition`/`checkReadCondition(uint32,bytes,bytes,address)`; sentinel probe hits `revert(0,0)` = clean miss
- [x] Byte layout verified: 42-byte runtime matches the `0x2a` deploy header; jumpdest offset `0x1f` matches both jumpi targets
- [x] Same fixture runs green routinely in the Aeneid integration suites against the same SDK code (no bypass flag there either)
- [x] `node --check` clean; workflow YAML parses; checkout ref = `inputs.harness_ref || format('v{0}', version)`
- [ ] Post-merge: dispatch with `version: 0.2.2`, `force_e2e: true`, `harness_ref: main` — expect `e2e-aeneid` green 