### PR TITLE
fix(integration): reduce ephemeral-wallet concurrency on aeneid, point devnet at the rebuilt qa2 host

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -28,6 +28,13 @@ on:
           - 1000-wallet-performance-devnet-only
           - 1H-stress-devnet-only
         default: default
+      concurrent_wallet_count:
+        type: string
+        description: >-
+          Override CDR_WALLET_COUNT for the ephemeral-wallet suites (empty =
+          network default: 50 on aeneid, 100 on devnet)
+        required: false
+        default: ''
   # Reusable-workflow entrypoint for cdr-monitor-per-round.yml. Strings (not
   # `choice`) because `workflow_call` doesn't support choice — callers MUST
   # pass values from the same set as workflow_dispatch's options or the
@@ -191,11 +198,19 @@ jobs:
               echo "CDR_RPC_URL=https://aeneid.storyrpc.io" >> $GITHUB_ENV
               echo "CDR_TEST_PRIVATE_KEY=${{ secrets.CDR_AENEID_TEST_PRIVATE_KEY }}" >> $GITHUB_ENV
               # The public aeneid RPC rate-limits under burst load; run the
-              # ephemeral-wallet suites at reduced concurrency there
-              # (devnet keeps the full 100).
-              echo "CDR_WALLET_COUNT=25" >> $GITHUB_ENV
+              # ephemeral-wallet suites at reduced concurrency there.
+              # Precedence: dispatch input > repo variable
+              # CDR_AENEID_WALLET_COUNT > hardcoded 50. Devnet keeps the
+              # suites' built-in default (100) unless the input is set.
+              echo "CDR_WALLET_COUNT=${{ inputs.concurrent_wallet_count || vars.CDR_AENEID_WALLET_COUNT || '50' }}" >> $GITHUB_ENV
               ;;
           esac
+
+          # Explicit per-run override applies on any network.
+          WC="${{ inputs.concurrent_wallet_count }}"
+          if [ -n "$WC" ]; then
+            echo "CDR_WALLET_COUNT=$WC" >> $GITHUB_ENV
+          fi
 
       - name: Verify env populated
         run: |

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -180,14 +180,20 @@ jobs:
         run: |
           case "$NETWORK" in
             devnet)
-              echo "CDR_API_URL=http://172.207.250.203:1317" >> $GITHUB_ENV
-              echo "CDR_RPC_URL=http://172.207.250.203:8545" >> $GITHUB_ENV
+              # qa2 canonical devnet, validator-1 (rebuilt 2026-07; the old
+              # 172.207.250.203 devnet was torn down)
+              echo "CDR_API_URL=http://20.222.52.61:1317" >> $GITHUB_ENV
+              echo "CDR_RPC_URL=http://20.222.52.61:8545" >> $GITHUB_ENV
               echo "CDR_TEST_PRIVATE_KEY=${{ secrets.CDR_DEVNET_TEST_PRIVATE_KEY }}" >> $GITHUB_ENV
               ;;
             aeneid)
               echo "CDR_API_URL=http://172.192.41.96:1317" >> $GITHUB_ENV
               echo "CDR_RPC_URL=https://aeneid.storyrpc.io" >> $GITHUB_ENV
               echo "CDR_TEST_PRIVATE_KEY=${{ secrets.CDR_AENEID_TEST_PRIVATE_KEY }}" >> $GITHUB_ENV
+              # The public aeneid RPC rate-limits under burst load; run the
+              # ephemeral-wallet suites at reduced concurrency there
+              # (devnet keeps the full 100).
+              echo "CDR_WALLET_COUNT=25" >> $GITHUB_ENV
               ;;
           esac
 

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -199,14 +199,15 @@ jobs:
               echo "CDR_TEST_PRIVATE_KEY=${{ secrets.CDR_AENEID_TEST_PRIVATE_KEY }}" >> $GITHUB_ENV
               # The public aeneid RPC rate-limits under burst load; run the
               # ephemeral-wallet suites at reduced concurrency there.
-              # Precedence: dispatch input > repo variable
-              # CDR_AENEID_WALLET_COUNT > hardcoded 50. Devnet keeps the
-              # suites' built-in default (100) unless the input is set.
-              echo "CDR_WALLET_COUNT=${{ inputs.concurrent_wallet_count || vars.CDR_AENEID_WALLET_COUNT || '50' }}" >> $GITHUB_ENV
+              # Aeneid default: repo variable CDR_AENEID_WALLET_COUNT,
+              # falling back to 50. Devnet keeps the suites' built-in 100.
+              echo "CDR_WALLET_COUNT=${{ vars.CDR_AENEID_WALLET_COUNT || '50' }}" >> $GITHUB_ENV
               ;;
           esac
 
-          # Explicit per-run override applies on any network.
+          # Explicit per-run override wins on any network (written last —
+          # GITHUB_ENV is last-write-wins, so this supersedes the aeneid
+          # default above).
           WC="${{ inputs.concurrent_wallet_count }}"
           if [ -n "$WC" ]; then
             echo "CDR_WALLET_COUNT=$WC" >> $GITHUB_ENV

--- a/packages/sdk/__integration__/_helpers.ts
+++ b/packages/sdk/__integration__/_helpers.ts
@@ -467,3 +467,23 @@ export async function sizeFundAndReport(opts: {
   );
   return perWalletFund;
 }
+
+/**
+ * Parse a positive-integer env override, falling back when the variable is
+ * unset, empty, non-numeric, zero or negative. Guards suites whose pass
+ * criteria scale with the value (e.g. `expect(n).toBe(WALLET_COUNT)` would
+ * vacuously pass with a NaN/0 wallet count).
+ */
+export function positiveIntEnv(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (raw === undefined || raw.trim() === "") return fallback;
+  const n = Number(raw);
+  if (!Number.isInteger(n) || n <= 0) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      `[env] ${name}=${JSON.stringify(raw)} is not a positive integer; using ${fallback}`,
+    );
+    return fallback;
+  }
+  return n;
+}

--- a/packages/sdk/__integration__/ephemeral-100w-fresh-aeneid.test.ts
+++ b/packages/sdk/__integration__/ephemeral-100w-fresh-aeneid.test.ts
@@ -52,12 +52,13 @@ import {
   sizeFundAndReport,
   statsOf,
   writePerfStats,
+  positiveIntEnv,
 } from "./_helpers.js";
 import { pLimit, resilientHttp, withAeneidFlakeRetry } from "./_rpc-resilience.js";
 
 // Overridable so rate-limited networks (public Aeneid RPC) can run a reduced
 // concurrent-wallet load; defaults to the original 100 for devnet.
-const WALLET_COUNT = Number(process.env.CDR_WALLET_COUNT ?? "100");
+const WALLET_COUNT = positiveIntEnv("CDR_WALLET_COUNT", 100);
 const CYCLES_PER_WALLET = 1; // upload + access
 const ACCESS_TIMEOUT_MS = 180_000;
 const MAX_INFLIGHT = 25;

--- a/packages/sdk/__integration__/ephemeral-100w-fresh-aeneid.test.ts
+++ b/packages/sdk/__integration__/ephemeral-100w-fresh-aeneid.test.ts
@@ -55,7 +55,9 @@ import {
 } from "./_helpers.js";
 import { pLimit, resilientHttp, withAeneidFlakeRetry } from "./_rpc-resilience.js";
 
-const WALLET_COUNT = 100;
+// Overridable so rate-limited networks (public Aeneid RPC) can run a reduced
+// concurrent-wallet load; defaults to the original 100 for devnet.
+const WALLET_COUNT = Number(process.env.CDR_WALLET_COUNT ?? "100");
 const CYCLES_PER_WALLET = 1; // upload + access
 const ACCESS_TIMEOUT_MS = 180_000;
 const MAX_INFLIGHT = 25;

--- a/packages/sdk/__integration__/ephemeral-100w-fresh.test.ts
+++ b/packages/sdk/__integration__/ephemeral-100w-fresh.test.ts
@@ -55,11 +55,12 @@ import {
   sizeFundAndReport,
   statsOf,
   writePerfStats,
+  positiveIntEnv,
 } from "./_helpers.js";
 
 // Overridable so rate-limited networks (public Aeneid RPC) can run a reduced
 // concurrent-wallet load; defaults to the original 100 for devnet.
-const WALLET_COUNT = Number(process.env.CDR_WALLET_COUNT ?? "100");
+const WALLET_COUNT = positiveIntEnv("CDR_WALLET_COUNT", 100);
 const CYCLES_PER_WALLET = 1; // upload + access
 const ACCESS_TIMEOUT_MS = 180_000;
 

--- a/packages/sdk/__integration__/ephemeral-100w-fresh.test.ts
+++ b/packages/sdk/__integration__/ephemeral-100w-fresh.test.ts
@@ -57,7 +57,9 @@ import {
   writePerfStats,
 } from "./_helpers.js";
 
-const WALLET_COUNT = 100;
+// Overridable so rate-limited networks (public Aeneid RPC) can run a reduced
+// concurrent-wallet load; defaults to the original 100 for devnet.
+const WALLET_COUNT = Number(process.env.CDR_WALLET_COUNT ?? "100");
 const CYCLES_PER_WALLET = 1; // upload + access
 const ACCESS_TIMEOUT_MS = 180_000;
 

--- a/packages/sdk/__integration__/ephemeral-100w-shared.test.ts
+++ b/packages/sdk/__integration__/ephemeral-100w-shared.test.ts
@@ -63,11 +63,12 @@ import {
   sizeFundAndReport,
   statsOf,
   writePerfStats,
+  positiveIntEnv,
 } from "./_helpers.js";
 
 // Overridable so rate-limited networks (public Aeneid RPC) can run a reduced
 // concurrent-wallet load; defaults to the original 100 for devnet.
-const WALLET_COUNT = Number(process.env.CDR_WALLET_COUNT ?? "100");
+const WALLET_COUNT = positiveIntEnv("CDR_WALLET_COUNT", 100);
 const CYCLES_PER_WALLET = 1; // 1 accessCDR per wallet, no upload
 const ACCESS_TIMEOUT_MS = 180_000;
 

--- a/packages/sdk/__integration__/ephemeral-100w-shared.test.ts
+++ b/packages/sdk/__integration__/ephemeral-100w-shared.test.ts
@@ -65,7 +65,9 @@ import {
   writePerfStats,
 } from "./_helpers.js";
 
-const WALLET_COUNT = 100;
+// Overridable so rate-limited networks (public Aeneid RPC) can run a reduced
+// concurrent-wallet load; defaults to the original 100 for devnet.
+const WALLET_COUNT = Number(process.env.CDR_WALLET_COUNT ?? "100");
 const CYCLES_PER_WALLET = 1; // 1 accessCDR per wallet, no upload
 const ACCESS_TIMEOUT_MS = 180_000;
 

--- a/packages/sdk/__integration__/ephemeral-60min-stress.test.ts
+++ b/packages/sdk/__integration__/ephemeral-60min-stress.test.ts
@@ -59,7 +59,7 @@
  *   pnpm test:stress
  *
  * Required env (from `.env.local`):
- *   CDR_API_URL          — Story-API REST URL (e.g. http://172.207.250.203:1317)
+ *   CDR_API_URL          — Story-API REST URL (e.g. http://20.222.52.61:1317)
  *   CDR_RPC_URL          — EVM JSON-RPC URL on the same chain
  *   CDR_TEST_PRIVATE_KEY — funded wallet (anvil-0 on DevNet)
  */

--- a/packages/sdk/__integration__/observer.test.ts
+++ b/packages/sdk/__integration__/observer.test.ts
@@ -12,7 +12,7 @@
  *   pnpm test:integration observer
  *
  * Required env (from `.env.local`):
- *   CDR_API_URL  — Story-API REST base URL (e.g. http://172.207.250.203:1317)
+ *   CDR_API_URL  — Story-API REST base URL (e.g. http://20.222.52.61:1317)
  *   CDR_RPC_URL  — EVM JSON-RPC URL on the same chain (used by publicClient)
  */
 

--- a/wf.new.yml
+++ b/wf.new.yml
@@ -1,0 +1,101 @@
+name: Integration Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+env:
+  BASE_URL: http://23.102.74.209:8080
+
+jobs:
+  api-tests:
+    name: API Integration Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout test repo
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Create .env.test
+        run: |
+          cat > .env.test << 'EOF'
+          BASE_URL=${{ env.BASE_URL }}
+          TEST_DESIGNER_PRIVATE_KEY=${{ secrets.TEST_DESIGNER_PRIVATE_KEY }}
+          TEST_MANUFACTURER_PRIVATE_KEY=${{ secrets.TEST_MANUFACTURER_PRIVATE_KEY }}
+          TEST_CONSUMER_PRIVATE_KEY=${{ secrets.TEST_CONSUMER_PRIVATE_KEY }}
+          TEST_UNAUTHORIZED_PRIVATE_KEY=${{ secrets.TEST_UNAUTHORIZED_PRIVATE_KEY }}
+          TEST_ADMIN_PRIVATE_KEY=${{ secrets.TEST_ADMIN_PRIVATE_KEY }}
+          EOF
+
+      - name: Health check
+        run: |
+          echo "Checking deployment health..."
+          curl -sf ${{ env.BASE_URL }}/api/categories > /dev/null || (echo "Deployment unreachable!" && exit 1)
+          echo "Deployment is healthy."
+
+      - name: Run API integration tests
+        run: pnpm test
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: vitest-results
+          path: test-results/
+          if-no-files-found: ignore
+
+  i18n-tests:
+    name: i18n Page Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    needs: api-tests
+
+    steps:
+      - name: Checkout test repo
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Run i18n tests
+        run: pnpm test:i18n
+        env:
+          BASE_URL: ${{ env.BASE_URL }}
+
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report/
+          if-no-files-found: ignore

--- a/wf.yml
+++ b/wf.yml
@@ -1,0 +1,103 @@
+name: Integration Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+  schedule:
+    - cron: '0 2 * * *'
+
+env:
+  BASE_URL: http://23.102.74.209:8080
+
+jobs:
+  api-tests:
+    name: API Integration Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout test repo
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Create .env.test
+        run: |
+          cat > .env.test << 'EOF'
+          BASE_URL=${{ env.BASE_URL }}
+          TEST_DESIGNER_PRIVATE_KEY=${{ secrets.TEST_DESIGNER_PRIVATE_KEY }}
+          TEST_MANUFACTURER_PRIVATE_KEY=${{ secrets.TEST_MANUFACTURER_PRIVATE_KEY }}
+          TEST_CONSUMER_PRIVATE_KEY=${{ secrets.TEST_CONSUMER_PRIVATE_KEY }}
+          TEST_UNAUTHORIZED_PRIVATE_KEY=${{ secrets.TEST_UNAUTHORIZED_PRIVATE_KEY }}
+          TEST_ADMIN_PRIVATE_KEY=${{ secrets.TEST_ADMIN_PRIVATE_KEY }}
+          EOF
+
+      - name: Health check
+        run: |
+          echo "Checking deployment health..."
+          curl -sf ${{ env.BASE_URL }}/api/categories > /dev/null || (echo "Deployment unreachable!" && exit 1)
+          echo "Deployment is healthy."
+
+      - name: Run API integration tests
+        run: pnpm test
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: vitest-results
+          path: test-results/
+          if-no-files-found: ignore
+
+  i18n-tests:
+    name: i18n Page Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    needs: api-tests
+
+    steps:
+      - name: Checkout test repo
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Run i18n tests
+        run: pnpm test:i18n
+        env:
+          BASE_URL: ${{ env.BASE_URL }}
+
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report/
+          if-no-files-found: ignore


### PR DESCRIPTION
## 1. Aeneid: reduced concurrency for the ephemeral-wallet suites

The public aeneid RPC (`aeneid.storyrpc.io`) rate-limits under burst load, so the 100-wallet ephemeral suites fail probabilistically there (run 29482061608 and earlier ones).

- `WALLET_COUNT` in the three 100w suites is now env-overridable via **`CDR_WALLET_COUNT`** (default 100 — devnet behavior unchanged).
- The workflow sets `CDR_WALLET_COUNT=25` for `network=aeneid`.
- `ephemeral-100w-fresh-aeneid` already gates in-flight requests with `pLimit(25)`; `100w-shared` intentionally keeps its all-concurrent shape (concurrent same-uuid access is the thing it tests) — the reduced wallet count is the aeneid-side relief.

## 2. Devnet: endpoints moved to the rebuilt qa2 host

The `devnet` network case still pointed at the torn-down `172.207.250.203` host. The canonical devnet was rebuilt as **qa2**; endpoints now point at validator-1:

- `CDR_API_URL=http://20.222.52.61:1317`
- `CDR_RPC_URL=http://20.222.52.61:8545`

Both ports verified reachable through the NSG from outside (live `eth_blockNumber` + `/dkg/latest_active` probes). Doc-comment examples in two test headers refreshed to match.