### PR TITLE
feat(sdk): license-token minting with automatic WIP fee handling

### DIFF
--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -13,6 +13,7 @@ The **CDR (Confidential Data Rails) SDK** provides a TypeScript interface for en
   - [Observer (Read-Only)](#observer-read-only)
   - [Uploader (Write)](#uploader-write)
   - [Consumer (Read/Decrypt)](#consumer-readdecrypt)
+  - [License Helper](#license-helper)
 - [Examples](#examples)
   - [Query DKG State](#query-dkg-state)
   - [Upload Encrypted Data](#upload-encrypted-data)
@@ -306,6 +307,24 @@ to the remaining budget) — partials mostly arrive shortly after the read tx,
 so polling thins out over time, and collection returns as soon as enough
 partials are seen. Set `maxIntervalMs` to cap the curve, or `pollIntervalMs`
 for a fixed rate (mutually exclusive with the min/max options).
+
+### License Helper
+
+Mints Story Protocol license tokens for reading `LicenseReadCondition`-gated vaults, handling the WIP fee automatically (predict fee → wrap native DATA → approve RoyaltyModule → mint). Requires a `walletClient`.
+
+```typescript
+const { licenseTokenIds, feePaid, wrappedWei, txHashes } =
+  await client.license.mintLicenseToken({
+    licensorIpId: `0x${string}`,   // the licensor IP asset (IP ID)
+    licenseTermsId: bigint | number,
+    amount?: bigint | number,      // default 1
+    receiver?: `0x${string}`,      // default: your wallet address
+    autoWrap?: boolean,            // default true — wrap missing WIP from native
+    autoApprove?: boolean,         // default true — approve RoyaltyModule (maxUint256)
+  });
+```
+
+Fee preparation is idempotent — wrap/approve steps are skipped (and absent from `txHashes`) when the balance or a standing allowance already covers the fee. Only WIP-denominated license terms are supported; other currencies throw `UnsupportedLicenseCurrencyError`. Also available without a `CDRClient` as the standalone `mintLicenseToken({ publicClient, walletClient, ... })` export.
 
 ---
 

--- a/docs/CONDITIONS.md
+++ b/docs/CONDITIONS.md
@@ -48,6 +48,15 @@ await client.uploader.uploadCDR({
 });
 ```
 
+If you don't hold a license token yet, the SDK can mint one — it predicts the minting fee on-chain, wraps native DATA into WIP for it (the fee is pulled in WIP by Story's RoyaltyModule), approves, and mints in one call:
+
+```typescript
+const { licenseTokenIds } = await client.license.mintLicenseToken({
+  licensorIpId: "0x3Aa560C9072E0D4A1443CD192745C24A176b4925",  // the IP ID
+  licenseTermsId: 2645,
+});
+```
+
 At read time, pass the license token IDs as `accessAuxData`:
 
 ```typescript

--- a/packages/sdk/__integration__/dx-improvements.test.ts
+++ b/packages/sdk/__integration__/dx-improvements.test.ts
@@ -238,9 +238,15 @@ describe(`DX improvement tests (live: ${API_URL})`, () => {
       licenseTermsId: LICENSE_TERMS_ID,
     });
     expect(mintResult.licenseTokenIds).toHaveLength(1);
-    // The fresh reader held no WIP, so the helper must have wrapped the
-    // full fee (0 for free terms) — and skipped nothing it needed.
+    // These terms carry a minting fee (the pre-helper version of this test
+    // wrapped WIP specifically to pay it), so the fee path must be exercised
+    // — otherwise this test proves nothing about wrapping/approving. The
+    // fresh reader held no WIP, so the full fee must have been wrapped and a
+    // deposit tx produced.
+    expect(mintResult.feePaid).toBeGreaterThan(0n);
     expect(mintResult.wrappedWei).toBe(mintResult.feePaid);
+    expect(mintResult.txHashes.deposit).toBeDefined();
+    expect(mintResult.txHashes.approve).toBeDefined();
     console.log(
       `DX-03 | minted licenseTokenId=${mintResult.licenseTokenIds[0]} feePaid=${mintResult.feePaid} wrapped=${mintResult.wrappedWei}`,
     );

--- a/packages/sdk/__integration__/dx-improvements.test.ts
+++ b/packages/sdk/__integration__/dx-improvements.test.ts
@@ -6,7 +6,8 @@
  *
  *   DX-01 (#11)  conditions.{open,tokenGate,ownerOnly,merkle,custom}
  *   DX-02 (#12)  accessCDR with just {uuid, accessAuxData}
- *   DX-03 (#13)  LicenseReadCondition (Aeneid-only; skipped on other chains)
+ *   DX-03 (#13)  LicenseReadCondition end-to-end via license.mintLicenseToken
+ *                (#39) — Aeneid-only; skipped on other chains
  *   DX-04 (#16)  Method aliases: createVault / readVault / *FileVault
  */
 
@@ -145,13 +146,7 @@ describe(`DX improvement tests (live: ${API_URL})`, () => {
     expect(txHash).toMatch(/^0x[0-9a-f]{64}$/);
   }, 240_000);
 
-  // DX-03 is currently `it.skip` because it needs `@story-protocol/core-sdk`
-  // to mint a license token, and that package is intentionally NOT a dep of
-  // @piplabs/cdr-sdk (it's a heavy SDK that the published cdr-sdk shouldn't
-  // pull in). The original story-cdr-e2e test wallet had it as a test-only
-  // dep. Flipping this on is a follow-up: add `@story-protocol/core-sdk` to
-  // packages/sdk devDependencies + change `it.skip` → `it`.
-  it.skip("DX-03: LicenseReadCondition gates vault access to license holders (Issue #13, Aeneid only) — needs @story-protocol/core-sdk dep", async () => {
+  it("DX-03: LicenseReadCondition gates vault access; license minted via license.mintLicenseToken (Issues #13 + #39, Aeneid only)", async () => {
     const { publicClient, walletClient } = makeCDRClient();
     const chainId = await publicClient.getChainId();
     if (chainId !== 1315) {
@@ -167,10 +162,6 @@ describe(`DX improvement tests (live: ${API_URL})`, () => {
       "0x4C9bFC96d7092b590D497A191826C3dA2277c34B" as `0x${string}`;
     const LICENSE_TOKEN =
       "0xFe3838BFb30B34170F00030B52eA4893d8aAC6bC" as `0x${string}`;
-    const WIP_TOKEN =
-      "0x1514000000000000000000000000000000000000" as `0x${string}`;
-    const ROYALTY_MODULE =
-      "0xD2f60c40fEbccf6311f8B47c4f2Ec6b040400086" as `0x${string}`;
     const IP_ID =
       "0x3Aa560C9072E0D4A1443CD192745C24A176b4925" as `0x${string}`;
     const LICENSE_TERMS_ID = 2054;
@@ -234,60 +225,29 @@ describe(`DX improvement tests (live: ${API_URL})`, () => {
       account: readerAccount,
     }) as unknown as WalletClient;
 
-    // Wrap 1 IP → WIP via WIP_TOKEN.deposit().
-    const wrapTx = await readerWallet.sendTransaction({
-      chain: readerWallet.chain ?? null,
-      account: readerWallet.account ?? null,
-      to: WIP_TOKEN,
-      data: "0xd0e30db0" as `0x${string}`,
-      value: parseEther("1"),
-    });
-    await publicClient.waitForTransactionReceipt({ hash: wrapTx });
-
-    const approveTx = await readerWallet.writeContract({
-      chain: readerWallet.chain ?? null,
-      account: readerWallet.account ?? null,
-      address: WIP_TOKEN,
-      abi: [
-        {
-          type: "function",
-          name: "approve",
-          inputs: [{ type: "address" }, { type: "uint256" }],
-          outputs: [{ type: "bool" }],
-          stateMutability: "nonpayable",
-        },
-      ],
-      functionName: "approve",
-      args: [ROYALTY_MODULE, parseEther("1")],
-    });
-    await publicClient.waitForTransactionReceipt({ hash: approveTx });
-
-    // Mint a license token via Story Protocol SDK.
-    // @ts-expect-error — @story-protocol/core-sdk is not a dep of @piplabs/cdr-sdk.
-    // This `it.skip`'d test would need the dep added before it can run.
-    const { StoryClient } = await import("@story-protocol/core-sdk");
-    const storyClient = StoryClient.newClient({
-      transport: http(RPC_URL),
-      account: readerAccount,
-    });
-    const mintResult = await storyClient.license.mintLicenseTokens({
-      licensorIpId: IP_ID,
-      licenseTermsId: LICENSE_TERMS_ID,
-      amount: 1,
-      maxMintingFee: "100000000000000000",
-      maxRevenueShare: 100,
-    });
-    const licenseTokenId = mintResult.licenseTokenIds![0];
-
+    // Mint a license token: the helper wraps the shortfall from the fresh
+    // reader's native balance into WIP, approves the RoyaltyModule, and mints.
     const readerCdr = new CDRClient({
       network: "testnet",
       publicClient,
       walletClient: readerWallet as unknown as WalletClient,
       apiUrl: API_URL!,
     });
+    const mintResult = await readerCdr.license.mintLicenseToken({
+      licensorIpId: IP_ID,
+      licenseTermsId: LICENSE_TERMS_ID,
+    });
+    expect(mintResult.licenseTokenIds).toHaveLength(1);
+    // The fresh reader held no WIP, so the helper must have wrapped the
+    // full fee (0 for free terms) — and skipped nothing it needed.
+    expect(mintResult.wrappedWei).toBe(mintResult.feePaid);
+    console.log(
+      `DX-03 | minted licenseTokenId=${mintResult.licenseTokenIds[0]} feePaid=${mintResult.feePaid} wrapped=${mintResult.wrappedWei}`,
+    );
+
     const accessAuxData = encodeAbiParameters(
       [{ type: "uint256[]" }],
-      [[BigInt(licenseTokenId)]],
+      [[mintResult.licenseTokenIds[0]]],
     );
     const { dataKey: recovered } = await readerCdr.consumer.accessCDR({
       uuid,

--- a/packages/sdk/__integration__/dx-improvements.test.ts
+++ b/packages/sdk/__integration__/dx-improvements.test.ts
@@ -146,12 +146,34 @@ describe(`DX improvement tests (live: ${API_URL})`, () => {
     expect(txHash).toMatch(/^0x[0-9a-f]{64}$/);
   }, 240_000);
 
-  it("DX-03: LicenseReadCondition gates vault access; license minted via license.mintLicenseToken (Issues #13 + #39, Aeneid only)", async () => {
+// Two known Aeneid LicenseReadCondition fixtures, exercised through the
+  // identical mint→gated-read journey. Free proves the wrap/approve SKIP
+  // (idempotency) path; fee-bearing proves the wrap→approve→pay path — the
+  // real reason license.mintLicenseToken exists (#39). Fees verified on-chain
+  // via predictMintingLicenseFee; the fee-bearing case spends 1 real WIP/run.
+  const LICENSE_FIXTURES = [
+    {
+      label: "free terms",
+      ipId: "0x3Aa560C9072E0D4A1443CD192745C24A176b4925" as `0x${string}`,
+      termsId: 2054,
+      expectFee: false,
+    },
+    {
+      label: "fee-bearing terms (1 WIP)",
+      ipId: "0x2dfCEf84c4772133981679Cf624854455e4dD98f" as `0x${string}`,
+      termsId: 2795,
+      expectFee: true,
+    },
+  ] as const;
+
+  async function runLicenseGatedFlow(
+    fixture: (typeof LICENSE_FIXTURES)[number],
+  ): Promise<void> {
     const { publicClient, walletClient } = makeCDRClient();
     const chainId = await publicClient.getChainId();
     if (chainId !== 1315) {
       console.log(
-        `DX-03 | SKIPPED: LicenseReadCondition only on Aeneid (chainId=${chainId})`,
+        `DX-03 [${fixture.label}] | SKIPPED: LicenseReadCondition only on Aeneid (chainId=${chainId})`,
       );
       return;
     }
@@ -162,9 +184,6 @@ describe(`DX improvement tests (live: ${API_URL})`, () => {
       "0x4C9bFC96d7092b590D497A191826C3dA2277c34B" as `0x${string}`;
     const LICENSE_TOKEN =
       "0xFe3838BFb30B34170F00030B52eA4893d8aAC6bC" as `0x${string}`;
-    const IP_ID =
-      "0x3Aa560C9072E0D4A1443CD192745C24A176b4925" as `0x${string}`;
-    const LICENSE_TERMS_ID = 2054;
 
     const uploaderAddr = privateKeyToAccount(PRIVATE_KEY!).address;
     const cdr = new CDRClient({
@@ -182,7 +201,7 @@ describe(`DX improvement tests (live: ${API_URL})`, () => {
     );
     const readCondData = encodeAbiParameters(
       [{ type: "address" }, { type: "address" }],
-      [LICENSE_TOKEN, IP_ID],
+      [LICENSE_TOKEN, fixture.ipId],
     );
 
     const { uuid } = await cdr.uploader.uploadCDR({
@@ -196,7 +215,7 @@ describe(`DX improvement tests (live: ${API_URL})`, () => {
       accessAuxData: "0x",
     });
 
-    // (a) Read without license fails.
+    // (a) Read without a license fails.
     const emptyAux = encodeAbiParameters([{ type: "uint256[]" }], [[]]);
     await expect(
       cdr.consumer.accessCDR({
@@ -206,8 +225,8 @@ describe(`DX improvement tests (live: ${API_URL})`, () => {
       }),
     ).rejects.toThrow();
 
-    // (b) Spin up a temp reader wallet, fund it, mint a license token,
-    // then read with it.
+    // (b) Fresh reader wallet (holds only native DATA, no WIP), funded to
+    // cover the fee + gas, mints a license via the helper, then reads.
     const readerKey = generatePrivateKey();
     const readerAccount = privateKeyToAccount(readerKey);
 
@@ -225,8 +244,6 @@ describe(`DX improvement tests (live: ${API_URL})`, () => {
       account: readerAccount,
     }) as unknown as WalletClient;
 
-    // Mint a license token: the helper wraps the shortfall from the fresh
-    // reader's native balance into WIP, approves the RoyaltyModule, and mints.
     const readerCdr = new CDRClient({
       network: "testnet",
       publicClient,
@@ -234,22 +251,27 @@ describe(`DX improvement tests (live: ${API_URL})`, () => {
       apiUrl: API_URL!,
     });
     const mintResult = await readerCdr.license.mintLicenseToken({
-      licensorIpId: IP_ID,
-      licenseTermsId: LICENSE_TERMS_ID,
+      licensorIpId: fixture.ipId,
+      licenseTermsId: fixture.termsId,
     });
     expect(mintResult.licenseTokenIds).toHaveLength(1);
-    // These terms carry a minting fee (the pre-helper version of this test
-    // wrapped WIP specifically to pay it), so the fee path must be exercised
-    // — otherwise this test proves nothing about wrapping/approving. The
-    // fresh reader held no WIP, so the full fee must have been wrapped and a
-    // deposit tx produced.
-    expect(mintResult.feePaid).toBeGreaterThan(0n);
-    expect(mintResult.wrappedWei).toBe(mintResult.feePaid);
-    expect(mintResult.txHashes.deposit).toBeDefined();
-    expect(mintResult.txHashes.approve).toBeDefined();
     console.log(
-      `DX-03 | minted licenseTokenId=${mintResult.licenseTokenIds[0]} feePaid=${mintResult.feePaid} wrapped=${mintResult.wrappedWei}`,
+      `DX-03 [${fixture.label}] | minted licenseTokenId=${mintResult.licenseTokenIds[0]} feePaid=${mintResult.feePaid} wrapped=${mintResult.wrappedWei}`,
     );
+
+    // The helper's fee handling is the crux of #39. wrappedWei === feePaid
+    // always holds (fresh reader had zero WIP). The rest asserts the two
+    // outcomes explicitly so neither passes vacuously.
+    expect(mintResult.wrappedWei).toBe(mintResult.feePaid);
+    if (fixture.expectFee) {
+      expect(mintResult.feePaid).toBeGreaterThan(0n);
+      expect(mintResult.txHashes.deposit).toBeDefined();
+      expect(mintResult.txHashes.approve).toBeDefined();
+    } else {
+      expect(mintResult.feePaid).toBe(0n);
+      expect(mintResult.txHashes.deposit).toBeUndefined();
+      expect(mintResult.txHashes.approve).toBeUndefined();
+    }
 
     const accessAuxData = encodeAbiParameters(
       [{ type: "uint256[]" }],
@@ -262,7 +284,7 @@ describe(`DX improvement tests (live: ${API_URL})`, () => {
     });
     expect(toHex(new Uint8Array(recovered))).toBe(toHex(dataKey));
 
-    // Best-effort cleanup: return remaining IP from reader to uploader.
+    // Best-effort cleanup: return remaining native balance to the uploader.
     try {
       const bal = await publicClient.getBalance({
         address: readerAccount.address,
@@ -280,7 +302,15 @@ describe(`DX improvement tests (live: ${API_URL})`, () => {
     } catch {
       /* swallow cleanup errors — best-effort */
     }
-  }, 300_000);
+  }
+
+  for (const fixture of LICENSE_FIXTURES) {
+    it(
+      `DX-03 [${fixture.label}]: LicenseReadCondition gates vault access; license minted via license.mintLicenseToken (Issues #13 + #39, Aeneid only)`,
+      () => runLicenseGatedFlow(fixture),
+      300_000,
+    );
+  }
 
   it("DX-04: createVault / readVault method aliases exist (Issue #16)", () => {
     const { client } = makeCDRClient();

--- a/packages/sdk/__tests__/license.test.ts
+++ b/packages/sdk/__tests__/license.test.ts
@@ -1,0 +1,309 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { encodeEventTopics, encodeAbiParameters, getAddress, maxUint256 } from "viem";
+import { LicenseClient, mintLicenseToken } from "../src/license.js";
+import {
+  LICENSING_MODULE_ADDRESS,
+  PI_LICENSE_TEMPLATE_ADDRESS,
+  ROYALTY_MODULE_ADDRESS,
+  WIP_ADDRESS,
+  licensingModuleAbi,
+  wipAbi,
+} from "../src/license-contracts.js";
+import {
+  InsufficientBalanceError,
+  LicenseMintPreparationError,
+  LicenseTokensMintedEventNotFoundError,
+  LicenseTransactionRevertedError,
+  UnsupportedLicenseCurrencyError,
+  WalletClientRequiredError,
+} from "../src/errors.js";
+import { CDRClient } from "../src/client.js";
+import { makeWalletMock, decodeWriteCalls } from "./_write-contract-mock.js";
+
+const MINTER = "0xaaaa000000000000000000000000000000000001" as `0x${string}`;
+const LICENSOR = "0x072d000000000000000000000000000000000001" as `0x${string}`;
+const OTHER_TOKEN = "0x9999000000000000000000000000000000009999" as `0x${string}`;
+const COMBINED_ABI = [...wipAbi, ...licensingModuleAbi];
+
+function makeMintLog(opts: {
+  startId: bigint;
+  amount?: bigint;
+  receiver?: `0x${string}`;
+}) {
+  const topics = encodeEventTopics({
+    abi: licensingModuleAbi,
+    eventName: "LicenseTokensMinted",
+    args: { caller: MINTER, licensorIpId: LICENSOR, licenseTermsId: 2645n },
+  });
+  const data = encodeAbiParameters(
+    [
+      { type: "address" },
+      { type: "uint256" },
+      { type: "address" },
+      { type: "uint256" },
+    ],
+    [
+      PI_LICENSE_TEMPLATE_ADDRESS,
+      opts.amount ?? 1n,
+      opts.receiver ?? MINTER,
+      opts.startId,
+    ],
+  );
+  return { address: LICENSING_MODULE_ADDRESS, topics, data };
+}
+
+function makeClients(opts: {
+  fee?: bigint;
+  currency?: `0x${string}`;
+  wipBalance?: bigint;
+  allowance?: bigint;
+  nativeBalance?: bigint;
+  receiptLogs?: ReturnType<typeof makeMintLog>[];
+  /** Status for every receipt (default "success"). Use to simulate a revert. */
+  receiptStatus?: "success" | "reverted";
+} = {}) {
+  const readContract = vi.fn().mockImplementation((args: unknown) => {
+    const a = args as { functionName?: string };
+    switch (a.functionName) {
+      case "predictMintingLicenseFee":
+        return Promise.resolve([opts.currency ?? WIP_ADDRESS, opts.fee ?? 0n]);
+      case "balanceOf":
+        return Promise.resolve(opts.wipBalance ?? 0n);
+      case "allowance":
+        return Promise.resolve(opts.allowance ?? 0n);
+    }
+    return Promise.resolve(undefined);
+  });
+  const publicClient = {
+    readContract,
+    getBalance: vi.fn().mockResolvedValue(opts.nativeBalance ?? 10n ** 18n),
+    waitForTransactionReceipt: vi.fn().mockResolvedValue({
+      status: opts.receiptStatus ?? "success",
+      logs: opts.receiptLogs ?? [makeMintLog({ startId: 100n })],
+    }),
+  };
+  const walletClient = { ...makeWalletMock(), chain: { id: 1315 } };
+  // Full-length address: license writes ABI-encode the minter/receiver, which
+  // viem validates (unlike the CDR write paths the shared mock default serves).
+  (walletClient as any).account = { address: MINTER, type: "local" };
+  walletClient.sendRawTransaction.mockResolvedValue("0xtxhash" as `0x${string}`);
+  const license = new LicenseClient({
+    publicClient: publicClient as any,
+    walletClient: walletClient as any,
+  });
+  return { license, publicClient, walletClient };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("LicenseClient.mintLicenseToken", () => {
+  it("free terms: mints with no wrap/approve and parses the token id", async () => {
+    const { license, walletClient } = makeClients({ fee: 0n });
+    const result = await license.mintLicenseToken({
+      licensorIpId: LICENSOR,
+      licenseTermsId: 2645,
+    });
+    expect(result.licenseTokenIds).toEqual([100n]);
+    expect(result.feePaid).toBe(0n);
+    expect(result.wrappedWei).toBe(0n);
+    expect(result.txHashes.deposit).toBeUndefined();
+    expect(result.txHashes.approve).toBeUndefined();
+    const writes = decodeWriteCalls(walletClient, COMBINED_ABI as any);
+    expect(writes).toHaveLength(1);
+    expect(writes[0].functionName).toBe("mintLicenseTokens");
+  });
+
+  it("sufficient WIP + standing allowance: mint is the only transaction", async () => {
+    const { license, walletClient } = makeClients({
+      fee: 10n,
+      wipBalance: 50n,
+      allowance: maxUint256,
+    });
+    const result = await license.mintLicenseToken({
+      licensorIpId: LICENSOR,
+      licenseTermsId: 2645,
+    });
+    expect(result.wrappedWei).toBe(0n);
+    expect(result.txHashes.deposit).toBeUndefined();
+    expect(result.txHashes.approve).toBeUndefined();
+    expect(decodeWriteCalls(walletClient, COMBINED_ABI as any)).toHaveLength(1);
+  });
+
+  it("short allowance: approves the RoyaltyModule for maxUint256 before minting", async () => {
+    const { license, walletClient } = makeClients({
+      fee: 10n,
+      wipBalance: 50n,
+      allowance: 0n,
+    });
+    const result = await license.mintLicenseToken({
+      licensorIpId: LICENSOR,
+      licenseTermsId: 2645,
+    });
+    expect(result.txHashes.approve).toBeDefined();
+    const writes = decodeWriteCalls(walletClient, COMBINED_ABI as any);
+    expect(writes.map((w) => w.functionName)).toEqual(["approve", "mintLicenseTokens"]);
+    expect(writes[0].args).toEqual([ROYALTY_MODULE_ADDRESS, maxUint256]);
+    expect(writes[0].address).toBe(WIP_ADDRESS);
+  });
+
+  it("WIP shortfall: wraps exactly the missing amount, then approves and mints", async () => {
+    const { license, walletClient } = makeClients({
+      fee: 10n,
+      wipBalance: 4n,
+      allowance: 0n,
+    });
+    const result = await license.mintLicenseToken({
+      licensorIpId: LICENSOR,
+      licenseTermsId: 2645,
+    });
+    expect(result.wrappedWei).toBe(6n);
+    const writes = decodeWriteCalls(walletClient, COMBINED_ABI as any);
+    expect(writes.map((w) => w.functionName)).toEqual([
+      "deposit",
+      "approve",
+      "mintLicenseTokens",
+    ]);
+    expect(writes[0].address).toBe(WIP_ADDRESS);
+    expect(writes[0].value).toBe(6n);
+  });
+
+  it("insufficient native for the wrap: throws InsufficientBalanceError before any tx", async () => {
+    const { license, walletClient } = makeClients({
+      fee: 10n,
+      wipBalance: 0n,
+      nativeBalance: 5n,
+    });
+    await expect(
+      license.mintLicenseToken({ licensorIpId: LICENSOR, licenseTermsId: 2645 }),
+    ).rejects.toThrow(InsufficientBalanceError);
+    expect(walletClient.prepareTransactionRequest).not.toHaveBeenCalled();
+  });
+
+  it("non-WIP fee currency: throws UnsupportedLicenseCurrencyError", async () => {
+    const { license } = makeClients({ fee: 10n, currency: OTHER_TOKEN });
+    await expect(
+      license.mintLicenseToken({ licensorIpId: LICENSOR, licenseTermsId: 2645 }),
+    ).rejects.toThrow(UnsupportedLicenseCurrencyError);
+  });
+
+  it("autoWrap:false with shortfall: throws LicenseMintPreparationError", async () => {
+    const { license } = makeClients({ fee: 10n, wipBalance: 0n });
+    await expect(
+      license.mintLicenseToken({
+        licensorIpId: LICENSOR,
+        licenseTermsId: 2645,
+        autoWrap: false,
+      }),
+    ).rejects.toThrow(LicenseMintPreparationError);
+  });
+
+  it("autoApprove:false with short allowance: throws LicenseMintPreparationError", async () => {
+    const { license } = makeClients({ fee: 10n, wipBalance: 50n, allowance: 0n });
+    await expect(
+      license.mintLicenseToken({
+        licensorIpId: LICENSOR,
+        licenseTermsId: 2645,
+        autoApprove: false,
+      }),
+    ).rejects.toThrow(LicenseMintPreparationError);
+  });
+
+  it("amount > 1: returns sequential ids and passes the predicted fee as maxMintingFee", async () => {
+    const { license, walletClient } = makeClients({
+      fee: 30n,
+      wipBalance: 50n,
+      allowance: maxUint256,
+      receiptLogs: [makeMintLog({ startId: 200n, amount: 3n })],
+    });
+    const result = await license.mintLicenseToken({
+      licensorIpId: LICENSOR,
+      licenseTermsId: 2645,
+      amount: 3,
+    });
+    expect(result.licenseTokenIds).toEqual([200n, 201n, 202n]);
+    const [mint] = decodeWriteCalls(walletClient, COMBINED_ABI as any);
+    expect(mint.functionName).toBe("mintLicenseTokens");
+    // [licensorIpId, licenseTemplate, licenseTermsId, amount, receiver,
+    //  royaltyContext, maxMintingFee, maxRevenueShare]
+    // decodeFunctionData returns checksummed addresses.
+    expect(mint.args).toEqual([
+      getAddress(LICENSOR),
+      PI_LICENSE_TEMPLATE_ADDRESS,
+      2645n,
+      3n,
+      getAddress(MINTER),
+      "0x",
+      30n,
+      100_000_000,
+    ]);
+  });
+
+  it("receipt without the mint event: throws LicenseTokensMintedEventNotFoundError", async () => {
+    const { license } = makeClients({ fee: 0n, receiptLogs: [] });
+    await expect(
+      license.mintLicenseToken({ licensorIpId: LICENSOR, licenseTermsId: 2645 }),
+    ).rejects.toThrow(LicenseTokensMintedEventNotFoundError);
+  });
+
+  it("reverted mint tx: throws LicenseTransactionRevertedError (not event-not-found)", async () => {
+    // A reverted mint emits no logs; waitForReceiptResilient returns the
+    // reverted receipt without throwing, so the status check must catch it
+    // rather than falling through to 'mint event not found'.
+    const { license } = makeClients({
+      fee: 0n,
+      receiptStatus: "reverted",
+      receiptLogs: [],
+    });
+    try {
+      await license.mintLicenseToken({ licensorIpId: LICENSOR, licenseTermsId: 2645 });
+      expect.fail("expected LicenseTransactionRevertedError");
+    } catch (err) {
+      expect(err).toBeInstanceOf(LicenseTransactionRevertedError);
+      expect((err as LicenseTransactionRevertedError).step).toBe("mint");
+      expect((err as LicenseTransactionRevertedError).code).toBe(
+        "LICENSE_TRANSACTION_REVERTED",
+      );
+    }
+  });
+
+  it("reverted deposit tx: throws at the deposit step, before approve/mint", async () => {
+    const { license, walletClient } = makeClients({
+      fee: 10n,
+      wipBalance: 0n,
+      receiptStatus: "reverted",
+    });
+    try {
+      await license.mintLicenseToken({ licensorIpId: LICENSOR, licenseTermsId: 2645 });
+      expect.fail("expected LicenseTransactionRevertedError");
+    } catch (err) {
+      expect(err).toBeInstanceOf(LicenseTransactionRevertedError);
+      expect((err as LicenseTransactionRevertedError).step).toBe("deposit");
+    }
+    // Only the deposit was attempted — no approve/mint after the revert.
+    expect(walletClient.prepareTransactionRequest).toHaveBeenCalledTimes(1);
+  });
+
+  it("standalone mintLicenseToken function works without a CDRClient", async () => {
+    const { publicClient, walletClient } = makeClients({ fee: 0n });
+    const result = await mintLicenseToken({
+      publicClient: publicClient as any,
+      walletClient: walletClient as any,
+      licensorIpId: LICENSOR,
+      licenseTermsId: 2645,
+    });
+    expect(result.licenseTokenIds).toEqual([100n]);
+  });
+});
+
+describe("CDRClient.license getter", () => {
+  it("throws WalletClientRequiredError without a wallet", () => {
+    const client = new CDRClient({
+      network: "testnet",
+      publicClient: { readContract: vi.fn() } as any,
+      apiUrl: "http://test:1317",
+    });
+    expect(() => client.license).toThrow(WalletClientRequiredError);
+  });
+});

--- a/packages/sdk/__tests__/license.test.ts
+++ b/packages/sdk/__tests__/license.test.ts
@@ -11,6 +11,7 @@ import {
 } from "../src/license-contracts.js";
 import {
   InsufficientBalanceError,
+  InvalidParamsError,
   LicenseMintPreparationError,
   LicenseTokensMintedEventNotFoundError,
   LicenseTransactionRevertedError,
@@ -179,6 +180,36 @@ describe("LicenseClient.mintLicenseToken", () => {
       license.mintLicenseToken({ licensorIpId: LICENSOR, licenseTermsId: 2645 }),
     ).rejects.toThrow(InsufficientBalanceError);
     expect(walletClient.prepareTransactionRequest).not.toHaveBeenCalled();
+  });
+
+  it("rejects amount < 1 and amount beyond MAX_SAFE_INTEGER", async () => {
+    const { license } = makeClients({ fee: 0n });
+    await expect(
+      license.mintLicenseToken({ licensorIpId: LICENSOR, licenseTermsId: 2645, amount: 0 }),
+    ).rejects.toThrow(InvalidParamsError);
+    await expect(
+      license.mintLicenseToken({
+        licensorIpId: LICENSOR,
+        licenseTermsId: 2645,
+        amount: BigInt(Number.MAX_SAFE_INTEGER) + 1n,
+      }),
+    ).rejects.toThrow(InvalidParamsError);
+  });
+
+  it("missing getBalance: skips the native preflight and proceeds to wrap", async () => {
+    const { license, publicClient, walletClient } = makeClients({
+      fee: 10n,
+      wipBalance: 0n,
+    });
+    // Structural client without getBalance — the typed preflight is skipped.
+    delete (publicClient as any).getBalance;
+    const result = await license.mintLicenseToken({
+      licensorIpId: LICENSOR,
+      licenseTermsId: 2645,
+    });
+    expect(result.wrappedWei).toBe(10n);
+    expect(result.txHashes.deposit).toBeDefined();
+    expect(walletClient.prepareTransactionRequest).toHaveBeenCalled();
   });
 
   it("non-WIP fee currency: throws UnsupportedLicenseCurrencyError", async () => {

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -1,6 +1,7 @@
 import type { Network } from "@piplabs/cdr-contracts";
 import { Uploader } from "./uploader.js";
 import { Consumer } from "./consumer.js";
+import { LicenseClient } from "./license.js";
 import { Observer } from "./observer.js";
 import type { CDRPublicClient, CDRWalletClient } from "./client-types.js";
 import { type CDRLogger, noopLogger } from "./logger.js";
@@ -10,6 +11,7 @@ export class CDRClient {
   public readonly observer: Observer;
   private _uploader: Uploader | null;
   private _consumer: Consumer | null;
+  private _license: LicenseClient | null;
 
   constructor(params: {
     network: Network;
@@ -49,9 +51,11 @@ export class CDRClient {
         apiUrl,
         logger,
       });
+      this._license = new LicenseClient({ publicClient, walletClient, logger });
     } else {
       this._uploader = null;
       this._consumer = null;
+      this._license = null;
     }
   }
 
@@ -65,5 +69,15 @@ export class CDRClient {
   get consumer(): Consumer {
     if (!this._consumer) throw new WalletClientRequiredError();
     return this._consumer;
+  }
+
+  /**
+   * Access the license helper (Story Protocol license-token minting with
+   * automatic WIP fee handling, #39). Throws WalletClientRequiredError if
+   * no wallet was provided.
+   */
+  get license(): LicenseClient {
+    if (!this._license) throw new WalletClientRequiredError();
+    return this._license;
   }
 }

--- a/packages/sdk/src/errors.ts
+++ b/packages/sdk/src/errors.ts
@@ -132,6 +132,60 @@ export class VaultAllocatedEventNotFoundError extends CDRError {
 }
 
 /**
+ * The license terms' minting fee is denominated in a token the SDK cannot
+ * auto-wrap. Only the native-token wrapper WIP is supported — pay the fee
+ * manually in the terms' currency, then mint without this helper.
+ */
+export class UnsupportedLicenseCurrencyError extends CDRError {
+  currency: `0x${string}`;
+  constructor(currency: `0x${string}`) {
+    super(
+      `License minting fee is denominated in ${currency}, which is not the WIP native-token wrapper — auto-wrapping cannot pay it`,
+      "UNSUPPORTED_LICENSE_CURRENCY",
+    );
+    this.currency = currency;
+  }
+}
+
+/**
+ * A fee-preparation step (wrap / approve) was needed but disabled via
+ * `autoWrap: false` / `autoApprove: false`. Perform the step manually or
+ * re-enable the flag.
+ */
+export class LicenseMintPreparationError extends CDRError {
+  constructor(message: string) {
+    super(message, "LICENSE_MINT_PREPARATION");
+  }
+}
+
+export class LicenseTokensMintedEventNotFoundError extends CDRError {
+  constructor() {
+    super(
+      "LicenseTokensMinted event not found in transaction logs",
+      "LICENSE_TOKENS_MINTED_EVENT_NOT_FOUND",
+    );
+  }
+}
+
+/**
+ * A license-mint step (`deposit` / `approve` / `mint`) landed on-chain but
+ * its transaction reverted. `step` says which one, so the failure isn't
+ * mistaken for a missing mint event.
+ */
+export class LicenseTransactionRevertedError extends CDRError {
+  step: "deposit" | "approve" | "mint";
+  txHash: `0x${string}`;
+  constructor(step: "deposit" | "approve" | "mint", txHash: `0x${string}`) {
+    super(
+      `License ${step} transaction ${txHash} reverted`,
+      "LICENSE_TRANSACTION_REVERTED",
+    );
+    this.step = step;
+    this.txHash = txHash;
+  }
+}
+
+/**
  * Thrown by `hexToBytes` when the input is malformed. `reason` discriminates
  * the failure mode so callers can branch without parsing the message:
  *   - `"ODD_LENGTH"`: hex digit count was odd — `length` carries the count.
@@ -226,9 +280,9 @@ export class InvalidPartialError extends CDRError {
 export class InsufficientBalanceError extends CDRError {
   balance: bigint;
   required: bigint;
-  constructor(balance: bigint, required: bigint) {
+  constructor(balance: bigint, required: bigint, context = "read fee") {
     super(
-      `Insufficient balance for read fee: have ${balance}, need ${required}`,
+      `Insufficient balance for ${context}: have ${balance}, need ${required}`,
       "INSUFFICIENT_BALANCE",
     );
     this.balance = balance;

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -9,7 +9,6 @@ export * from "./errors.js";
 export * from "./label.js";
 export * from "./conditions.js";
 export * from "./license.js";
-export * from "./license-contracts.js";
 export * from "./attestation.js";
 export * from "./storage/index.js";
 export * from "./story-api/index.js";

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -8,6 +8,8 @@ export * from "./types.js";
 export * from "./errors.js";
 export * from "./label.js";
 export * from "./conditions.js";
+export * from "./license.js";
+export * from "./license-contracts.js";
 export * from "./attestation.js";
 export * from "./storage/index.js";
 export * from "./story-api/index.js";

--- a/packages/sdk/src/license-contracts.ts
+++ b/packages/sdk/src/license-contracts.ts
@@ -1,0 +1,115 @@
+/**
+ * Minimal Story Protocol contract surface for license-token minting (#39).
+ *
+ * These are Story Protocol deployments, NOT part of the CDR system — kept
+ * here (not in `@piplabs/cdr-contracts`) so that package stays purely CDR.
+ * ABIs are the subset of functions/events this SDK calls; re-sync against
+ * thedatafoundation/sdk `packages/core-sdk/src/abi/generated.ts`.
+ *
+ * All addresses are identical on Aeneid (1315) and mainnet (1514) —
+ * deterministic deployments — so they are flat constants rather than a
+ * per-network map.
+ */
+
+/** WIP — the immutable native-token wrapper (pre-rebrand name; wraps native $DATA). */
+export const WIP_ADDRESS =
+  "0x1514000000000000000000000000000000000000" as const;
+
+/** Story Protocol LicensingModule — mints license tokens against license terms. */
+export const LICENSING_MODULE_ADDRESS =
+  "0x04fbd8a2e56dd85CFD5500A4A4DfA955B9f1dE6f" as const;
+
+/** Story Protocol RoyaltyModule — pulls the minting fee via WIP `transferFrom`. */
+export const ROYALTY_MODULE_ADDRESS =
+  "0xD2f60c40fEbccf6311f8B47c4f2Ec6b040400086" as const;
+
+/** Story Protocol PILicenseTemplate — the default `licenseTemplate` for terms. */
+export const PI_LICENSE_TEMPLATE_ADDRESS =
+  "0x2E896b0b2Fdb7457499B56AAaA4AE55BCB4Cd316" as const;
+
+export const wipAbi = [
+  {
+    type: "function",
+    name: "balanceOf",
+    inputs: [{ name: "owner", type: "address" }],
+    outputs: [{ name: "", type: "uint256" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "allowance",
+    inputs: [
+      { name: "owner", type: "address" },
+      { name: "spender", type: "address" },
+    ],
+    outputs: [{ name: "", type: "uint256" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "deposit",
+    inputs: [],
+    outputs: [],
+    stateMutability: "payable",
+  },
+  {
+    type: "function",
+    name: "approve",
+    inputs: [
+      { name: "spender", type: "address" },
+      { name: "amount", type: "uint256" },
+    ],
+    outputs: [{ name: "", type: "bool" }],
+    stateMutability: "nonpayable",
+  },
+] as const;
+
+export const licensingModuleAbi = [
+  {
+    type: "function",
+    name: "predictMintingLicenseFee",
+    inputs: [
+      { name: "licensorIpId", type: "address" },
+      { name: "licenseTemplate", type: "address" },
+      { name: "licenseTermsId", type: "uint256" },
+      { name: "amount", type: "uint256" },
+      { name: "receiver", type: "address" },
+      { name: "royaltyContext", type: "bytes" },
+    ],
+    outputs: [
+      { name: "currencyToken", type: "address" },
+      { name: "tokenAmount", type: "uint256" },
+    ],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "mintLicenseTokens",
+    inputs: [
+      { name: "licensorIpId", type: "address" },
+      { name: "licenseTemplate", type: "address" },
+      { name: "licenseTermsId", type: "uint256" },
+      { name: "amount", type: "uint256" },
+      { name: "receiver", type: "address" },
+      { name: "royaltyContext", type: "bytes" },
+      { name: "maxMintingFee", type: "uint256" },
+      { name: "maxRevenueShare", type: "uint32" },
+    ],
+    outputs: [{ name: "startLicenseTokenId", type: "uint256" }],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "event",
+    name: "LicenseTokensMinted",
+    anonymous: false,
+    inputs: [
+      { name: "caller", type: "address", indexed: true },
+      { name: "licensorIpId", type: "address", indexed: true },
+      { name: "licenseTemplate", type: "address", indexed: false },
+      { name: "licenseTermsId", type: "uint256", indexed: true },
+      { name: "amount", type: "uint256", indexed: false },
+      { name: "receiver", type: "address", indexed: false },
+      { name: "startLicenseTokenId", type: "uint256", indexed: false },
+    ],
+  },
+] as const;

--- a/packages/sdk/src/license.ts
+++ b/packages/sdk/src/license.ts
@@ -150,6 +150,14 @@ export class LicenseClient {
     params: MintLicenseTokenParams,
   ): Promise<MintLicenseTokenResult> {
     const amount = BigInt(params.amount ?? 1);
+    // Upper bound is Number.MAX_SAFE_INTEGER because the token-id expansion
+    // below uses `Number(amount)`; beyond it that conversion loses precision.
+    // (Any real mint is a handful of tokens — this only rejects absurd input.)
+    if (amount < 1n || amount > BigInt(Number.MAX_SAFE_INTEGER)) {
+      throw new InvalidParamsError(
+        `mintLicenseToken: amount must be between 1 and ${Number.MAX_SAFE_INTEGER}`,
+      );
+    }
     const licenseTermsId = BigInt(params.licenseTermsId);
     const licenseTemplate = params.licenseTemplate ?? PI_LICENSE_TEMPLATE_ADDRESS;
     const minter = getWalletAddress(this.walletClient.account);
@@ -200,7 +208,9 @@ export class LicenseClient {
           );
         }
         // Native must cover the wrap; check only when the structural client
-        // exposes getBalance (mirrors Consumer.read's fee preflight).
+        // exposes getBalance (mirrors Consumer.read's fee preflight). When it
+        // doesn't, the deposit still reverts on-chain for a true shortfall —
+        // just without the typed early error, so log the skip for parity.
         if (this.publicClient.getBalance) {
           const nativeBalance = await this.publicClient.getBalance({ address: minter });
           if (nativeBalance < shortfall) {
@@ -210,6 +220,11 @@ export class LicenseClient {
               "license minting fee (wrapping native DATA to WIP)",
             );
           }
+        } else {
+          this.logger.debug("license.wrap.preflight.skipped", {
+            reason: "publicClient has no getBalance",
+            shortfall: shortfall.toString(),
+          });
         }
         ({ hash: txHashes.deposit } = await this.writeAndConfirm("deposit", {
           address: WIP_ADDRESS,

--- a/packages/sdk/src/license.ts
+++ b/packages/sdk/src/license.ts
@@ -1,0 +1,320 @@
+import {
+  decodeEventLog,
+  maxUint256,
+  type PublicClient,
+  type WalletClient,
+} from "viem";
+import {
+  InsufficientBalanceError,
+  InvalidParamsError,
+  LicenseMintPreparationError,
+  LicenseTokensMintedEventNotFoundError,
+  LicenseTransactionRevertedError,
+  UnsupportedLicenseCurrencyError,
+} from "./errors.js";
+import type { TransactionReceipt } from "viem";
+import {
+  type CDRPublicClient,
+  type CDRWalletClient,
+  getWalletAddress,
+} from "./client-types.js";
+import { type CDRLogger, noopLogger } from "./logger.js";
+import { safeWriteContract } from "./_tx-submit.js";
+import { waitForReceiptResilient } from "./_rpc-resilience.js";
+import {
+  LICENSING_MODULE_ADDRESS,
+  PI_LICENSE_TEMPLATE_ADDRESS,
+  ROYALTY_MODULE_ADDRESS,
+  WIP_ADDRESS,
+  licensingModuleAbi,
+  wipAbi,
+} from "./license-contracts.js";
+
+/**
+ * 100% in the licensing module's revenue-share basis points (1% = 10^6).
+ * Passed as `maxRevenueShare` = "accept any licensor revenue share" — the
+ * SDK does not restrict terms on the caller's behalf.
+ */
+const MAX_REVENUE_SHARE_100_PCT = 100_000_000;
+
+export interface MintLicenseTokenResult {
+  /** Minted token IDs, ready to encode as `accessAuxData` for `accessCDR`. */
+  licenseTokenIds: bigint[];
+  /** Fee paid (in WIP wei) for the whole mint; 0n for free terms. */
+  feePaid: bigint;
+  /** Native DATA wrapped into WIP by this call; 0n when balance sufficed. */
+  wrappedWei: bigint;
+  /** Hashes of the steps that actually ran (wrap/approve are skipped when unneeded). */
+  txHashes: {
+    deposit?: `0x${string}`;
+    approve?: `0x${string}`;
+    mint: `0x${string}`;
+  };
+}
+
+export interface MintLicenseTokenParams {
+  /** The licensor IP asset (IP ID) to mint a license for. */
+  licensorIpId: `0x${string}`;
+  /** License terms ID attached to the licensor IP. */
+  licenseTermsId: bigint | number;
+  /** Number of license tokens to mint (default 1). */
+  amount?: bigint | number;
+  /** Recipient of the minted tokens (default: the wallet address). */
+  receiver?: `0x${string}`;
+  /** License template the terms live on (default: PILicenseTemplate). */
+  licenseTemplate?: `0x${string}`;
+  /**
+   * Auto-wrap native DATA into WIP when the WIP balance can't cover the
+   * fee (default true). When false, a shortfall throws
+   * {@link LicenseMintPreparationError} instead of wrapping.
+   */
+  autoWrap?: boolean;
+  /**
+   * Auto-approve the RoyaltyModule for the fee when the current allowance
+   * is short (default true; approves `maxUint256`, so subsequent mints skip
+   * the approval tx). When false, a short allowance throws
+   * {@link LicenseMintPreparationError}.
+   */
+  autoApprove?: boolean;
+}
+
+/**
+ * Mints Story Protocol license tokens, handling the WIP fee end-to-end
+ * (#39): predicts the minting fee on-chain, wraps the missing amount of
+ * native DATA into WIP, approves the RoyaltyModule, and executes the mint —
+ * so reading a `LicenseReadCondition`-gated vault needs no manual
+ * `deposit`/`approve` steps and no separate Story SDK.
+ *
+ * Fee preparation is idempotent: steps that aren't needed (sufficient WIP,
+ * standing allowance, zero-fee terms) are skipped and absent from the
+ * returned `txHashes`.
+ *
+ * The predicted fee is passed on-chain as `maxMintingFee`, so a fee raised
+ * between prediction and execution reverts the mint instead of overpaying.
+ *
+ * @example
+ * ```ts
+ * const { licenseTokenIds } = await cdr.license.mintLicenseToken({
+ *   licensorIpId: "0x072D...",
+ *   licenseTermsId: 2645,
+ * });
+ * const accessAuxData = encodeAbiParameters(
+ *   [{ type: "uint256[]" }],
+ *   [licenseTokenIds],
+ * );
+ * const { dataKey } = await cdr.consumer.accessCDR({ uuid, accessAuxData });
+ * ```
+ */
+export class LicenseClient {
+  private publicClient: CDRPublicClient;
+  private walletClient: CDRWalletClient;
+  private logger: CDRLogger;
+
+  constructor(params: {
+    publicClient: CDRPublicClient;
+    walletClient: CDRWalletClient;
+    /** Optional structured logger; defaults to a no-op. */
+    logger?: CDRLogger;
+  }) {
+    this.publicClient = params.publicClient;
+    this.walletClient = params.walletClient;
+    this.logger = params.logger ?? noopLogger;
+  }
+
+  /**
+   * Submit a write, wait for its receipt, and fail loudly if it reverted.
+   * `waitForReceiptResilient` returns reverted receipts rather than throwing
+   * (see its docs), so without this a reverted deposit/approve would cascade
+   * into a misleading "mint event not found" at the end.
+   */
+  private async writeAndConfirm(
+    step: "deposit" | "approve" | "mint",
+    params: Parameters<typeof safeWriteContract>[2],
+  ): Promise<{ hash: `0x${string}`; receipt: TransactionReceipt }> {
+    const hash = await safeWriteContract(
+      this.walletClient as unknown as WalletClient,
+      this.publicClient as unknown as PublicClient,
+      params,
+    );
+    const receipt = await waitForReceiptResilient(
+      this.publicClient as unknown as PublicClient,
+      hash,
+    );
+    if (receipt.status === "reverted") {
+      throw new LicenseTransactionRevertedError(step, hash);
+    }
+    return { hash, receipt };
+  }
+
+  async mintLicenseToken(
+    params: MintLicenseTokenParams,
+  ): Promise<MintLicenseTokenResult> {
+    const amount = BigInt(params.amount ?? 1);
+    const licenseTermsId = BigInt(params.licenseTermsId);
+    const licenseTemplate = params.licenseTemplate ?? PI_LICENSE_TEMPLATE_ADDRESS;
+    const minter = getWalletAddress(this.walletClient.account);
+    if (!minter) {
+      throw new InvalidParamsError(
+        "mintLicenseToken: walletClient has no resolvable account address",
+      );
+    }
+    const receiver = params.receiver ?? minter;
+    const autoWrap = params.autoWrap !== false;
+    const autoApprove = params.autoApprove !== false;
+
+    // 1. Predict the fee on-chain — returns the terms' currency too, which
+    // doubles as the only-WIP-supported check.
+    const [currencyToken, feeWei] = (await this.publicClient.readContract({
+      address: LICENSING_MODULE_ADDRESS,
+      abi: licensingModuleAbi,
+      functionName: "predictMintingLicenseFee",
+      args: [params.licensorIpId, licenseTemplate, licenseTermsId, amount, receiver, "0x"],
+    })) as [`0x${string}`, bigint];
+    this.logger.debug("license.fee.predicted", {
+      licensorIpId: params.licensorIpId,
+      licenseTermsId: licenseTermsId.toString(),
+      currencyToken,
+      feeWei: feeWei.toString(),
+    });
+
+    const txHashes: MintLicenseTokenResult["txHashes"] = { mint: "0x" };
+    let wrappedWei = 0n;
+
+    if (feeWei > 0n) {
+      if (currencyToken.toLowerCase() !== WIP_ADDRESS.toLowerCase()) {
+        throw new UnsupportedLicenseCurrencyError(currencyToken);
+      }
+
+      // 2. Wrap the shortfall (if any) from native DATA into WIP.
+      const wipBalance = (await this.publicClient.readContract({
+        address: WIP_ADDRESS,
+        abi: wipAbi,
+        functionName: "balanceOf",
+        args: [minter],
+      })) as bigint;
+      const shortfall = feeWei > wipBalance ? feeWei - wipBalance : 0n;
+      if (shortfall > 0n) {
+        if (!autoWrap) {
+          throw new LicenseMintPreparationError(
+            `WIP balance ${wipBalance} is short of the ${feeWei} minting fee and autoWrap is disabled — wrap ${shortfall} manually via WIP.deposit() or re-enable autoWrap`,
+          );
+        }
+        // Native must cover the wrap; check only when the structural client
+        // exposes getBalance (mirrors Consumer.read's fee preflight).
+        if (this.publicClient.getBalance) {
+          const nativeBalance = await this.publicClient.getBalance({ address: minter });
+          if (nativeBalance < shortfall) {
+            throw new InsufficientBalanceError(
+              nativeBalance,
+              shortfall,
+              "license minting fee (wrapping native DATA to WIP)",
+            );
+          }
+        }
+        ({ hash: txHashes.deposit } = await this.writeAndConfirm("deposit", {
+          address: WIP_ADDRESS,
+          abi: wipAbi,
+          functionName: "deposit",
+          args: [],
+          value: shortfall,
+        }));
+        wrappedWei = shortfall;
+        this.logger.debug("license.wrapped", {
+          wrappedWei: shortfall.toString(),
+          txHash: txHashes.deposit,
+        });
+      }
+
+      // 3. Ensure the RoyaltyModule allowance covers the fee.
+      const allowance = (await this.publicClient.readContract({
+        address: WIP_ADDRESS,
+        abi: wipAbi,
+        functionName: "allowance",
+        args: [minter, ROYALTY_MODULE_ADDRESS],
+      })) as bigint;
+      if (allowance < feeWei) {
+        if (!autoApprove) {
+          throw new LicenseMintPreparationError(
+            `WIP allowance ${allowance} for the RoyaltyModule is short of the ${feeWei} minting fee and autoApprove is disabled — approve manually or re-enable autoApprove`,
+          );
+        }
+        ({ hash: txHashes.approve } = await this.writeAndConfirm("approve", {
+          address: WIP_ADDRESS,
+          abi: wipAbi,
+          functionName: "approve",
+          args: [ROYALTY_MODULE_ADDRESS, maxUint256],
+        }));
+        this.logger.debug("license.approved", {
+          spender: ROYALTY_MODULE_ADDRESS,
+          txHash: txHashes.approve,
+        });
+      }
+    }
+
+    // 4. Mint. The predicted fee doubles as maxMintingFee so a fee raised
+    // after prediction reverts instead of overpaying.
+    const { hash: mintHash, receipt } = await this.writeAndConfirm("mint", {
+      address: LICENSING_MODULE_ADDRESS,
+      abi: licensingModuleAbi,
+      functionName: "mintLicenseTokens",
+      args: [
+        params.licensorIpId,
+        licenseTemplate,
+        licenseTermsId,
+        amount,
+        receiver,
+        "0x",
+        feeWei,
+        MAX_REVENUE_SHARE_100_PCT,
+      ],
+    });
+    txHashes.mint = mintHash;
+
+    // 5. Recover the minted token IDs from the LicenseTokensMinted event.
+    let startLicenseTokenId: bigint | null = null;
+    for (const log of receipt.logs ?? []) {
+      if (log.address.toLowerCase() !== LICENSING_MODULE_ADDRESS.toLowerCase()) continue;
+      try {
+        const decoded = decodeEventLog({
+          abi: licensingModuleAbi,
+          eventName: "LicenseTokensMinted",
+          data: log.data,
+          topics: log.topics,
+        });
+        startLicenseTokenId = decoded.args.startLicenseTokenId;
+        break;
+      } catch {
+        // Not the LicenseTokensMinted event — keep scanning.
+      }
+    }
+    if (startLicenseTokenId === null) {
+      throw new LicenseTokensMintedEventNotFoundError();
+    }
+    const licenseTokenIds = Array.from(
+      { length: Number(amount) },
+      (_, i) => startLicenseTokenId! + BigInt(i),
+    );
+    this.logger.debug("license.minted", {
+      licenseTokenIds: licenseTokenIds.map(String),
+      feePaid: feeWei.toString(),
+      txHash: txHashes.mint,
+    });
+
+    return { licenseTokenIds, feePaid: feeWei, wrappedWei, txHashes };
+  }
+}
+
+/**
+ * Standalone form of {@link LicenseClient.mintLicenseToken} for callers
+ * without a `CDRClient` — same parameters plus the two viem clients.
+ */
+export async function mintLicenseToken(
+  params: MintLicenseTokenParams & {
+    publicClient: CDRPublicClient;
+    walletClient: CDRWalletClient;
+    logger?: CDRLogger;
+  },
+): Promise<MintLicenseTokenResult> {
+  const { publicClient, walletClient, logger, ...rest } = params;
+  return new LicenseClient({ publicClient, walletClient, logger }).mintLicenseToken(rest);
+}


### PR DESCRIPTION
## Summary

Closes #39. Reading a `LicenseReadCondition`-gated vault requires holding a Story Protocol license token, and minting one charges a fee the RoyaltyModule pulls in **WIP** (the ERC-20 wrapper of the native token). A user with only native balance and no WIP hit a bare `InsufficientBalance` revert and had to run three manual transactions — `WIP.deposit()`, `WIP.approve(RoyaltyModule, fee)`, `LicensingModule.mintLicenseTokens(...)` — or pull in the heavy `@story-protocol/core-sdk`.

This adds `mintLicenseToken`, which does the whole flow in one call: predict the fee on-chain → wrap the missing native DATA into WIP → approve the RoyaltyModule → mint → return the token IDs (ready to encode as `accessAuxData` for `accessCDR`). Fee preparation is idempotent — wrap/approve are skipped when balance/allowance already suffice.

> **Token naming:** the native token was renamed $IP → $DATA in the rebrand, but its wrapper contract (`0x1514…`, immutable) keeps the on-chain name **WIP**. So the flow wraps native **DATA** and receives **WIP** — the name mismatch is expected. Existing license terms are WIP-denominated, so the helper handles WIP only; WDATA (a separate new wrapper) is out of scope, and non-WIP terms surface `UnsupportedLicenseCurrencyError`.

## API

Exposed two ways (mirrors observer/uploader/consumer):
- `client.license.mintLicenseToken({ licensorIpId, licenseTermsId, amount?, receiver?, autoWrap?, autoApprove? })`
- standalone `mintLicenseToken({ publicClient, walletClient, ...same })` for callers without a `CDRClient`

Returns `{ licenseTokenIds, feePaid, wrappedWei, txHashes }` — `txHashes.deposit`/`.approve` are absent when those steps were skipped.

## Design notes

- **Fee is read on-chain** (`predictMintingLicenseFee`), not passed in — the caller shouldn't need to know it. The same call returns the fee currency, which gives the WIP-only check for free (non-WIP terms → `UnsupportedLicenseCurrencyError`).
- **`maxUint256` approval by default** so repeat mints skip the approve tx (opt out with `autoApprove: false`). `autoWrap: false` likewise turns a shortfall into a typed error instead of wrapping.
- **Predicted fee is passed as `maxMintingFee`** so terms repriced between prediction and execution revert rather than overpay.
- **Story Protocol contracts kept in a self-contained `license-contracts.ts`** (addresses + minimal ABI subsets), NOT in `@piplabs/cdr-contracts`, so that package stays purely CDR. Addresses are identical on Aeneid and mainnet.
- **Not wired into `accessCDR`** — minting spends money and the read path can't reliably infer mint parameters, so it stays an explicit user-invoked helper. (A future non-spending enhancement could make `accessCDR` point at it when a license-gated read fails.)
- **Multicall batching and `@story-protocol/core-sdk` deliberately avoided** — sequential txs keep the new external surface to the addresses above.

## Tests

- **16 unit tests** (`license.test.ts`): free terms, sufficient-WIP fast path, approve-then-mint, exact-shortfall wrap, insufficient-native (typed error, zero txs), non-WIP currency, both opt-out flags, `amount > 1` with full mint-arg assertion, missing mint event, reverted deposit/mint (step-labeled error, no cascade), standalone function, wallet-required getter.
- **Integration DX-03 un-skipped & parametrized** (`dx-improvements.test.ts`): runs the full `LicenseReadCondition` journey (upload gated vault → unlicensed read rejects → fresh reader mints via the helper → gated read recovers the dataKey) over **two Aeneid fixtures** — free terms (2054) and a **fee-bearing pair** (`0x2dfC…`/2795, 1 WIP, currency + fee verified on-chain via `predictMintingLicenseFee`). Free asserts the wrap/approve **skip** path; fee-bearing asserts wrap→approve→pay (`feePaid > 0`, `wrappedWei === feePaid`, deposit+approve ran).

## Test plan

- [x] `pnpm -r build`, `pnpm lint`, unit tests green (270 sdk + 22 crypto + 21 monitor + 15 cli)
- [x] ABI subsets + addresses verified against thedatafoundation/sdk generated bindings
- [x] DX-03 live on Aeneid (both fixtures): https://github.com/piplabs/cdr-sdk/actions/runs/29810427904/job/88569996670

## Review fixes (jinn-agent)

- Dropped the `license-contracts` re-export from `index.ts` — raw ABIs/addresses stay out of the public semver surface.
- Reject `amount < 1` or `> Number.MAX_SAFE_INTEGER` (guards the `Number(amount)` token-id expansion).
- Log `license.wrap.preflight.skipped` when `getBalance` is absent, for parity with `Consumer.preflightBalance`.
- DX-03's fee assertion was mis-scoped (2054 is free on-chain, so `feePaid > 0` falsely failed). Resolved by parametrizing over a free fixture (asserts wrap/approve skipped) and a verified fee-bearing fixture (asserts the fee path), rather than assuming any single terms carries a fee.
