### PR TITLE
fix(post-release): split CJS smoke into resolve (bridge-off) + require (default) to end engines-contract false failure

### DIFF
--- a/.github/workflows/post-release-integration.yml
+++ b/.github/workflows/post-release-integration.yml
@@ -288,19 +288,31 @@ jobs:
 
       - name: 'Smoke: CJS imports'
         id: cjs_smoke
-        # NODE_OPTIONS=--no-experimental-require-module disables Node's
-        # implicit ESM-bridge for require(). Without it, Node 20.19+ and
-        # 22.12+ silently bridge `require("@piplabs/cdr-sdk")` even when
-        # the package is ESM-only with no exports.require — defeating the
-        # gate. With the flag, require() returns the original
-        # ERR_REQUIRE_ESM, catching the missing CJS entry that consumers
-        # on Node <20.19 (still LTS-supported) actually hit.
+        # Two-phase gate — see #135. Phase 1 (resolve, bridge OFF):
+        # require.resolve() under --no-experimental-require-module verifies a
+        # real CJS entry exists (exports.require / CJS main) without executing
+        # transitive ESM-only deps. Phase 2 (require, bridge ON = default Node
+        # options): require() the package the way a real consumer does. Every
+        # runtime engines admits (node >=20.19.0) bridges require(esm) by
+        # default, so an ESM-only transitive dep (@noble/hashes v2) loads —
+        # forcing the bridge off here was a false failure for a Node <20.19
+        # runtime engines already excludes.
         if: always() && steps.install.outcome == 'success'
-        env:
-          NODE_OPTIONS: --no-experimental-require-module
         run: |
           set -uo pipefail
           cd "$INSTALL_DIR"
+          # Phase 1 helper: resolve the CJS entry without loading it.
+          cat > resolve.cjs <<'JSEOF'
+          const pkgName = process.argv[2];
+          try {
+            const resolved = require.resolve(pkgName);
+            console.log(`OK ${pkgName}: CJS entry resolves (${resolved})`);
+          } catch (err) {
+            console.error(`FAIL ${pkgName}: ${err && err.code ? err.code + ": " : ""}${err && err.message ? err.message : err}`);
+            process.exit(1);
+          }
+          JSEOF
+          # Phase 2 helper: require() and confirm non-empty exports.
           cat > smoke.cjs <<'JSEOF'
           const pkgName = process.argv[2];
           try {
@@ -318,13 +330,21 @@ jobs:
           FAILED=()
           ROWS=()
           for pkg in @piplabs/cdr-contracts @piplabs/cdr-crypto @piplabs/cdr-sdk; do
+            # Phase 1: CJS entry must resolve (bridge OFF).
+            if ! OUTPUT=$(NODE_OPTIONS=--no-experimental-require-module node resolve.cjs "$pkg" 2>&1); then
+              SHORT=$(echo "$OUTPUT" | head -1 | tr -d '`' | tr '|' '/')
+              ROWS+=("| \`${pkg}\` | ❌ | resolve: ${SHORT:0:130} |")
+              FAILED+=("$pkg (resolve)")
+              continue
+            fi
+            # Phase 2: require() must work for a real consumer (bridge ON, default opts).
             if OUTPUT=$(node smoke.cjs "$pkg" 2>&1); then
               SHORT=$(echo "$OUTPUT" | head -1 | tr -d '`' | tr '|' '/')
               ROWS+=("| \`${pkg}\` | ✅ | ${SHORT:0:140} |")
             else
               SHORT=$(echo "$OUTPUT" | head -1 | tr -d '`' | tr '|' '/')
-              ROWS+=("| \`${pkg}\` | ❌ | ${SHORT:0:140} |")
-              FAILED+=("$pkg")
+              ROWS+=("| \`${pkg}\` | ❌ | require: ${SHORT:0:130} |")
+              FAILED+=("$pkg (require)")
             fi
           done
           {


### PR DESCRIPTION
## Summary

Closes #135. The post-release "Smoke: CJS imports" gate failed for `@piplabs/cdr-crypto` and `@piplabs/cdr-sdk` with `ERR_REQUIRE_ESM: require() of ES Module @noble/hashes/hkdf.js` — a **false failure**. Two of our own gates disagreed:

- `cdr-crypto` pins `@noble/hashes@2.0.1` (ESM-only), so the CJS build loads it via Node's `require(esm)` bridge —
- But the smoke step set `NODE_OPTIONS=--no-experimental-require-module`, disabling that bridge to protect "consumers on Node <20.19" — a runtime the `engines` field already excludes, and whose rationale expired when Node 20 hit EOL (April 2026).

The dual-publish itself is fine: on every runtime `engines` admits, plain `require("@piplabs/cdr-sdk")` works. Only the gate was wrong.

## Fix (issue Option 1)

Split the single step into two correctly-configured phases, so the gate tests what real consumers hit while keeping the regression it was built for:

- **Phase 1 — `require.resolve()`, bridge OFF.** Keeps `--no-experimental-require-module`. Resolves the CJS entry without executing it, so it never touches the ESM-only transitive dep. Still fails loudly if a package loses its CJS entry (ships ESM-only with no `exports.require`).
- **Phase 2 — `require()`, default Node options (bridge ON).** Actually requires the package the way a consumer on a supported runtime does. The ESM-only transitive dep loads via the bridge.

Row output now prefixes failures with `resolve:` / `require:` so a red gate says which phase broke.

## Test plan

- [x] YAML parses; step-level `NODE_OPTIONS` env removed; `cjs_smoke` id + `rows` output preserved (summary section unchanged)
- [x] Local reproduction against the **published 0.2.2 tarballs** (`@piplabs/cdr-{contracts,crypto,sdk}`):
- [ ] Dispatch `post-release-integration.yml` from this branch against `version=0.2.2` — expect the CJS smoke green 

## Notes

- Fix is entirely in the workflow (the test harness), not the package — so it validates against the **already-published 0.2.2**; no republish required.
- The `--no-experimental-require-module` flag on Phase 1 is spec-per-issue but functionally vestigial: `require.resolve()` is unaffected by the bridge flag. Kept to document intent and match the issue's recommendation.
- The `verify` job's Node 20 pin (still `>=20.19`) remains correct — Phase 2 depends on the bridge being on by default, which that line provides.