### PR TITLE
fix(cli): derive --version from package.json to end version-stamp drift

### DIFF
--- a/apps/cli/__integration__/cli.test.ts
+++ b/apps/cli/__integration__/cli.test.ts
@@ -22,6 +22,7 @@ import { describe, it, expect, beforeAll } from "vitest";
 import { execaNode } from "execa";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { createRequire } from "node:module";
 
 /**
  * Per-case diagnostic logger. Mirrors `packages/sdk/__integration__/_helpers.ts:logCase`
@@ -124,6 +125,21 @@ beforeAll(async () => {
   // eslint-disable-next-line no-console
   console.log(`\n[suite-setup] openCondition deployed at ${openCondition}\n`);
 }, 30_000);
+
+// ---------------------------------------------------------------------------
+// Binary metadata — no network, no wallet.
+// ---------------------------------------------------------------------------
+
+describe("binary metadata", () => {
+  it("--version matches package.json (guards against #134-style drift)", async () => {
+    const require = createRequire(import.meta.url);
+    const { version } = require("../package.json") as { version: string };
+    const { stdout, exitCode } = await runCli(["--version"], {});
+    logCase("reported version", stdout);
+    expect(exitCode).toBe(0);
+    expect(stdout.trim()).toBe(version);
+  }, 30_000);
+});
 
 // ---------------------------------------------------------------------------
 // Read-only `status` commands — no wallet required, no chain mutation.

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -3,11 +3,12 @@ import { Command } from "commander";
 import { statusCommand } from "./commands/status.js";
 import { uploadCommand } from "./commands/upload.js";
 import { accessCommand } from "./commands/access.js";
+import { version } from "./version.js";
 
 const program = new Command()
   .name("cdr-cli")
   .description("CLI wrapping common SDK operations against a live Story L1 CDR system")
-  .version("0.1.2")
+  .version(version)
   .option("--network <network>", "Network (mainnet or testnet)", "testnet")
   .option("--rpc-url <url>", "EVM RPC URL (or CDR_RPC_URL env; falls back to network default)")
   .option("--api-url <url>", "Story-API REST URL (or CDR_API_URL env, required)")

--- a/apps/cli/src/version-cjs.cts
+++ b/apps/cli/src/version-cjs.cts
@@ -1,0 +1,3 @@
+// CommonJS counterpart of version.ts — tshy swaps this in for the CJS build,
+// where `require` is native and `import.meta` won't compile.
+export const version: string = require("@piplabs/cdr-cli/package.json").version;

--- a/apps/cli/src/version.ts
+++ b/apps/cli/src/version.ts
@@ -1,0 +1,8 @@
+import { createRequire } from "node:module";
+
+// Self-reference through the package's own `exports` map, so this resolves
+// from both `src/` (tsx dev) and `dist/esm/` without a fragile relative path.
+// The CJS build swaps in `version-cjs.cts` (tshy dialect polyfill), but still
+// type-checks this file — hence the ts-ignore on the ESM-only `import.meta`.
+//@ts-ignore
+export const version: string = createRequire(import.meta.url)("@piplabs/cdr-cli/package.json").version;


### PR DESCRIPTION
## Summary

Closes #134. The published `cdr-cli` printed a stale version for `--version` (the 0.2.2 binary reported `0.1.2`), because `apps/cli/src/index.ts` hardcoded `.version("0.1.2")` into commander. The release workflow bumps only the four `package.json` manifests, so the npm-level version was correct but the binary never knew its own version.

The version is now **derived from `package.json` at runtime**, so the stamp cannot drift from the published version again. This is issue #134's Option 1, kept compatible with dual (ESM + CJS) publishing via a tshy dialect polyfill rather than dropping the CJS build or generating a file at build time.

## Approach

- `src/version.ts` (ESM): `createRequire(import.meta.url)("@piplabs/cdr-cli/package.json").version`. Self-referencing through the package's own `exports` map resolves correctly from both `src/` (tsx dev) and `dist/esm/` without a depth-fragile relative path.
- `src/version-cjs.cts`: the CommonJS counterpart using native `require`. tshy's `-cjs.cts` dialect-polyfill convention swaps this in for the CJS build only, where `import.meta` won't compile. A `//@ts-ignore` on the ESM file's `import.meta` line is required because tshy still type-checks it during the CJS pass — this is the documented convention.
- `src/index.ts`: `.version("0.1.2")` → `.version(version)`.

## Why this survives the next release

The release workflow's bump step runs `npm pkg set version` on `apps/cli` (it's in the `PACKAGES` list) and nothing else, then rebuilds before publish via `prepublishOnly`. Both build dialects read the version at runtime from that freshly-bumped manifest, so a bump-only change flows to the binary automatically — verified by simulation below.

## Test plan

- [x] `pnpm lint` (tsc --noEmit) and `pnpm build` (tshy) clean
- [x] `--version` reports `0.2.2` from all run modes: built ESM (`dist/esm/index.js`, the bin), built CJS (`dist/commonjs/index.js`), and dev (`tsx src/index.ts`)
- [x] **Future-bump simulation**: `npm pkg set version=9.9.9` on `package.json` only (no source edits), rebuild → ESM/CJS/dev all report `9.9.9`; restored to `0.2.2` after
- [x] **Packaged-artifact check**: `pnpm pack` → installed the tarball into a clean project → `./node_modules/.bin/cdr-cli --version` reports the correct version (reproduces the environment where 0.2.2 failed)
- [x] New integration case in `apps/cli/__integration__/cli.test.ts` asserts the binary's `--version` equals `package.json` (network-independent; guards against reintroducing a hardcoded literal)

## Notes

- The `--version` regression is caught by the integration suite (source tree) and by post-release verification (published tarball, which is what caught it last time). Neither gates the publish itself — this PR makes the drift structurally impossible rather than adding a pre-publish gate. A release-time assertion can be added separately if we want.
- The new integration assertion exercises the ESM build, which is the only dialect `bin.cdr-cli` points at — i.e. the only version surface a CLI user can reach. The CJS `--version` path is verified manually but is not consumer-reachable given the current package shape (no `require`-able version API; `bin` is a literal ESM path, not an `exports`-conditional entry).