### PR TITLE
feat(sdk): adaptive backoff for collectPartials polling + 180s default timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,6 @@ const { uuid } = await client.uploader.uploadCDR({
 const { dataKey: recovered } = await client.consumer.accessCDR({
   uuid,
   accessAuxData: "0x",
-  timeoutMs: 120_000,
 });
 ```
 
@@ -132,7 +131,6 @@ const { content } = await client.consumer.downloadFile({
   uuid,
   accessAuxData: "0x",
   storageProvider: storage,
-  timeoutMs: 120_000,
 });
 ```
 

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -284,7 +284,10 @@ const { dataKey, txHash } = await client.consumer.accessCDR({
   requesterPubKey: `0x${string}`,         // your uncompressed secp256k1 public key
   recipientPrivKey: Uint8Array,           // your private key bytes (for ECIES decryption)
   globalPubKey?: Uint8Array,              // optional; auto-queried if omitted
-  timeoutMs?: number,                     // partial collection timeout (default: 60000)
+  timeoutMs?: number,                     // partial collection timeout (default: 180000)
+  pollIntervalMs?: number,                // fixed poll rate; disables adaptive backoff
+  minIntervalMs?: number,                 // adaptive backoff floor (default: 2000)
+  maxIntervalMs?: number,                 // optional backoff ceiling (default: uncapped)
   feeOverride?: bigint,                   // optional: override auto-queried read fee
 });
 ```
@@ -294,8 +297,15 @@ const { dataKey, txHash } = await client.consumer.accessCDR({
 | Method | Description |
 |--------|-------------|
 | `read({ uuid, accessAuxData, requesterPubKey, feeOverride? })` | Submit a read request on-chain |
-| `collectPartials({ uuid, requesterPubKey, timeoutMs?, pollIntervalMs?, attestationConfig? })` | Poll Story-API for partial decryptions |
+| `collectPartials({ uuid, requesterPubKey, timeoutMs?, pollIntervalMs?, minIntervalMs?, maxIntervalMs?, attestationConfig? })` | Poll Story-API for partial decryptions (adaptive backoff by default; `pollIntervalMs` forces a fixed rate) |
 | `decryptDataKey({ ciphertext, partials, recipientPrivKey, globalPubKey, label })` | Decrypt and combine partials |
+
+Partial collection polls with **adaptive exponential backoff**: waits start at
+2s and grow ×1.5 per poll, bounded only by `timeoutMs` (each wait is clamped
+to the remaining budget) — partials mostly arrive shortly after the read tx,
+so polling thins out over time, and collection returns as soon as enough
+partials are seen. Set `maxIntervalMs` to cap the curve, or `pollIntervalMs`
+for a fixed rate (mutually exclusive with the min/max options).
 
 ---
 

--- a/docs/CONDITIONS.md
+++ b/docs/CONDITIONS.md
@@ -59,7 +59,6 @@ const accessAuxData = encodeAbiParameters(
 const { dataKey } = await client.consumer.accessCDR({
   uuid,
   accessAuxData,
-  timeoutMs: 120_000,
 });
 ```
 

--- a/packages/sdk/__tests__/consumer.test.ts
+++ b/packages/sdk/__tests__/consumer.test.ts
@@ -552,6 +552,63 @@ describe("Consumer", () => {
       }
     });
 
+    it("rejects pollIntervalMs combined with minIntervalMs/maxIntervalMs", async () => {
+      const { consumer } = makeConsumer(makeFakeObserver({ threshold: 2 }));
+      await expect(
+        consumer.collectPartials({
+          uuid: 1,
+          requesterPubKey: "0x04" as `0x${string}`,
+          pollIntervalMs: 5,
+          minIntervalMs: 5,
+        }),
+      ).rejects.toThrow(InvalidParamsError);
+    });
+
+    it("rejects an adaptive ceiling below the floor", async () => {
+      const { consumer } = makeConsumer(makeFakeObserver({ threshold: 2 }));
+      await expect(
+        consumer.collectPartials({
+          uuid: 1,
+          requesterPubKey: "0x04" as `0x${string}`,
+          minIntervalMs: 50,
+          maxIntervalMs: 10,
+        }),
+      ).rejects.toThrow(InvalidParamsError);
+    });
+
+    it("adaptive backoff polls less than a fixed floor-rate poll over the same window", async () => {
+      const { consumer } = makeConsumer(makeFakeObserver({ threshold: 3 }));
+      vi.mocked(queryCDRPartials).mockResolvedValue([]);
+
+      await consumer
+        .collectPartials({
+          uuid: 1,
+          requesterPubKey: "0x04" as `0x${string}`,
+          timeoutMs: 120,
+          minIntervalMs: 5,
+          maxIntervalMs: 40,
+        })
+        .catch(() => {});
+      const adaptivePolls = vi.mocked(queryCDRPartials).mock.calls.length;
+
+      vi.mocked(queryCDRPartials).mockClear();
+      await consumer
+        .collectPartials({
+          uuid: 1,
+          requesterPubKey: "0x04" as `0x${string}`,
+          timeoutMs: 120,
+          pollIntervalMs: 5,
+        })
+        .catch(() => {});
+      const fixedPolls = vi.mocked(queryCDRPartials).mock.calls.length;
+
+      // Backoff curve 5 → 7.5 → 11.25 → … → 40 covers the 120ms window in
+      // far fewer polls than a flat 5ms rate. Assert strictly-less rather
+      // than exact counts to stay robust to CI timer jitter.
+      expect(adaptivePolls).toBeGreaterThanOrEqual(2);
+      expect(adaptivePolls).toBeLessThan(fixedPolls);
+    });
+
     it("treats empty groups as 'wait, may arrive later'", async () => {
       const { consumer } = makeConsumer(makeFakeObserver({ threshold: 2 }));
       vi.mocked(queryCDRPartials)

--- a/packages/sdk/src/consumer.ts
+++ b/packages/sdk/src/consumer.ts
@@ -329,7 +329,7 @@ export class Consumer {
    * const partials = await consumer.collectPartials({
    *   uuid: 42,
    *   requesterPubKey: "0x04...",
-   *   timeoutMs: 60_000,
+   *   timeoutMs: 180_000,
    * });
    * // partials[i].ciphertext is the same for every i — caller can use it
    * // for the subsequent decryptDataKey step without re-reading the chain.
@@ -339,7 +339,24 @@ export class Consumer {
     uuid: number;
     requesterPubKey: `0x${string}`;
     timeoutMs?: number;
+    /**
+     * Fixed poll interval. When set, adaptive backoff is disabled and the
+     * loop polls at exactly this rate. Mutually exclusive with `minIntervalMs`
+     * / `maxIntervalMs`.
+     */
     pollIntervalMs?: number;
+    /**
+     * Adaptive backoff floor (default 2000ms). The wait after the first
+     * poll; each subsequent poll grows the wait ×1.5 — partials mostly
+     * arrive shortly after the read tx, so polling thins out over time.
+     */
+    minIntervalMs?: number;
+    /**
+     * Optional adaptive backoff ceiling. Unset by default — the curve
+     * grows unbounded and is naturally capped by `timeoutMs` (each wait
+     * is clamped to the remaining budget) or by collection completing.
+     */
+    maxIntervalMs?: number;
     onInvalidPartial?: (
       event: PartialDecryptionEvent,
       reason: InvalidPartialReason,
@@ -362,8 +379,10 @@ export class Consumer {
     const {
       uuid,
       requesterPubKey,
-      timeoutMs = 60_000,
-      pollIntervalMs = 3_000,
+      timeoutMs = 180_000,
+      pollIntervalMs,
+      minIntervalMs,
+      maxIntervalMs,
       onInvalidPartial,
       attestationConfig,
       pinnedCiphertext,
@@ -371,6 +390,25 @@ export class Consumer {
 
     if (!requesterPubKey) {
       throw new InvalidParamsError("collectPartials: requesterPubKey is required");
+    }
+    if (
+      pollIntervalMs !== undefined &&
+      (minIntervalMs !== undefined || maxIntervalMs !== undefined)
+    ) {
+      throw new InvalidParamsError(
+        "collectPartials: pollIntervalMs (fixed rate) is mutually exclusive with minIntervalMs/maxIntervalMs (adaptive)",
+      );
+    }
+    // Fixed rate = a flat curve (floor == ceiling). Adaptive default:
+    // 2s floor, no ceiling — the curve grows ×1.5 per poll and is
+    // naturally bounded by the deadline clamp below or by collection
+    // completing. An explicit maxIntervalMs bounds the curve if set.
+    const intervalFloor = pollIntervalMs ?? minIntervalMs ?? 2_000;
+    const intervalCeil = pollIntervalMs ?? maxIntervalMs ?? Infinity;
+    if (intervalFloor <= 0 || intervalCeil < intervalFloor) {
+      throw new InvalidParamsError(
+        `collectPartials: invalid poll intervals (floor=${intervalFloor}ms, ceiling=${intervalCeil}ms)`,
+      );
     }
 
     // Pin the vault's current ciphertext for the entire poll loop. The
@@ -399,6 +437,12 @@ export class Consumer {
      * appears.
      */
     let lastNeeded = await this.observer.getThreshold().catch(() => 0);
+
+    // Adaptive backoff state: wait `interval` between polls,
+    // growing ×1.5 each iteration (unbounded unless maxIntervalMs is
+    // set) — partials mostly arrive shortly after the read tx, so
+    // polling thins out over time.
+    let interval = intervalFloor;
 
     while (Date.now() < deadline) {
       let groups: Awaited<ReturnType<typeof queryCDRPartials>> = [];
@@ -489,7 +533,12 @@ export class Consumer {
         }
       }
 
-      await sleep(pollIntervalMs);
+      // The wait is clamped to the remaining budget so the loop never
+      // overshoots the deadline by a full interval.
+      const remainingMs = deadline - Date.now();
+      if (remainingMs <= 0) break;
+      await sleep(Math.min(interval, remainingMs));
+      interval = Math.min(interval * 1.5, intervalCeil);
     }
 
     this.logger.warn("partial.collection.timeout", {
@@ -627,6 +676,12 @@ export class Consumer {
     recipientPrivKey?: Uint8Array;
     globalPubKey?: Uint8Array;
     timeoutMs?: number;
+    /** See {@link collectPartials} — fixed poll rate, disables backoff. */
+    pollIntervalMs?: number;
+    /** See {@link collectPartials} — adaptive backoff floor (default 2000ms). */
+    minIntervalMs?: number;
+    /** See {@link collectPartials} — optional adaptive backoff ceiling (unset = unbounded, clamped by timeoutMs). */
+    maxIntervalMs?: number;
     /** See {@link read}'s `feeOverride` — same strict-equality semantics. */
     feeOverride?: bigint;
     onInvalidPartial?: (
@@ -680,6 +735,9 @@ export class Consumer {
         uuid: params.uuid,
         requesterPubKey,
         timeoutMs: params.timeoutMs,
+        pollIntervalMs: params.pollIntervalMs,
+        minIntervalMs: params.minIntervalMs,
+        maxIntervalMs: params.maxIntervalMs,
         onInvalidPartial: params.onInvalidPartial,
         attestationConfig: params.attestationConfig,
         pinnedCiphertext: vaultCiphertext,
@@ -721,6 +779,12 @@ export class Consumer {
     globalPubKey?: Uint8Array;
     storageProvider: StorageProvider;
     timeoutMs?: number;
+    /** See {@link collectPartials} — fixed poll rate, disables backoff. */
+    pollIntervalMs?: number;
+    /** See {@link collectPartials} — adaptive backoff floor (default 2000ms). */
+    minIntervalMs?: number;
+    /** See {@link collectPartials} — optional adaptive backoff ceiling (unset = unbounded, clamped by timeoutMs). */
+    maxIntervalMs?: number;
     /** See {@link read}'s `feeOverride` — same strict-equality semantics. */
     feeOverride?: bigint;
     onInvalidPartial?: (
@@ -743,6 +807,9 @@ export class Consumer {
       recipientPrivKey: params.recipientPrivKey,
       globalPubKey: params.globalPubKey,
       timeoutMs: params.timeoutMs,
+      pollIntervalMs: params.pollIntervalMs,
+      minIntervalMs: params.minIntervalMs,
+      maxIntervalMs: params.maxIntervalMs,
       feeOverride: params.feeOverride,
       onInvalidPartial: params.onInvalidPartial,
       attestationConfig: params.attestationConfig,


### PR DESCRIPTION
## Summary

Closes #128. `collectPartials` polled at a fixed 3s rate for the entire timeout window — up to ~60 mostly-idle `queryCDRPartials` calls per read on a long timeout, multiplied across concurrent CI wallets against the shared endpoint.

Polling is now **adaptive**: waits start at 2s and grow ×1.5 per poll, uncapped — bounded only by the deadline (every wait is clamped to the remaining budget, so the wall clock honors `timeoutMs` exactly) and by collection completing the moment enough partials are seen. Partials mostly arrive shortly after the read tx, so polling thins out over time; a 180s no-show drops from ~60 polls to ~11. Default `timeoutMs` is raised 60s → 180s.

## API

- `pollIntervalMs` keeps its exact meaning: a fixed rate, backoff disabled. Mutually exclusive with the options below (combining throws `InvalidParamsError`).
- New `minIntervalMs` (default 2000) shifts the backoff floor; new `maxIntervalMs` (unset = uncapped) optionally re-caps the curve.
- All three knobs are exposed on `collectPartials`, `accessCDR`, and `downloadFile` (the latter two forward to the loop — polling was previously untunable from the high-level API).

Out of scope: #128's `eth_subscribe` alternative — partials are collected via Story-API REST since #73, so a push channel is a server-side feature discussion, not an SDK transport swap.

## Behavior changes

- **Adaptive is the default** (not opt-in behind min/max): faster first re-check (2s vs 3s), sparser tail. Callers needing tight detection of late partials set `maxIntervalMs` or `pollIntervalMs`.
- **Default `timeoutMs` 60s → 180s** on `collectPartials` / `accessCDR` / `downloadFile`. Doc examples recommending the now-lower `timeoutMs: 120_000` were cleaned up (README ×2, CONDITIONS ×1); USER_GUIDE documents the new defaults and the backoff.
- **`timeoutMs` no longer overshoots**: the old loop always slept a full interval before re-checking the deadline, returning up to one interval late. Waits are now clamped to the remaining budget.
- **`pollIntervalMs: 0` now throws** `InvalidParamsError` (previously produced a zero-sleep tight loop).

## Test plan

- [x] 3 new unit tests: fixed/adaptive mutual exclusion; ceiling-below-floor rejection; adaptive polls strictly fewer times than a fixed floor-rate poll over the same window (relative assertion, robust to CI timer jitter)
- [x] All 251 pre-existing SDK tests pass **unmodified** (backward-compat proof); 254 sdk + 22 crypto + 21 monitor + 15 cli total
- [x] Workspace build 10/10, lint clean
- [ ] Aeneid integration suite run 