### PR TITLE
fix(monitor): on cache miss, warn and retry next tick instead of replaying from round 24

### DIFF
--- a/.github/workflows/dkg-round-monitor-aeneid.yml
+++ b/.github/workflows/dkg-round-monitor-aeneid.yml
@@ -23,6 +23,16 @@ run-name: dkg-round-monitor-aeneid${{ github.event.inputs.start_round != '' && f
 #      FINALIZATION or report a FAILED round.
 #   4. otherwise stop until the next tick (the round is still progressing).
 #
+# Cache miss: GitHub's actions/cache restore intermittently fails to return an
+# entry that still exists (same failure class PR #143 hit; bit this workflow on
+# 2026-07-23, when the miss made the pointer fall back to a hardcoded round 24
+# and replay rounds 24-29 as six fresh notifications). The restore is a READ
+# miss — the saved state is still there and the next tick restores it fine — so
+# the right response is to change nothing: post one explicit cache-miss warning
+# and end the tick without touching or saving state. If the miss persists
+# (entry truly evicted), the warning repeats each tick until a manual
+# workflow_dispatch with start_round re-seeds the pointer.
+#
 # Stage codes (story x/dkg DKGStage): 1=REGISTRATION 2=DEALING 3=FINALIZATION
 #   4=ACTIVE 5=FAILED 6=ENDED. A status of 5 always raises a WARNING.
 #
@@ -55,7 +65,6 @@ env:
   # Public aeneid REST endpoint. Overridable via repo variable so the node can
   # be reprovisioned without editing the workflow (falls back to the default).
   AENEID_REST: ${{ vars.AENEID_REST || 'http://172.192.41.96:1317' }}
-  DEFAULT_START_ROUND: '24'
   MAX_ADVANCES_PER_RUN: '6'
 
 jobs:
@@ -130,8 +139,15 @@ jobs:
             LS=$(jq -r '.last_stage // 0' ./state.json)
             UNREACH=$(jq -r '.unreachable // 0' ./state.json)
           else
-            WR="$DEFAULT_START_ROUND"; LS=0
-            echo "no cached state; starting at default watch_round=$WR"
+            # No state restored — an intermittent actions/cache READ miss (the
+            # entry almost certainly still exists; see header). Change nothing:
+            # announce it and end the tick. The next tick's restore will very
+            # likely succeed and the monitor resumes exactly where it was.
+            # Guessing a start round here (the old hardcoded-24 fallback) is
+            # what replayed rounds 24-29 as fresh notifications on 2026-07-23.
+            notify "$(stage_emoji 5) WARNING: DKG round monitor could not restore its state cache (intermittent GitHub actions/cache read miss); leaving state untouched and retrying next tick. If this repeats, re-seed via workflow_dispatch (start_round)."
+            echo "changed=0" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
           [[ "$WR" =~ ^[0-9]+$ ]] || { echo "::error::bad watch_round='$WR'"; exit 1; }
           [[ "$LS" =~ ^[0-6]$ ]] || LS=0


### PR DESCRIPTION
## Summary

On 2026-07-23 ~13:55 UTC the aeneid round monitor burst six stale notifications into Slack (rounds 24–29, including a historical-but-alarming `Round 27 -> FAILED`). Root cause (run [30013425033](https://github.com/piplabs/cdr-sdk/actions/runs/30013425033)): the actions/cache restore step failed with `Failed to GetCacheEntryDownloadURL: (404) Not Found`. With no cached state the watch pointer fell back to the hardcoded `DEFAULT_START_ROUND=24` and replayed every terminal stage from there (exactly `MAX_ADVANCES_PER_RUN=6` messages).

This is the same failure class #143 hit: an **intermittent actions/cache read miss** — the saved entry still exists (the very next tick restored it fine), GitHub just failed to return it on read.

## Fix

Since the state is still there and the next tick recovers it, the right response to a cache miss is to **change nothing**:

- Post one explicit warning (`WARNING: DKG round monitor could not restore its state cache ...; leaving state untouched and retrying next tick`) and end the tick without touching or saving state.
- The hardcoded `DEFAULT_START_ROUND` fallback is removed — guessing a start round is what produced the replay burst, and any guess either re-announces history or (if suppressed) risks swallowing a FAILED that landed in the blind window.
- If the miss persists (entry truly evicted), the warning repeats each tick until a manual `workflow_dispatch` (`start_round`) re-seeds the pointer — deliberate loudness, and the message says exactly what to do.
- Dispatch reseed and all other paths are unchanged.

## Test plan

- [x] YAML parses; extracted the run script and exercised it against **live aeneid REST** with a local mock webhook capturing posts:
  - cache miss → exactly one warning message, no state written, `changed=0`, exit 0
  - steady-state tick (cached `{31,3}`, round 31 still FINALIZATION) → silent, `changed=0`
  - real transition (cached `{31,0}`) → `🟡 Round 31 -> FINALIZATION` fires as before, `changed=1`