### PR TITLE
test(integration): lower aeneid default wallet count 50 -> 10

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -32,7 +32,7 @@ on:
         type: string
         description: >-
           Override CDR_WALLET_COUNT for the ephemeral-wallet suites (empty =
-          network default: 50 on aeneid, 100 on devnet)
+          network default: 10 on aeneid, 100 on devnet)
         required: false
         default: ''
   # Reusable-workflow entrypoint for cdr-monitor-per-round.yml. Strings (not
@@ -200,8 +200,8 @@ jobs:
               # The public aeneid RPC rate-limits under burst load; run the
               # ephemeral-wallet suites at reduced concurrency there.
               # Aeneid default: repo variable CDR_AENEID_WALLET_COUNT,
-              # falling back to 50. Devnet keeps the suites' built-in 100.
-              echo "CDR_WALLET_COUNT=${{ vars.CDR_AENEID_WALLET_COUNT || '50' }}" >> $GITHUB_ENV
+              # falling back to 10. Devnet keeps the suites' built-in 100.
+              echo "CDR_WALLET_COUNT=${{ vars.CDR_AENEID_WALLET_COUNT || '10' }}" >> $GITHUB_ENV
               ;;
           esac
 


### PR DESCRIPTION
The public aeneid RPC (`aeneid.storyrpc.io`) still rate-limits the ephemeral-wallet suites at 50 concurrent wallets — #147 added 429 retries, but reducing the burst pressure at the source is cheaper. This lowers the aeneid fallback default from 50 to 10.

- Only the fallback changes: the repo variable `CDR_AENEID_WALLET_COUNT` and the `concurrent_wallet_count` dispatch input still override it, and devnet keeps the suites' built-in 100.
- No test-code changes; the suites read `CDR_WALLET_COUNT` via `positiveIntEnv`.